### PR TITLE
release(minor): 2.2.0 — throttle, websocket middleware, sync paginate, teardown that finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ await app.listen(3000);
 
 That is the whole programming model. Note what is **not** there: no `@Injectable()`,
 no `@Inject()`, no `reflect-metadata` import, no `experimentalDecorators` in your
-tsconfig, and no `Response.json()` to remember. One line in `bunfig.toml` turns the
+tsconfig, and no `Response.json()` to remember. Two lines in `bunfig.toml` turn the
 constructor types into wiring:
 
 ```toml
 preload = ["@dunx/transform/preload"]
+
+[test]
+preload = ["@dunx/transform/preload"]
 ```
+
+Bun's test runner reads its own `preload`, so the `[test]` entry is what keeps
+`bun test` working. Miss it and the app runs while the suite fails at the first
+provider with a constructor parameter.
 
 ## Three things that are different
 
@@ -85,6 +92,10 @@ frames from where the mistake was.
 **No `forwardRef`.** The dependency record is a thunk, evaluated at resolution rather
 than at class-definition time, so a circular import resolves on its own. Nothing to
 annotate, nothing to remember.
+
+One thing to add rather than delete: **every relative import ends in `.js`**, because
+`moduleResolution: nodenext` is what the scaffold sets. An extensionless specifier is a
+compile error, not a runtime surprise.
 
 ## Benchmarks
 
@@ -113,8 +124,8 @@ Reproduce it with `bun run --filter '@dunx/bench' start`; the methodology is in
 
 ## Documentation
 
-- **[The guide](https://petarzarkov.github.io/dunx)** - eighteen pages, introduction
-  through deployment
+- **[The guide](https://petarzarkov.github.io/dunx)** - twenty-one pages,
+  introduction through agent tooling
 - **[Migrating from NestJS](docs/MIGRATION-FROM-NEST.md)** - what maps across and
   what does not
 - **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** - what was measured, what was rejected,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,10 +18,10 @@ that contradicts it is a decision made without measuring.
 
 ## The framework
 
-| Page                                                           | What it settles                                                                                         |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| [Dependency injection](./architecture/dependency-injection.md) | The decorator dialect, recording constructor types without metadata, and why modules do not encapsulate |
-| [The HTTP layer](./architecture/http.md)                       | The `Bun.serve` adapter, route discovery, and multi-node websocket fan-out                              |
+| Page                                                           | What it settles                                                                                     |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| [Dependency injection](./architecture/dependency-injection.md) | The decorator dialect, recording constructor types without metadata, and the scope each module gets |
+| [The HTTP layer](./architecture/http.md)                       | The `Bun.serve` adapter, route discovery, and multi-node websocket fan-out                          |
 
 ## The integrations
 
@@ -42,6 +42,7 @@ mature library already solves.** None of them restates the library's own surface
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [Building and releasing](./architecture/packaging.md) | The topological build, why versioning is lockstep, and what the scaffolder resolves |
 | [The tools](./architecture/tooling.md)                | The documentation site and the API explorer                                         |
+| [The MCP server](./architecture/mcp.md)               | What an agent may read out of an app, and why it never boots one                    |
 
 ## What was measured
 

--- a/docs/MIGRATION-FROM-NEST.md
+++ b/docs/MIGRATION-FROM-NEST.md
@@ -3,8 +3,71 @@
 A gap analysis between what a production NestJS application uses and what dunx
 provides, written from the migrating application's point of view.
 
-Status legend: **planned** = designed in ARCHITECTURE.md, unbuilt ·
-**undesigned** = no decision recorded anywhere.
+Status legend: **undesigned** = no decision recorded anywhere · **out of scope** =
+refused, with the reasoning below.
+
+## Read this part first: four things that fail at boot
+
+Everything else on this page is a mapping you can look up when you reach it. These
+four are what a migrating app hits in the first hour, and each one stops the process
+rather than degrading.
+
+**1. The `bunfig.toml` preload is not optional.**
+
+```toml
+preload = ["@dunx/transform/preload"]
+
+[test]
+preload = ["@dunx/transform/preload"]
+```
+
+Constructor injection needs no decorator because a load-time plugin records each
+class's parameter types instead. Without the plugin a class with constructor
+parameters has no record, and the container compares that against
+`Function.prototype.length` and fails at boot naming the class.
+
+- **Both entries are needed.** Bun's test runner reads its own `preload`, so missing
+  the second gives you a working app and a failing suite.
+- **It is a runtime dependency.** A `--production` install, or a `.dockerignore` that
+  drops `bunfig.toml`, breaks the deploy rather than the build.
+
+Deploying a **built** tree changes the answer. The plugin's filter is `/\.tsx?$/`, so
+it never sees emitted JavaScript and no preload setting makes it. Record the
+dependencies at build time instead, with `Bun.build({ plugins: [depsPlugin] })`. The
+boot error tells you which of the two situations you are in.
+
+**2. A constructor parameter must name something that exists at runtime.**
+
+An interface, a type alias, a primitive, a union, a class type parameter or a value
+imported with `import type` all erase, so there is no token to resolve.
+`emitDecoratorMetadata` degrades those to `Object` and hands you `undefined` three
+frames from the mistake. dunx fails at boot naming the parameter and its position.
+
+Replace the type with an abstract class, or bind it with `token()` and declare the
+parameter as that token. Every `*Options` in the framework is a class for this reason.
+The error tells the `import type` case apart from the others, because that one has a
+one-line fix.
+
+**3. A module is decorated or configured, never both.**
+
+A scope is keyed on the module **reference**, and `forRoot()` returns a fresh object
+on every call. So `@Module` on a class that also has a `static forRoot()` registers
+its contents twice, and two importers each calling `forRoot()` build two scopes with
+two instances of everything in them. Take one:
+
+| The module          | Spelling                                                |
+| ------------------- | ------------------------------------------------------- |
+| Has nothing to vary | `@Module({ ... })` on the class                         |
+| Takes options       | `static forRoot(opts): DynamicModule`, and no decorator |
+
+If two feature modules need the same binding, give it its own module with
+`global: true` rather than calling `forRoot()` twice.
+
+**4. Every relative import ends in `.js`.**
+
+Not `.ts`, not extensionless. `moduleResolution: nodenext` makes it a compile error
+rather than a consumer's problem, which is the good outcome, but it is the change with
+the most occurrences in a migrating codebase.
 
 ## Core DI
 
@@ -58,9 +121,9 @@ Status legend: **planned** = designed in ARCHITECTURE.md, unbuilt ·
 | `@nestjs/serve-static`                 | `StaticFiles` in `@dunx/http`                                    | done         |
 | `@bull-board/*`                        | bull-board mounted by `@dunx/dashboard`                          | done         |
 | `@nestjs/cache-manager`                | `@dunx/infra/redis`                                              | partial      |
-| `@nestjs/schedule` (`@Cron`)           | bullmq repeatable jobs                                           | undesigned   |
+| `@nestjs/schedule` (`@Cron`)           | [`@dunx/infra/schedule`](./guide/16-scheduling.md)               | done         |
 | `@nestjs/throttler`                    | middleware                                                       | undesigned   |
-| `@nestjs/terminus`                     | -                                                                | undesigned   |
+| `@nestjs/terminus`                     | [`HealthModule` in `@dunx/http`](./guide/20-health-checks.md)    | done         |
 | `@nestjs/platform-express` (`app.use`) | -                                                                | out of scope |
 
 ## The reference application
@@ -202,27 +265,38 @@ to collate across files.
 
 ### Custom param decorators
 
-`createParamDecorator` is a Nest extensibility point with **no successor
-designed**. The reference app has 14 usages across `@CurrentUser` and
-`@UuidParam`.
+`createParamDecorator` has no successor and will not get one: TC39 decorators have
+no parameter decorators, so there is nowhere for it to come from. The reference app
+has 14 usages across `@CurrentUser` and `@UuidParam`, and the two halves of that
+migrate differently.
 
-`@Body`/`@Query`/`@Param` are already answered - schemas move onto the route
-decorator (architecture/dependency-injection.md, "Params without parameter decorators"). Custom ones
-are not, because they read state a guard put there.
+`@UuidParam` and its relatives are **validation**, and are answered: the schema moves
+onto the route decorator, where it also coerces and documents. See
+[Validation](./guide/06-validation.md).
 
-The natural shape is that middleware writes onto a typed per-request context the
-handler receives:
+`@CurrentUser` and its relatives read **state a guard put there**, and the shape that
+replaced them is an injected service over `AsyncLocalStorage`. `@dunx/auth` ships one:
 
 ```ts
-@Get('/me', { auth: true })
-getMe(req: BunRequest, ctx: Ctx<{ user: User }>) {
-  return this.#users.findById(ctx.user.id);
+export class ProfileController {
+  constructor(private readonly auth: AuthContext) {}
+
+  @Get('/me')
+  me() {
+    return this.users.findById(this.auth.require().id);
+  }
 }
 ```
 
-This still needs a decision, and it shares a signature with validated input, so it
-belongs in ARCHITECTURE.md before any of it is written. Today the workaround is
-what a guard already has: put the value on `req` and read it in the handler.
+`current()` returns the caller or `undefined`; `require()` returns the caller or
+throws a 401. `SessionGuard` is what calls `run()` to establish it, and a job or a
+socket handler that resolved a session itself can call `run()` too.
+
+The gain over a parameter decorator is that it reaches **anything the handler calls,
+however deep**, rather than only the handler's own signature. The cost is that the
+caller is not in the method signature, so it does not appear in the handler's type.
+An app wanting its own `@CurrentUser` writes a one-method service over `AuthContext`
+and injects that.
 
 ### `@Optional()`
 
@@ -233,24 +307,34 @@ implementation.
 
 ## Out of scope
 
-**Express interop.** `app.use(expressMiddleware)`, `app.set('trust proxy')`, and
-mounting express-shaped handlers (Bull Board, ServeStatic) have no equivalent.
-`Bun.serve` is not a middleware stack, and building an express compatibility
-layer would contradict "dunx should stay a DI + structure framework that happens
-to serve HTTP." Applications depending on mounted express apps need those
-replaced, not adapted.
+**Express interop.** `app.use(expressMiddleware)` and mounting express-shaped
+handlers have no equivalent. Two of the things usually reached for through it do ship:
 
-**socket.io.** Bun has native WebSocket support with a different shape. A
-`@dunx/ws` is plausible; a socket.io-protocol-compatible one is not, and the
-`@socket.io/redis-adapter` multi-node story would have to be rebuilt.
+- `app.set('trust proxy', n)` is the one key `AppSettings` declares. It counts hops
+  from the right-hand end of `X-Forwarded-For`.
+- bull-board is mounted by `@dunx/dashboard`, not by an express adapter.
+  `Bun.serve` is not a middleware stack, and building an express compatibility
+  layer would contradict "dunx should stay a DI + structure framework that happens
+  to serve HTTP." Applications depending on mounted express apps need those
+  replaced, not adapted.
+
+**The socket.io protocol.** Gateways are neither out of scope nor a separate
+package: `@Gateway` ships in `@dunx/http` on Bun's native WebSocket support, and
+multi-node fan-out ships as a relay.
+
+What is out of scope is **protocol compatibility**. A socket.io client cannot talk to
+a dunx gateway, so anything depending on the socket.io wire format, its
+acknowledgement semantics or `@socket.io/redis-adapter` needs replacing rather than
+adapting. See [WebSockets](./guide/09-websockets.md).
 
 Check both before planning a migration. They gate whether an app can move today.
 
 ## The acceptance test
 
-`dunx-template` is a running parity app: config module, async database factory,
+The parity target is a running app with a config module, an async database factory,
 CRUD controllers, an auth guard reading `@Roles`, OpenAPI, queues and a health
-endpoint.
+endpoint. [`examples/full`](https://github.com/petarzarkov/dunx/tree/main/examples/full)
+is the version of that which CI keeps alive.
 
 It exercises the question module scoping introduced, which is which
 cross-cutting guards were only ever cross-cutting because Nest offered nowhere

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,18 +10,18 @@ other.
 
 ## Built
 
-| Package            | Contains                                                               |
-| ------------------ | ---------------------------------------------------------------------- |
-| `@dunx/core`       | DI container, modules, lifecycle, the `Logger` contract - zero deps    |
-| `@dunx/transform`  | Load-time transform: constructor parameter types                       |
-| `@dunx/http`       | Routes, websocket gateways, middleware, guards, CORS, validation       |
-| `@dunx/infra`      | `/db` (drizzle) `/redis` `/files` `/images` `/logger` (`@arkv/logger`) |
-| `@dunx/openapi`    | OpenAPI 3.1 from route zod schemas, self-contained HTML                |
-| `@dunx/testing`    | Bindings replaced in place, a real `Bun.serve` on port 0               |
-| `@dunx/auth`       | better-auth mounted, `SessionGuard`, `Bun.password` hashing            |
-| `@dunx/dashboard`  | Opt-in ops page, one middleware, bull-board mounted for queues         |
-| `@dunx/create-app` | `bunx @dunx/create-app my-api` - base template plus feature folders    |
-| `@dunx/mcp`        | MCP server that reads an app's routes, providers and modules           |
+| Package            | Contains                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| `@dunx/core`       | DI container, modules, lifecycle, the `Logger` contract - zero deps                         |
+| `@dunx/transform`  | Load-time transform: constructor parameter types                                            |
+| `@dunx/http`       | Routes, websocket gateways, middleware, guards, CORS, validation, health probes, `./client` |
+| `@dunx/infra`      | `/db` (drizzle) `/redis` `/queue` `/schedule` `/files` `/images` `/logger` `/pagination`    |
+| `@dunx/openapi`    | OpenAPI 3.1 from route zod schemas, self-contained HTML                                     |
+| `@dunx/testing`    | Bindings replaced in place, a real `Bun.serve` on port 0                                    |
+| `@dunx/auth`       | better-auth mounted, `SessionGuard`, `Bun.password` hashing                                 |
+| `@dunx/dashboard`  | Opt-in ops page, one middleware, bull-board mounted for queues                              |
+| `@dunx/create-app` | `bunx @dunx/create-app my-api` - base template plus feature folders                         |
+| `@dunx/mcp`        | MCP server that reads an app's routes, providers and modules                                |
 
 The two integrations are deliberate - never invent what a mature library already
 solves: `drizzle-orm` is an

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -177,8 +177,9 @@ Default: nothing. With no relay configured `PubSub` is byte-for-byte the code it
 before - one `server.publish` call and no branch that costs anything measurable.
 
 The Redis-backed implementation, `RedisRelay`, uses **`Bun.RedisClient` directly**.
-It is a Bun global, so this adds **zero dependencies** to `@dunx/http`, which still
-depends only on `@dunx/core`.
+It is a Bun global, so this adds **no dependency** to `@dunx/http`. The package
+carries one, `@arkv/shared`, for the outbound client behind `./client`; the relay path
+does not touch it.
 
 **The rejected alternative was putting it in `@dunx/infra/redis`**, where the
 connection handling, retry policy and error classification already exist. It was

--- a/docs/guide/01-introduction.md
+++ b/docs/guide/01-introduction.md
@@ -121,14 +121,14 @@ harness produces is the gap between the two, because that gap is dunx's own
 overhead and nothing else.
 
 Run on an AMD Ryzen 9 5950X with 32 logical cores, Bun 1.3.14, oha 1.15.0, 64
-connections, 3 s warmup, 5 measured runs of 5 s, dated 2026-08-02:
+connections, 3 s warmup, 5 measured runs of 5 s, dated 2026-08-03:
 
-| Scenario    | raw `Bun.serve` | `@dunx/http` | dunx costs |          Elysia |
-| ----------- | --------------: | -----------: | ---------: | --------------: |
-| `plaintext` |   138,507 req/s |      135,442 |       2.2% | 132,503 (95.7%) |
-| `json`      |   130,055 req/s |      123,306 |       5.2% | 124,264 (95.5%) |
-| `params`    |   126,000 req/s |      123,263 |       2.2% | 124,507 (98.8%) |
-| `validate`  |    84,701 req/s |       78,311 |       7.5% |  70,831 (83.6%) |
+| Scenario    | raw `Bun.serve` | `@dunx/http` | % of raw |           Elysia |
+| ----------- | --------------: | -----------: | -------: | ---------------: |
+| `plaintext` |   136,940 req/s |      137,539 |   100.4% |  135,907 (99.2%) |
+| `json`      |   133,311 req/s |      119,912 |    90.0% |  127,524 (95.7%) |
+| `params`    |   128,930 req/s |      124,867 |    96.8% | 129,497 (100.4%) |
+| `validate`  |    89,047 req/s |       75,769 |    85.1% |   74,858 (84.1%) |
 
 Read that with the harness's own rules. A figure at or above 100% would be noise,
 not a win: dunx dispatches through `Bun.serve` and cannot serve a request faster
@@ -140,13 +140,13 @@ Startup is the clearest loss, and it is a real one:
 
 | Subject          | cold start to first served request (median of 7) |
 | ---------------- | -----------------------------------------------: |
-| raw `Bun.serve`  |                                          26.7 ms |
-| **`@dunx/http`** |                                      **53.1 ms** |
-| Elysia           |                                          58.2 ms |
-| raw `node:http`  |                                          72.8 ms |
-| Express          |                                         120.2 ms |
-| Fastify          |                                         146.1 ms |
-| NestJS (Express) |                                         270.7 ms |
+| raw `Bun.serve`  |                                          28.7 ms |
+| **`@dunx/http`** |                                      **54.8 ms** |
+| Elysia           |                                          58.1 ms |
+| raw `node:http`  |                                          69.7 ms |
+| Express          |                                         121.0 ms |
+| Fastify          |                                         148.2 ms |
+| NestJS (Express) |                                         269.0 ms |
 
 Roughly twice raw `Bun.serve`, from the `oxc-parser` preload plus eager DI
 resolution and route discovery. That is the trade this architecture makes on
@@ -157,8 +157,8 @@ Two more numbers worth having before you commit to anything:
 
 **Request logging is on by default and costs throughput.** `@dunx/http` installs
 `RequestLoggingMiddleware` outermost, writing one structured entry per request.
-With it on, `plaintext` runs at 77,658 req/s against 135,442 with it off: 56.1%
-of raw `Bun.serve` against 97.8%.
+With it on, `plaintext` runs at 78,060 req/s against 137,539 with it off: 57.0%
+of raw `Bun.serve` against 100.4%.
 
 The cost decomposes to about 1.3 µs reading `req.headers`, 0.9 µs for the
 `AsyncLocalStorage` scope, 2.1 µs building and serialising the entry, and 0.7 µs
@@ -186,7 +186,7 @@ or class-based controllers, and that gap is the whole reason dunx exists. If you
 would not use the DI, you are paying its boot cost and its concepts for nothing.
 
 **Boot time is the number that matters.** A short-lived process, a serverless
-function billed per invocation, or a CLI will feel the ~53 ms. dunx is built for a
+function billed per invocation, or a CLI will feel the ~55 ms. dunx is built for a
 service that starts once and stays up. Note also that the startup numbers were
 taken on an idle 32-core desktop, which is not what a constrained serverless CPU
 looks like.
@@ -199,8 +199,13 @@ compatibility layer, and `Bun.serve`, `bun:sqlite`, `Bun.RedisClient`,
 `Bun.password` and `Bun.S3Client` are load-bearing throughout. Portability was
 never a goal.
 
-**You want MySQL or MariaDB through the ORM integration.** There is no drizzle
-path for either on Bun at all.
+**You want MySQL or MariaDB with nothing to assemble.** The database module
+ships two backends: `bun:sqlite`, and `Bun.SQL` for Postgres. `drizzle-orm/bun-sql`
+builds a Postgres dialect unconditionally, so a MySQL URL is rejected at
+construction with a message saying so. MySQL and MariaDB do run, through
+`drizzle-orm/mysql-proxy` over `Bun.SQL`, but the backend is a `DbOptions` subclass
+you write. [`examples/databases`](https://github.com/petarzarkov/dunx/tree/main/examples/databases)
+ships a working one.
 
 **You want a mature ecosystem of third-party modules.** There is not one. dunx is
 ten published workspaces in one repository. The established frameworks have a decade or more

--- a/docs/guide/02-first-steps.md
+++ b/docs/guide/02-first-steps.md
@@ -64,22 +64,21 @@ Created my-api in my-api/
 
 `bunx @dunx/create-app --list` prints the current set:
 
-| Feature      | What arrives                                                     | Pulls in            |
-| ------------ | ---------------------------------------------------------------- | ------------------- |
-| `notes`      | CRUD routes with zod validation. The smallest real feature       |                     |
-| `openapi`    | OpenAPI 3.1 from the routes' own schemas, plus the explorer page |                     |
-| `http`       | CORS, a request-logging middleware and error mapping             |                     |
-| `guards`     | `@Roles` and `@Public`, and a protected controller               |                     |
-| `database`   | drizzle over `bun:sqlite`, with a schema, seeds and migrations   |                     |
-| `users`      | A repository, a service and validated routes over the database   | `database`          |
-| `auth`       | better-auth mounted, with `SessionGuard` and an audit trail      | `database`          |
-| `cache`      | `Bun.RedisClient` behind a session store                         |                     |
-| `websockets` | A `@Gateway` with `@OnMessage`, `PubSub` and a Redis relay       |                     |
-| `images`     | `Bun.Image` resizing and format conversion behind a route        |                     |
-| `files`      | Uploads and downloads on `Bun.file`                              |                     |
-| `jobs`       | bullmq queues and a worker, over `Bun.RedisClient`               | `images`            |
-| `health`     | One endpoint reporting which parts are live and which degraded   | `cache`, `database` |
-| `dashboard`  | bull-board at `/queues`, over the queue `jobs` publishes to      | `jobs`              |
+| Feature      | What arrives                                                     | Pulls in                     |
+| ------------ | ---------------------------------------------------------------- | ---------------------------- |
+| `notes`      | CRUD routes with zod validation. The smallest real feature       |                              |
+| `openapi`    | OpenAPI 3.1 from the routes' own schemas, plus the explorer page |                              |
+| `http`       | CORS, a request-logging middleware and error mapping             |                              |
+| `guards`     | `@Roles` and `@Public`, and a protected controller               |                              |
+| `database`   | drizzle over `bun:sqlite`, with a schema, seeds and migrations   |                              |
+| `users`      | A repository, a service and validated routes over the database   | `database`                   |
+| `auth`       | better-auth mounted, with `SessionGuard` and an audit trail      | `database`                   |
+| `cache`      | `Bun.RedisClient` behind a session store                         |                              |
+| `websockets` | A `@Gateway` with `@OnMessage`, `PubSub` and a Redis relay       | `cache`                      |
+| `images`     | `Bun.Image` resizing and format conversion behind a route        |                              |
+| `files`      | Uploads and downloads on `Bun.file`                              |                              |
+| `jobs`       | bullmq queues and a job processor, over `Bun.RedisClient`        | `images`                     |
+| `health`     | Liveness and readiness probes, and which parts are degraded      | `cache`, `database`, `files` |
 
 Requirements come along automatically, and the order they are imported in is
 construction order, so a database is built before the feature that reads it and torn

--- a/docs/guide/03-providers.md
+++ b/docs/guide/03-providers.md
@@ -39,6 +39,16 @@ Three consequences you can rely on:
 A class with constructor parameters and no record means the preload never ran,
 and the container says so at boot with the snippet above.
 
+It checks the entrypoint before choosing that snippet. The plugin's filter is
+`/\.tsx?$/`, so it never sees an emitted `.js` no matter how it is preloaded. When
+`Bun.main` ends in `.js`, `.cjs` or `.mjs` the message says the tree is prebuilt and
+prints the build-time fix instead:
+
+```
+import { depsPlugin } from '@dunx/transform';
+await Bun.build({ /* ... */ plugins: [depsPlugin] });
+```
+
 How the transform rewrites the source, and why the record is a thunk:
 [Dependency injection](../architecture/dependency-injection.md).
 
@@ -172,7 +182,8 @@ Calling it anywhere else throws:
 
 ```
 inject(Clock) was called outside of construction. inject() only works in a field
-initializer or constructor of a class the container builds.
+initializer or constructor of a class the container builds, because that is what
+decides which module scope the token resolves from.
 ```
 
 **A factory cannot use `inject()`.** After a factory's first `await`, the
@@ -322,9 +333,14 @@ Full lifetime, boot order, hooks and error propagation: [Lifecycle](./07-lifecyc
 
 ## Eager resolution
 
-`AppFactory.create()` instantiates every provider and awaits every async factory
-before it returns, so wiring errors surface at boot rather than at first request.
-There is no separate `init()`.
+`AppFactory.create()` instantiates every declared binding and awaits every async
+factory before it returns, so wiring errors surface at boot rather than at first
+request. There is no separate `init()`.
+
+Two kinds of provider sit outside that. A class that self-binds because no module
+declared it, and the `Logger` / `RequestContext` defaults the container promotes into
+every scope, are built on first `get`. A provider nothing ever asks for is therefore
+never constructed, and never gets an `onInit` or an `onShutdown`.
 
 That is also what keeps `inject()` synchronous: by the time any constructor runs,
 every async provider has resolved.
@@ -347,8 +363,10 @@ opening a socket in a field initializer is not.
 
 ## Lifecycle
 
-Two hooks, both structural. Implement the method and the container finds it; the
-`implements` clause only makes TypeScript check the signature.
+Three hooks, all structural. Implement the method and the container finds it; the
+`implements` clause only makes TypeScript check the signature. `OnInit` and
+`OnShutdown` are below; `OnBeforeShutdown` runs while the server is still accepting
+and is covered in [Lifecycle](./07-lifecycle.md).
 
 ```ts
 import type { OnInit, OnShutdown } from '@dunx/core';
@@ -390,10 +408,11 @@ early is torn down last, after every repository that uses it. Reversing
 construction-completion order is already a dependency-aware teardown, so
 `app.shutdown()` needs no separate pass.
 
-For an HTTP application there is one step in front of that. `HttpApp.shutdown()`
-stops the `Bun.serve` server first, then closes `PubSub`, then delegates to the
-container's teardown. Requests in flight finish against providers that are still
-alive.
+For an HTTP application there are three steps in front of that.
+`HttpApp.shutdown()` runs the container's `drain()`, then stops the `Bun.serve`
+server, then closes `PubSub`, then delegates to the container's teardown. Draining
+before the port closes is what lets a readiness probe fail while the server is still
+answering; requests in flight then finish against providers that are still alive.
 
 Beyond dependency order, the order tokens are _registered_ decides the rest, and
 that is a module-graph question. [Modules](./04-modules.md) covers it: imports
@@ -461,13 +480,19 @@ Replacement rather than addition, and the distinction matters twice over. The
 discarded provider is never instantiated, so its `useFactory` never runs and its
 `onInit` never fires. That is what makes overriding a database safe.
 
-An override naming a token nobody binds is an error rather than a silent no-op:
+An override naming a **non-class** token nobody binds is an error rather than a
+silent no-op:
 
 ```
-Nothing to override for Clock: no module in the graph binds it. An override
-replaces a binding - it cannot add one, because a token nobody bound is a token
-nothing under test resolves.
+Nothing to override for DSN: no module in the graph binds it, and it is not a class,
+so nothing self-binds it either. An override replaces a binding - it cannot add one,
+because a token nobody bound is a token nothing under test resolves.
 ```
+
+A **class** token nobody bound is accepted, and registered lazily. A class self-binds
+on demand anyway, so the override is replacing the binding that would otherwise have
+appeared rather than adding one. An abstract class counts as a class here: the check
+is `typeof token === 'function'`.
 
 `Logger` and `RequestContext` are substituted too, so overriding `Logger` works in
 an app that binds none. `@dunx/testing` ships a `RecordingLogger` for exactly

--- a/docs/guide/04-modules.md
+++ b/docs/guide/04-modules.md
@@ -57,9 +57,9 @@ the same way; the split exists so an HTTP adapter can ask which instances to sca
 The only behavioural consequence: a class in `controllers` that declares no
 routes is a boot error telling you to move it to `providers`.
 
-An entry in either list is a bare class, which binds it to itself, or a
-`Registration` from `provide()`. See [Providers](./03-providers.md) for the shapes
-of the latter.
+A `controllers` entry is a bare class. A `providers` entry is a bare class, which
+binds it to itself, or a `Registration` from `provide()` - `providers` is the only
+list whose type admits one. See [Providers](./03-providers.md) for the shapes.
 
 ## How a token resolves
 
@@ -68,8 +68,14 @@ For a provider declared by module `M`, asking for a token:
 1. `M`'s own `providers` and `controllers`.
 2. The `exports` of the modules `M` imports, transitively through re-exports.
 3. The global scope - the `exports` of every module marked `global: true`.
-4. If the token is a **class** nothing visible binds, it self-binds into `M`'s scope.
+4. If the token is a **class** and **no module in the graph declares it**, it
+   self-binds into `M`'s scope.
 5. Otherwise it is a boot error, and the message names the fix.
+
+Step 4 tests the whole graph, not what `M` can see. A class some other module
+declares but does not export to `M` is a boot error naming that module. Self-binding
+it instead would hand `M` a second instance of a provider somebody already
+configured, which is the bug the check exists to catch.
 
 **Local shadows imported.** If `M` declares a token an import also exports, `M`'s
 binding wins. This per-module rebinding is why the scope boundary exists: a
@@ -78,8 +84,8 @@ one token.
 
 Visibility is flattened **once, at boot**, into one map per module. An import chain is
 never walked per lookup, so resolution stays the single `Map.get` it was before scopes
-existed, and the whole graph for `examples/full` - 16 modules, every feature - builds
-in a median 1.7 ms.
+existed, and the whole graph for `examples/full`, which is every feature the
+framework has, builds in a median 1.7 ms.
 
 ## `exports` is the public surface
 
@@ -134,11 +140,15 @@ Global is the weakest source: an import beats it, and a local declaration beats 
 answers it from the whole graph, which it has at boot:
 
 ```
-Cannot resolve UsersRepository for ReportsService in module "ReportsModule".
-"UsersModule" declares it and "ReportsModule" imports that module, but it does not
-export UsersRepository. Add UsersRepository to that module's exports, or move the
-provider into "ReportsModule".
+Cannot resolve UsersRepository in module "ReportsModule". "UsersModule" declares it
+and "ReportsModule" imports that module, but it does not export UsersRepository. Add
+UsersRepository to that module's exports, or move the provider into "ReportsModule".
 ```
+
+A dependency declared through `token()` gets one clause more, naming the class that
+asked: `Cannot resolve Dsn for DataService in module "DataModule"`. A class token
+does not, because the container re-raises the original error for those rather than
+rewriting it.
 
 A token declared by a module you do **not** import says so instead, and names the
 `imports` line to add. A token nothing declares says that, rather than blaming the
@@ -394,8 +404,14 @@ some other module's export passes `imports: [ThatModule]`.
 
 So why does the name exist at all? Because reading options off `ConfigService` is
 the one thing a zero-argument options object cannot do, and `forRootAsync` is the
-conventional name for that. It ships on `LoggerModule`, `ImagesModule`,
-`RedisModule`, `FilesModule` and `DbModule`:
+conventional name for that.
+
+Every configured module in the framework has one:
+
+- `@dunx/infra`: `LoggerModule`, `DbModule`, `RedisModule`, `QueueModule`,
+  `ScheduleModule`, `FilesModule`, `ImagesModule`
+- `@dunx/http`: `HealthModule`, `HttpClientModule`, `StaticModule`
+- `AuthModule`, `OpenApiModule`, `DashboardModule`
 
 ```ts
 @Module({
@@ -536,9 +552,14 @@ before any constructor runs.
 
 `AppFactory.create(root)` takes a module class or a `DynamicModule`. So does
 `HttpFactory.create(root)`, which wraps your root in an internal module of its own
-in order to bind `PubSub` and, unless you turned it off,
+in order to bind `PubSub`, `ClientAddress` and, unless you turned it off,
 `RequestLoggingMiddleware`. That wrapper is why those are injectable in an
 application that imported nothing.
+
+`ClientAddress` is bound rather than left to self-bind because an unbound class
+self-binds into whichever scope asks first: `listen()` would attach the live server
+to one instance while a second module's middleware injected another, and
+`app.clientIp(req)` would throw on an instance that never got a server.
 
 The wrapper is invisible to the boundary. Global middleware, `@UseGuards` classes
 and an error filter all resolve as **your** root sees them, so listing a guard in

--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -475,9 +475,14 @@ early check at `create()` is already complete.
 
 `set` is typed against the `AppSettings` interface rather than being a string bag,
 so a typo is a compile error rather than a setting that silently never applies.
-There is one key today: `'trust proxy'`, which makes `ClientAddress` read
-`X-Forwarded-For` instead of the socket. Only turn it on behind a proxy that
-rewrites the header, because a direct client can send whatever it likes.
+There is one key today: `'trust proxy'`, typed `boolean | number`.
+
+- The value is how many proxies sit in front of the server, `true` meaning one.
+- The address is taken that many entries from the **right-hand** end of
+  `X-Forwarded-For`. A direct client can put anything in the header it sends, so only
+  the entries a proxy appended carry weight.
+- A count higher than the number of proxies you run hands the caller its own choice
+  of address.
 
 ## Middleware, guards and metadata
 

--- a/docs/guide/06-validation.md
+++ b/docs/guide/06-validation.md
@@ -53,8 +53,8 @@ export interface StandardSchemaV1<In = unknown, Out = In> {
 ```
 
 That interface is **restated** by `@dunx/http` rather than imported. The spec is an interface and nothing else: `@standard-schema/spec` ships
-declarations with no runtime, so restating it costs one file and keeps the package
-at zero dependencies. zod 4, Valibot and ArkType already satisfy the shape, so all
+declarations with no runtime, so restating it costs one file and adds no dependency
+to the package. zod 4, Valibot and ArkType already satisfy the shape, so all
 three drop straight into a route's options with nothing adapting anything:
 
 ```ts

--- a/docs/guide/07-lifecycle.md
+++ b/docs/guide/07-lifecycle.md
@@ -1,6 +1,6 @@
 # Lifecycle
 
-One lifetime, two hooks, eager boot. All of it is `@dunx/core` and none of it
+One lifetime, three hooks, eager boot. All of it is `@dunx/core` and none of it
 needs `@dunx/http`.
 
 ## Provider lifetime
@@ -35,11 +35,15 @@ never touches the container:
 
 ```ts
 export class OrdersService {
-  constructor(private readonly context: RequestContext) {}
+  constructor(
+    private readonly context: RequestContext,
+    private readonly logger: Logger,
+  ) {}
 
   place(order: Order) {
     // requestId was set by RequestLoggingMiddleware, on the way in
-    this.log.info('placing', { requestId: this.context.get('requestId') });
+    const { requestId } = this.context.getContext();
+    this.logger.info('placing', { requestId });
   }
 }
 ```
@@ -84,13 +88,19 @@ constructed.
 ```ts
 provide(DbConnection, {
   useFactory: async (config: AppConfigService) =>
-    DbConnection.open(config.get('DATABASE_URL')),
-  inject: [ConfigService],
+    DbConnection.open(config.get('databaseUrl')),
+  inject: [AppConfigService],
 });
 ```
 
 A rejected factory rejects `AppFactory.create()`. Nothing partially built is
 returned, and `onInit` never runs.
+
+`inject` lists `AppConfigService`, the subclass, rather than `ConfigService`. A
+factory parameter annotated `ConfigService<AppConfig>` against `inject: [ConfigService]`
+is rejected: parameters are contravariant and the token carries no type argument.
+[Configuration](./12-configuration.md) covers the `as` option that declares the
+subclass.
 
 ## `OnInit`
 
@@ -211,10 +221,21 @@ CircularDependencyError: Circular dependency: UsersService -> AuditService -> Us
 | Cycle                                       | `CircularDependencyError` with the path                          |
 | Rejected `useFactory`                       | rejects `AppFactory.create()`                                    |
 | Throwing `onInit`                           | rejects `AppFactory.create()`                                    |
-| Throwing `onShutdown` via signal            | logged to `console.error`, exit code 1, drain continues          |
+| Throwing `onShutdown` via signal            | logged, exit code 1, **remaining teardown skipped**              |
 
 Every one of these is a rejected `create()` except the last. An app that boots
 has resolved everything it declares.
+
+The last row is the one to design around. The teardown loop is unguarded, so the
+first `onShutdown` that throws aborts it.
+
+- Every provider after it in the reverse order keeps its resources.
+- `app.closed` never resolves.
+- `ShutdownHooks` catches the rejection, logs `[dunx] shutdown failed` and arms exit
+  code 1. Its exit timer is what still ends the process.
+
+Put a `try` inside any `onShutdown` whose failure should not strand the ones behind
+it.
 
 ## Overrides in tests
 
@@ -230,8 +251,10 @@ const app = await createTestApp({
 The discarded provider is never constructed, so an async `useFactory` that would
 have opened the real database does not run.
 
-An override naming a token nothing binds throws. A silent no-op there produces a
-test asserting against the provider it believed it had swapped.
+An override naming a non-class token nothing binds throws. A silent no-op there
+produces a test asserting against the provider it believed it had swapped. A class
+token nobody bound is accepted instead, and bound lazily, because a class self-binds
+on demand anyway.
 
 Full harness, including `createTestServer` and `RecordingLogger`:
 [Testing](./11-testing.md).
@@ -240,11 +263,13 @@ Full harness, including `createTestServer` and `RecordingLogger`:
 
 ```ts
 app.get(UsersService); // root scope view, then any single declarer
-app.get(UsersService, OrdersModule); // resolved from one module's scope
+app.get(UsersService, OrdersModule); // prefers OrdersModule's view
 ```
 
-`app.get` is more permissive than constructor injection on purpose, being a
-wiring and debugging call. Two scopes binding the token differently is an error
-rather than a guess.
+`app.get` is more permissive than constructor injection, being a wiring and
+debugging call. With a module argument it prefers that module's view, then falls back
+to the root scope's, then to the single module that declares the token, and finally
+self-binds a class into the module named. Two scopes binding the token differently is
+an error rather than a guess, and a module that is not in the graph at all throws.
 
 `AppRef` is the injectable form, and is dunx's `ModuleRef`.

--- a/docs/guide/08-middleware-and-guards.md
+++ b/docs/guide/08-middleware-and-guards.md
@@ -657,9 +657,10 @@ your routes, because `HttpMethod` has no `OPTIONS` verb: only CORS mounts one.
   private providers. Declare it in the same module's `providers`. A class the
   module cannot see still resolves through the permissive `app.get` lookup, but
   it is then a shared instance built somewhere else.
-- **`'trust proxy'` is off by default.** Turn it on with
-  `app.set('trust proxy', true)` only behind a proxy that rewrites
-  `X-Forwarded-For`; a direct client can send whatever it likes.
+- **`'trust proxy'` is off by default, and it is a hop count.**
+  `app.set('trust proxy', n)` says how many proxies are in front of you, `true`
+  meaning one, and the address is read that many entries from the **right** of
+  `X-Forwarded-For`. Over-counting lets a caller choose its own address.
 
 Next: [WebSockets](./09-websockets.md), which are served by the same `Bun.serve`
 call and the same container.

--- a/docs/guide/09-websockets.md
+++ b/docs/guide/09-websockets.md
@@ -127,6 +127,8 @@ a socket yet, so the thing to run is a plain function call in `@OnUpgrade`.
 export interface SocketData<T = unknown> {
   readonly path: string;
   readonly context: T;
+  /** Minted per connection at the upgrade, with `crypto.randomUUID()`. */
+  readonly id: string;
 }
 
 export type Socket<T = unknown> = ServerWebSocket<SocketData<T>>;
@@ -292,9 +294,10 @@ const app = await HttpFactory.create(AppModule, {
 });
 ```
 
-`RedisRelay` is built on `Bun.RedisClient`, a Bun global, so it costs
-`@dunx/http` **zero dependencies**: the package still depends only on
-`@dunx/core`. With no `url` it resolves the same chain Bun's client does,
+`RedisRelay` is built on `Bun.RedisClient`, a Bun global, so the relay itself costs
+`@dunx/http` **no new dependency**. The package's one runtime dependency is
+`@arkv/shared`, which the outbound HTTP client behind `./client` uses; nothing in the
+gateway or the relay path reaches for it. With no `url` it resolves the same chain Bun's client does,
 `$VALKEY_URL`, then `$REDIS_URL`, then `redis://localhost:6379`.
 
 A URL with an unrecognised scheme is rejected at construction. Bun accepts any

--- a/docs/guide/15-queues.md
+++ b/docs/guide/15-queues.md
@@ -191,16 +191,81 @@ url and reapplies the options, so every one of those reconstructions comes out t
 same as the first. Nothing to configure; it is how `QueueConnection` builds a
 client.
 
-## Publish side and worker side are different processes
+## Publishing and consuming are separate decisions
 
-`QueueModule.forRoot()` binds three tokens: `QueueOptions`, `QueueConnection` and
-`JobPublisher`. That is the **publish** side, which is all a web process needs.
+`QueueModule.forRoot()` exports three tokens: `QueueOptions`, `QueueConnection` and
+`JobPublisher`. That is the **publish** side, which is all a web process needs. It
+also binds a fourth provider it does not export, `QueueRunner`, which is what opens
+workers when you ask it to.
 
-**Importing it opens no worker and consumes nothing.** A web process that
-publishes never consumes by accident. Consuming is a deliberate second step:
-either `WorkerFactory.create` in its own process, or `WorkerFactory.attach`
-inside a container that already exists. Either way, the two sides agree on
-exactly one thing: the module.
+**By default it consumes nothing.** `consume` is `false`, so a web process that
+publishes never starts a worker by accident. There are three ways to consume, and
+they agree on exactly one thing: the module.
+
+| How                                      | Where the workers live                       |
+| ---------------------------------------- | -------------------------------------------- |
+| `QueueModule.forRoot({ consume: true })` | the container that imported the module       |
+| `WorkerFactory.create(root)`             | a process of its own, with its own container |
+| `WorkerFactory.attach(app, root)`        | a container somebody else already built      |
+
+`consume: true` is the one to reach for first. `QueueRunner` implements `OnInit` and
+`OnShutdown`, so the workers start with the container and stop with it, before the
+connections the handlers use are closed. That ordering is why it lives in a module
+rather than in an entrypoint: nothing an app writes by hand can guarantee teardown
+runs in the right order.
+
+```ts
+@Module({
+  imports: [QueueModule.forRoot({ url, consume: true, processor })],
+  providers: [ThumbnailJobs],
+})
+export class JobsModule {}
+```
+
+A broker that is down degrades rather than failing boot: the runner logs at `error`
+that the process is serving but consuming nothing. A sandbox child sets
+`DUNX_JOB_WORKER`, and the runner refuses to open workers when it sees it, so a
+processor file may import a `consume: true` module without forking forever.
+
+### Isolation is per handler, and per queue in effect
+
+`@JobHandler({ queue, name, background })` marks one handler. `background: true`
+makes bullmq fork the file named by `QueueModule.forRoot({ processor })` instead of
+calling a function in this process, which is what keeps a CPU-bound handler off the
+loop serving requests.
+
+Two things about it are easy to get wrong.
+
+- **`processor` must be an absolute path.** bullmq resolves it in the child. A
+  `background` queue with no `processor` configured is a boot error at `start()`.
+- **`background` is declared per handler but takes effect per queue.** bullmq opens
+  one `Worker` per queue and takes either a file path or a function, so one marked
+  handler sandboxes every handler on that queue.
+
+`isolation` is **not** a `@JobHandler` option. It is
+`QueueModule.forRoot({ isolation })`, and it defaults to `'process'`. Keep it there:
+
+- A fork is a fresh Bun process. It reads `bunfig.toml`, so the transform preload
+  runs and constructor injection works in the child.
+- `'thread'` enters through bullmq's own prebuilt worker entry, where a preload
+  cannot match a `.ts` file. The first provider with a constructor parameter then
+  fails at boot.
+
+`'thread'` is usable only against a tree whose dependencies were recorded at build
+time.
+
+The file itself default-exports the processor's `handle`:
+
+```ts
+// src/jobs.processor.ts - the file bullmq forks
+import { JobProcessor } from '@dunx/infra/queue';
+import { JobsProcessorModule } from './jobs.processor.module.js';
+
+export default new JobProcessor(JobsProcessorModule).handle;
+```
+
+`handle` is an arrow property rather than a method, because bullmq calls the export
+bare. The child builds its container on the first job and reuses it.
 
 ### Publishing
 
@@ -349,12 +414,14 @@ the container and its `shutdown()` runs `consumer.stop()` before
 
 Which to reach for:
 
+- **`consume: true`** when one process is the whole deployment, which is most
+  deployments. The container owns start and stop ordering, and a `background`
+  handler still gets its own process per burst.
 - **A separate worker process** when the two halves should scale, fail and deploy
-  independently, or when a slow handler must not compete with request latency.
-  `examples/full` does this, and it is why that example has a `bun run worker`.
-- **`attach`** when one process is the whole deployment: a small service, a
-  single container, or a job whose handler is cheap enough that the isolation is
-  not worth a second process.
+  independently.
+- **`attach`** when a container already exists and you are adding consumption to it
+  after the fact. It is the only one of the three where you have to sequence
+  teardown yourself.
 
 ## `jobTimeoutMs`
 
@@ -502,5 +569,6 @@ line, fixed; `CLIENT SETNAME` runs and the worker appears..
 
 - [Configuration](./12-configuration.md) for `forRootAsync` and `AppConfigService`
 - [Logging](./13-logging.md), which the worker uses for job completion and failure
-- `examples/full`, whose `src/worker.ts` is the worked example this page is drawn
-  from
+- `examples/full`, whose `src/jobs/` is the worked example this page is drawn from.
+  It sets `consume: true` and ships a `jobs.processor.ts`, so it spawns no worker
+  process of its own

--- a/docs/guide/19-deployment.md
+++ b/docs/guide/19-deployment.md
@@ -129,23 +129,43 @@ the image.
 
 ## Health checks
 
-Give the orchestrator a route that answers without touching anything that can be
-slow:
+`HealthModule` from `@dunx/http` serves `/api/health/live` and `/api/health/ready`.
+Do not hand-roll a controller for this; the part worth having is the drain, and a
+controller cannot express it.
 
 ```ts
-@Controller('health')
-export class HealthController {
-  @Get('/')
-  live(): { status: string } {
-    return { status: 'ok' };
-  }
-}
+HealthModule.forRootAsync({
+  useFactory: (db: DbConnection, redis: RedisConnection) => ({
+    readiness: [
+      new DatabaseIndicator(db),
+      new RedisIndicator(redis, { critical: false }),
+    ],
+    drainDelayMs: 15_000,
+  }),
+  inject: [DbConnection, RedisConnection],
+});
 ```
 
-Keep readiness separate from liveness if you have dependencies that can degrade.
-`examples/full` has a health controller that reports each area as live or
-degraded. Copy that shape: a cache being down should not restart the process, and
-a liveness probe that checks Redis will do exactly that.
+Two settings decide whether a rollout drops requests.
+
+**`critical`** is what separates readiness from liveness. A `critical: false`
+indicator reports `degraded` without failing the probe, so an absent Redis degrades a
+route rather than restarting the process. Be sparing with `critical: true`: it should
+name only what makes the process useless, which in most services is the database
+alone. A liveness probe that checks Redis will restart a healthy process on a cache
+blip.
+
+**`drainDelayMs`** holds readiness failing before the port closes.
+
+`Readiness` implements `OnBeforeShutdown`, which runs while the server is still
+accepting. The probe can therefore answer "not ready" on an open socket for as long as
+the load balancer needs to notice. An `onShutdown` hook runs after the server has
+stopped, so a probe answering from there answers on a closed socket.
+
+Liveness keeps passing throughout: a pod that is shutting down does not need killing.
+
+Set `drainDelayMs` to at least your ingress's deregistration interval. The probes are
+hidden from the OpenAPI document, so they will not appear in a generated client.
 
 ## Logging
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -20,9 +20,9 @@ Node v24.18.0 where a comparison needed it. Numbers are from that machine.
 | Record                                                 | Verdict                | Owner                     | Blocked on                            |
 | ------------------------------------------------------ | ---------------------- | ------------------------- | ------------------------------------- |
 | [releases-subpages](./releases-subpages.md)            | build                  | `internal/docs`           | nothing                               |
-| [scheduler](./scheduler.md)                            | build                  | `@dunx/infra/schedule`    | discovery walker moving to core       |
-| [health](./health.md)                                  | build                  | `@dunx/http`              | `OnDrain` in `@dunx/core`             |
-| [throttle](./throttle.md)                              | build                  | `@dunx/http`              | `ClientAddress` hop counting          |
+| [scheduler](./scheduler.md)                            | **delivered**          | `@dunx/infra/schedule`    | nothing, shipped                      |
+| [health](./health.md)                                  | **delivered**          | `@dunx/http`              | nothing, shipped as `OnBeforeShutdown` |
+| [throttle](./throttle.md)                              | build                  | `@dunx/http`              | nothing, its blocker shipped          |
 | [arkv-logger-context](./arkv-logger-context.md)        | build, additive        | `@arkv/logger` 0.11.0     | nothing                               |
 | [arkv-logger-transports](./arkv-logger-transports.md)  | build, additive        | `@arkv/logger` 0.11.0     | nothing                               |
 | [arkv-logger-serialization](./arkv-logger-serialization.md) | build the fused walk | `@arkv/logger`       | the equivalence gate                  |
@@ -37,7 +37,8 @@ verified facts alone, in the format
 [architecture/constraints.md](../architecture/constraints.md) uses, ready to be
 appended there once the record is reviewed.
 
-All twelve records are in. The serialization one carries the logger performance
+All twelve records are in. Two of the six defects below have since been fixed and
+two of the verdicts have shipped; the rows say which. The serialization one carries the logger performance
 question, and it lands where
 [arkv-logger-transports](./arkv-logger-transports.md) pointed: the write is 4 to 9
 percent of a log call and entry assembly plus sanitization is the rest. A fused
@@ -48,26 +49,27 @@ corpus payloads byte-identical.
 
 These are not features and do not wait on a roadmap decision.
 
-1. **`ClientAddress` trusts the wrong end of `X-Forwarded-For`.**
-   `packages/http/src/server/client-address.ts:35-39` takes `.split(',')[0]`,
-   the leftmost entry, which is the one a client appends. Under
-   `trustProxy: true` a caller sets its own address, so logged client IPs are
-   spoofable and any IP-keyed limiter is bypassed by rotating one header. Under
-   `trustProxy: false` the whole fleet shares the proxy's address. The fix is a
-   hop count from the right, in `ClientAddress`. See
-   [throttle](./throttle.md), which found it and cannot ship without it.
-2. **`@dunx/mcp` drops JSON-RPC batches.** `tools/mcp/src/protocol.ts:65` opens
-   with `if (request.id === undefined) return null`, and a batch is an array
-   with no `id`, so it is answered as a notification. The same file declares
-   three of the five reserved error codes. See [rpc](./rpc.md).
+1. ~~**`ClientAddress` trusts the wrong end of `X-Forwarded-For`.**~~ **Fixed.**
+   It took `.split(',')[0]`, the leftmost entry, which is the one a client
+   appends, so a caller could set its own address and bypass any IP-keyed limiter
+   by rotating one header. `ClientAddress` now counts trusted hops from the right,
+   `true` meaning one proxy, and clamps a count longer than the header to the
+   leftmost entry. The setting is `app.set('trust proxy', n)`; the record below
+   still spells it `trustProxy`. This unblocked [throttle](./throttle.md), which
+   found it.
+2. ~~**`@dunx/mcp` drops JSON-RPC batches.**~~ **Fixed.** A batch is an array with
+   no `id`, so it fell through to the notification check and was answered with
+   silence while the client held an outstanding id. `protocol.ts` now has a
+   `rejection()` step ahead of that check which answers an array with `-32600`
+   and a message naming the protocol revision. See [rpc](./rpc.md).
 
-   **Correction to that record.** [rpc](./rpc.md) reads the absence of batch
-   handling as the defect, which would make implementing it the fix. MCP
-   **removed** JSON-RPC batching in 2025-06-18, listed first among that
-   revision's major changes, and `PROTOCOL_VERSION` in the same file is
-   `2025-06-18`. So a batch is not a request this server can answer and the fix
-   is to reject it with `-32600`. The defect is the silence, not the missing
-   feature: a client holding an outstanding id waits forever on it.
+   **Correction to that record, and it is what the fix followed.**
+   [rpc](./rpc.md) reads the absence of batch handling as the defect, which would
+   have made implementing it the fix. MCP **removed** JSON-RPC batching in
+   2025-06-18, listed first among that revision's major changes, and
+   `PROTOCOL_VERSION` in the same file is `2025-06-18`. A batch is therefore not a
+   request this server can answer, so the defect was the silence rather than the
+   missing feature.
 3. ~~**`@arkv/logger` loses buffered entries on SIGTERM.**~~ **Not a defect.**
    [arkv-logger-transports](./arkv-logger-transports.md) reports that a batched
    entry is lost on SIGTERM unless some handler is installed and that

--- a/examples/full/src/database/ledger.controller.ts
+++ b/examples/full/src/database/ledger.controller.ts
@@ -96,7 +96,7 @@ export class LedgerController {
    * `/ledger/page` cannot be swallowed by `/ledger/:id`.
    */
   @Get('/page', pagedEntries)
-  page(input: Input<typeof pagedEntries>): Promise<Page<Entry>> {
+  page(input: Input<typeof pagedEntries>): Page<Entry> {
     return this.ledger.page(input.query);
   }
 

--- a/examples/full/src/database/ledger.service.ts
+++ b/examples/full/src/database/ledger.service.ts
@@ -63,10 +63,11 @@ export class Ledger implements OnInit, OnShutdown {
    * so `paginate` falls back to the primary key - `id` is unique on its own, so no
    * tie-break column is needed.
    *
-   * `async` although bun-sqlite is synchronous, because `paginate` awaits the query
-   * builder - the one code path that serves both dialects.
+   * Synchronous, because `paginate`'s return type follows its `db`: a
+   * `drizzle-orm/bun-sqlite` handle answers `all()` rather than a promise, so this
+   * method needs no `async` and neither does its caller.
    */
-  page(options: PageOptions): Promise<Page<Entry>> {
+  page(options: PageOptions): Page<Entry> {
     return paginate<typeof ledger, Entry>({
       db: this.db,
       table: ledger,

--- a/packages/core/src/di/app.ts
+++ b/packages/core/src/di/app.ts
@@ -3,7 +3,13 @@ import { AsyncRequestContext, RequestContext } from '../logger/context.js';
 import { Logger } from '../logger/logger.js';
 import { AppError } from './errors.js';
 import { Injector } from './injector.js';
-import { hasOnBeforeShutdown, hasOnInit, hasOnShutdown } from './lifecycle.js';
+import {
+  hasOnBeforeShutdown,
+  hasOnInit,
+  hasOnShutdown,
+  teardownError,
+  teardownFailures,
+} from './lifecycle.js';
 import { ROOT_MODULE, type ModuleRef } from './module.js';
 import { buildScopes, type Binding } from './scope.js';
 import { provide, type Registration } from './provider.js';
@@ -144,29 +150,92 @@ class Application implements App {
    * then stop the server, then tear providers down. Memoized so the two paths
    * cannot double-drain - `shutdown()` calls it too, which is what makes a
    * process with no HTTP server drain at all.
+   *
+   * **`allSettled`, not `all`.** One rejecting hook used to reject the whole
+   * drain, which then aborted `shutdown()` at its own `await this.drain()` before
+   * a single `onShutdown` had run - so one bad hook leaked every resource in the
+   * app. Each failure is logged against the provider that raised it and the
+   * aggregate is thrown once the phase is over, so a caller can still see it.
    */
   async drain(): Promise<void> {
     this.#draining ??= (async () => {
-      await Promise.all(
-        [...this.#injector.instances]
-          .filter(hasOnBeforeShutdown)
-          // `onBeforeShutdown` may be synchronous, and `Promise.all` over a bare `void` is
-          // what `await-thenable` objects to. The wrapper costs one microtask.
-          .map(async (instance) => instance.onBeforeShutdown()),
+      const hooks = [...this.#injector.instances].filter(hasOnBeforeShutdown);
+      const settled = await Promise.allSettled(
+        // `onBeforeShutdown` may be synchronous, and `allSettled` over a bare `void`
+        // is what `await-thenable` objects to. The wrapper costs one microtask.
+        hooks.map(async (instance) => instance.onBeforeShutdown()),
       );
+
+      const failures: unknown[] = [];
+      for (const [index, result] of settled.entries()) {
+        if (result.status !== 'rejected') continue;
+        this.#report('onBeforeShutdown', hooks[index], result.reason);
+        failures.push(result.reason);
+      }
+      if (failures.length > 0) throw teardownError(failures);
     })();
     return this.#draining;
   }
 
+  /**
+   * Every `onShutdown`, in reverse resolution order, and **every one of them
+   * runs**.
+   *
+   * A throwing hook used to abort the loop, which left every provider after it
+   * holding its resources and left `closed` pending forever - a shutdown that ends
+   * in `SIGKILL` rather than an exit. Each failure is collected, the drain's
+   * failures are collected rather than allowed to abort this, `closed` resolves in
+   * a `finally`, and the aggregate is thrown last so a caller still observes it.
+   */
   async shutdown(): Promise<void> {
     this.#shuttingDown ??= (async () => {
-      await this.drain();
-      for (const instance of [...this.#injector.instances].reverse()) {
-        if (hasOnShutdown(instance)) await instance.onShutdown();
+      const failures: unknown[] = [];
+      try {
+        await this.drain();
+      } catch (error) {
+        failures.push(...teardownFailures(error));
       }
-      this.#resolveClosed?.();
+
+      try {
+        for (const instance of [...this.#injector.instances].reverse()) {
+          if (!hasOnShutdown(instance)) continue;
+          try {
+            await instance.onShutdown();
+          } catch (error) {
+            this.#report('onShutdown', instance, error);
+            failures.push(error);
+          }
+        }
+      } finally {
+        this.#resolveClosed?.();
+      }
+
+      if (failures.length > 0) throw teardownError(failures);
     })();
     return this.#shuttingDown;
+  }
+
+  /**
+   * One line per failed hook, naming the provider.
+   *
+   * The aggregate that comes out at the end of the phase is what a caller sees; a
+   * process being torn down by a signal has no caller, and without this the only
+   * record of a failed teardown would be whichever error happened to be first.
+   *
+   * The `Logger` lookup is guarded because this runs during teardown: a container
+   * whose logger failed to build, or a phase reached after it was torn down, must
+   * not turn a reported failure into a second unreported one.
+   */
+  #report(phase: string, instance: unknown, error: unknown): void {
+    const name = (instance as { constructor?: { name?: string } })?.constructor
+      ?.name;
+    try {
+      this.#injector
+        .find(Logger)
+        .error(`${name ?? 'A provider'}.${phase}() failed`, error);
+    } catch {
+      console.error(`[dunx] ${name ?? 'A provider'}.${phase}() failed`, error);
+    }
   }
 
   enableShutdownHooks(

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -25,7 +25,17 @@ export { inject } from './inject.js';
 // `@JobHandler`. Three copies meant a fix to the dedup or the `Object.prototype`
 // stop landing in one of them.
 export { classOf, markedMethods, type MarkedMethod } from './marked.js';
-export type { OnBeforeShutdown, OnInit, OnShutdown } from './lifecycle.js';
+// `teardownError` and `teardownFailures` are exported because every application
+// class runs its own teardown phase - @dunx/http stops a server between two of
+// them, @dunx/infra stops queue workers - and each has to collect failures the same
+// way rather than short-circuiting on the first.
+export {
+  teardownError,
+  teardownFailures,
+  type OnBeforeShutdown,
+  type OnInit,
+  type OnShutdown,
+} from './lifecycle.js';
 // The hook installer itself, not just its options: @dunx/http and @dunx/infra each
 // own an application class with its own `enableShutdownHooks`, and three copies of
 // "drain, then make sure the process actually ends" is three chances to fix the

--- a/packages/core/src/di/lifecycle.ts
+++ b/packages/core/src/di/lifecycle.ts
@@ -48,3 +48,24 @@ export const hasOnShutdown = (value: unknown): value is OnShutdown =>
 export const hasOnBeforeShutdown = (
   value: unknown,
 ): value is OnBeforeShutdown => hasMethod(value, 'onBeforeShutdown');
+
+/**
+ * Every failure a teardown phase collected, as one error.
+ *
+ * A single failure is passed through unchanged, so the common case still reads like
+ * the error it is; several become an `AggregateError`, whose `errors` keeps every
+ * original reachable. The point of collecting them at all is that teardown does not
+ * stop at the first one: a provider that throws must not be able to keep the
+ * providers after it from releasing anything.
+ */
+export const teardownError = (failures: readonly unknown[]): unknown =>
+  failures.length === 1
+    ? failures[0]
+    : new AggregateError(
+        failures,
+        `${failures.length} providers failed to shut down`,
+      );
+
+/** The inverse, so a phase that collects from another does not nest aggregates. */
+export const teardownFailures = (error: unknown): readonly unknown[] =>
+  error instanceof AggregateError ? (error.errors as unknown[]) : [error];

--- a/packages/core/src/di/module-compose.test.ts
+++ b/packages/core/src/di/module-compose.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'bun:test';
+import { AppFactory } from './app.js';
+import { Module, collectModules, type DynamicModule } from './module.js';
+import { provide } from './provider.js';
+import { buildScopes } from './scope.js';
+import { token, type Token } from './token.js';
+
+class Settings {
+  constructor(readonly value: string) {}
+}
+
+class Reader {
+  constructor(readonly settings: Settings) {}
+}
+
+/**
+ * Bound with `inject` declared. Core's own test run has no `@dunx/transform`
+ * preload, because one of its tests asserts what happens without one.
+ */
+const reader = () =>
+  provide(Reader, {
+    useFactory: (settings: Settings) => new Reader(settings),
+    inject: [Settings] as const,
+  });
+
+/**
+ * The shape the framework used to forbid: a `@Module` decorator carrying the static
+ * half, and a `forRoot()` carrying the configured half.
+ */
+@Module({
+  providers: [provide(Settings, { useValue: new Settings('default') })],
+  exports: [Settings],
+})
+class Configurable {
+  static forRoot(value: string): DynamicModule {
+    return {
+      module: Configurable,
+      providers: [provide(Settings, { useValue: new Settings(value) })],
+    };
+  }
+}
+
+describe('@Module and forRoot() on one class', () => {
+  it("lets the configured binding replace the decorator's default", async () => {
+    @Module({ imports: [Configurable.forRoot('configured')] })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    expect(app.get(Settings).value).toBe('configured');
+    await app.shutdown();
+  });
+
+  it('keeps the decorator default when forRoot binds nothing for it', async () => {
+    @Module({ imports: [{ module: Configurable }] })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    expect(app.get(Settings).value).toBe('default');
+    await app.shutdown();
+  });
+
+  it("keeps the decorator's exports, so the importer still sees them", async () => {
+    @Module({
+      imports: [Configurable.forRoot('x')],
+      providers: [reader()],
+      exports: [Reader],
+    })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    expect(app.get(Reader).settings.value).toBe('x');
+    await app.shutdown();
+  });
+
+  /**
+   * A plain concatenation registered an import once per place it was named, which is
+   * two scopes and two of everything in them.
+   */
+  it('registers an import named in both places exactly once', () => {
+    @Module({ providers: [reader()] })
+    class Leaf {}
+
+    @Module({ imports: [Leaf] })
+    class Both {
+      static forRoot(): DynamicModule {
+        return { module: Both, imports: [Leaf] };
+      }
+    }
+
+    const modules = collectModules({
+      module: class Root {},
+      imports: [Both.forRoot()],
+    } as DynamicModule);
+    const both = modules.find((entry) => entry.name === 'Both');
+    expect(both?.options.imports).toEqual([Leaf]);
+  });
+
+  it('joins a controller list without duplicating a shared entry', () => {
+    class Shared {}
+    class Extra {}
+
+    @Module({ controllers: [Shared] })
+    class Mixed {}
+
+    const [resolved] = collectModules({
+      module: Mixed,
+      controllers: [Shared, Extra],
+    });
+    expect(resolved?.options.controllers).toEqual([Shared, Extra]);
+  });
+
+  it('still rejects one token twice in the same providers list', () => {
+    expect(() =>
+      buildScopes({
+        module: class Twice {},
+        providers: [
+          provide(Settings, { useValue: new Settings('a') }),
+          provide(Settings, { useValue: new Settings('b') }),
+        ],
+      }),
+    ).toThrow(/declared twice in the same providers list/);
+  });
+});
+
+describe('re-exporting a configured import by its class', () => {
+  it('resolves to the configuration this module imported', async () => {
+    @Module({
+      imports: [Configurable.forRoot('inner')],
+      exports: [Configurable],
+    })
+    class Facade {}
+
+    @Module({ imports: [Facade], providers: [reader()], exports: [Reader] })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    expect(app.get(Reader).settings.value).toBe('inner');
+    await app.shutdown();
+  });
+
+  it('leaves a token that happens to be a class alone', () => {
+    const abstract = class Contract {};
+    @Module({
+      providers: [provide(abstract, { useValue: new abstract() })],
+      exports: [abstract],
+    })
+    class Owns {}
+
+    const [resolved] = collectModules(Owns);
+    expect(resolved?.options.exports).toEqual([abstract]);
+  });
+
+  it('still fails when the class is neither imported nor declared', () => {
+    class Absent {}
+    @Module({ exports: [Absent] })
+    class Root {}
+
+    expect(() => buildScopes(Root)).toThrow(/does not/);
+  });
+});
+
+describe('the same module configured twice', () => {
+  it('warns, naming the class and the token both copies bind', () => {
+    @Module({})
+    class Twice {
+      static forRoot(): DynamicModule {
+        return {
+          module: Twice,
+          providers: [provide(Settings, { useValue: new Settings('x') })],
+          exports: [Settings],
+        };
+      }
+    }
+
+    const { warnings } = buildScopes({
+      module: class Root {},
+      imports: [Twice.forRoot(), Twice.forRoot()],
+    } as DynamicModule);
+
+    expect(
+      warnings.some((line) => line.includes('Twice is registered 2 times')),
+    ).toBe(true);
+    expect(warnings.some((line) => line.includes('Settings'))).toBe(true);
+  });
+
+  /**
+   * Two configurations binding **different** tokens is the supported shape - a
+   * default connection alongside a named one - so it has to stay silent.
+   */
+  it('stays silent when the two bind different tokens', () => {
+    const first = token<string>('first');
+    const second = token<string>('second');
+
+    @Module({})
+    class Named {
+      static forRoot(as: Token<string>): DynamicModule {
+        return {
+          module: Named,
+          providers: [provide(as, { useValue: 'v' })],
+          exports: [as],
+        };
+      }
+    }
+
+    const { warnings } = buildScopes({
+      module: class Root {},
+      imports: [Named.forRoot(first), Named.forRoot(second)],
+    } as DynamicModule);
+
+    expect(
+      warnings.some((line) => line.includes('is registered 2 times')),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/di/module.ts
+++ b/packages/core/src/di/module.ts
@@ -147,24 +147,106 @@ const declaredOptions = (module: ModuleClass): ModuleOptions | undefined =>
     ? (module as ModuleClass & Marked)[MODULE]
     : undefined;
 
-const concat = <T>(
-  left: readonly T[] | undefined,
-  right: readonly T[] | undefined,
-): readonly T[] => [...(left ?? []), ...(right ?? [])];
+/**
+ * A declared list and a configured one, joined **without duplicating**: an entry
+ * present in both appears once, at the configured position.
+ *
+ * This is what makes `@Module` and a `static forRoot()` on the same class safe to
+ * combine. A plain concatenation registered the decorator's entries a second time -
+ * two scopes of one module, two of everything in them - so the rule used to be
+ * "decorated or configured, never both", and every module that needed a static core
+ * plus a configured extra had to put the static half in the factory too.
+ */
+const union = <T>(
+  declared: readonly T[] | undefined,
+  configured: readonly T[] | undefined,
+): readonly T[] => {
+  if (declared === undefined || declared.length === 0) return configured ?? [];
+  if (configured === undefined || configured.length === 0) return declared;
+  const claimed = new Set(configured);
+  return [...declared.filter((entry) => !claimed.has(entry)), ...configured];
+};
+
+const tokenOf = (entry: ProviderEntry): InjectionToken<unknown> =>
+  typeof entry === 'function' ? entry : entry.token;
+
+/**
+ * The same join for providers, keyed on the **token** rather than the entry.
+ *
+ * `forRoot()`'s binding wins, which is what makes a decorator a place to put the
+ * default: `@Module({ providers: [provide(Options, { useValue: defaults })] })`
+ * plus a `forRoot(init)` that binds `Options` is one module with a default and an
+ * override, instead of a duplicate-binding error.
+ */
+const unionProviders = (
+  declared: readonly ProviderEntry[] | undefined,
+  configured: readonly ProviderEntry[] | undefined,
+): readonly ProviderEntry[] => {
+  if (declared === undefined || declared.length === 0) return configured ?? [];
+  if (configured === undefined || configured.length === 0) return declared;
+  const claimed = new Set(configured.map(tokenOf));
+  return [
+    ...declared.filter((entry) => !claimed.has(tokenOf(entry))),
+    ...configured,
+  ];
+};
+
+/**
+ * An `exports` entry naming a module **class** becomes the configured module of
+ * that class this module imports.
+ *
+ * Re-exporting a configured import used to mean hoisting it to a module-level
+ * `const` so the same object could appear in `imports` and in `exports` - and
+ * writing the class instead was not an error at the call site, it was an
+ * unresolvable-token failure blamed on this module. The class is the name a reader
+ * would reach for, so it resolves to what was imported under it.
+ */
+type ExportEntry = InjectionToken<unknown> | ModuleRef;
+
+const resolveModuleExports = (
+  exports: readonly ExportEntry[] | undefined,
+  imports: readonly ModuleRef[] | undefined,
+  providers: readonly ProviderEntry[],
+): readonly ExportEntry[] | undefined => {
+  if (exports === undefined || imports === undefined) return exports;
+  if (exports.length === 0 || imports.length === 0) return exports;
+  const own = new Set(providers.map(tokenOf));
+
+  return exports.map((entry) => {
+    if (typeof entry !== 'function') return entry;
+    // An abstract-class token this module declares is a token, however module-like
+    // it looks - so a provider always wins over the rewrite.
+    if (own.has(entry as InjectionToken<unknown>)) return entry;
+    // A class imported bare is already the reference the scope is keyed on. Only a
+    // configured import is reached under a different object than its class.
+    return (
+      imports.find(
+        (imported) => isDynamic(imported) && imported.module === entry,
+      ) ?? entry
+    );
+  });
+};
 
 const resolveRef = (ref: ModuleRef): ResolvedModule => {
   if (isDynamic(ref)) {
     const declared = declaredOptions(ref.module);
+    const imports = union(declared?.imports, ref.imports);
+    const providers = unionProviders(declared?.providers, ref.providers);
     return {
       module: ref.module,
       name: ref.module.name,
       ref,
       options: {
-        imports: concat(declared?.imports, ref.imports),
-        controllers: concat(declared?.controllers, ref.controllers),
-        providers: concat(declared?.providers, ref.providers),
-        exports: concat(declared?.exports, ref.exports),
-        middleware: concat(declared?.middleware, ref.middleware),
+        imports,
+        controllers: union(declared?.controllers, ref.controllers),
+        providers,
+        exports:
+          resolveModuleExports(
+            union(declared?.exports, ref.exports),
+            imports,
+            providers,
+          ) ?? [],
+        middleware: union(declared?.middleware, ref.middleware),
         global: declared?.global === true || ref.global === true,
       },
     };
@@ -178,7 +260,20 @@ const resolveRef = (ref: ModuleRef): ResolvedModule => {
         `factory such as ${ref.name}.forRoot().`,
     );
   }
-  return { module: ref, name: ref.name, ref, options };
+  const resolvedExports = resolveModuleExports(
+    options.exports,
+    options.imports,
+    options.providers ?? [],
+  );
+  return {
+    module: ref,
+    name: ref.name,
+    ref,
+    options:
+      resolvedExports === options.exports || resolvedExports === undefined
+        ? options
+        : { ...options, exports: resolvedExports },
+  };
 };
 
 /**

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -3,6 +3,7 @@ import {
   collectModules,
   isModuleExport,
   readModule,
+  type ModuleClass,
   type ModuleRef,
   type ResolvedModule,
 } from './module.js';
@@ -72,9 +73,10 @@ const ownBindings = (
     if (own.has(registration.token)) {
       throw new AppError(
         `Duplicate binding for ${describeToken(registration.token)} in module ` +
-          `"${resolved.name}": it is declared twice in the same module. A ` +
-          "DynamicModule unions its options with the ones its class's @Module " +
-          'decorator declares, so a forRoot() in each place is two bindings.',
+          `"${resolved.name}": it is declared twice in the same providers list. A ` +
+          "DynamicModule's own binding replaces the one its class's @Module " +
+          'decorator declares, so this is two entries on the same side rather than ' +
+          'a decorator and a forRoot() disagreeing.',
       );
     }
     own.set(registration.token, {
@@ -160,6 +162,55 @@ const assertExportsResolve = (
 };
 
 /**
+ * One module class registered twice, each registration binding the same token.
+ *
+ * `forRoot()` returns a fresh object per call, and a scope is keyed on the
+ * reference - so two calls are two scopes with two of everything in them. Two
+ * database connections, two schedule registries, two auth instances: each one
+ * resolves, nothing errors, and half the app talks to the wrong copy.
+ *
+ * A warning rather than an error, because two registrations that bind **different**
+ * tokens are a supported shape - `RedisModule.forRoot()` alongside
+ * `RedisModule.forRoot({ name: 'cache' })` is two connections on purpose, and it is
+ * silent here because the named one binds named tokens.
+ */
+const duplicateConfigurations = (
+  modules: readonly ResolvedModule[],
+  own: Map<ModuleRef, Map<InjectionToken<unknown>, Binding>>,
+): readonly string[] => {
+  const byClass = new Map<ModuleClass, ResolvedModule[]>();
+  for (const resolved of modules) {
+    const group = byClass.get(resolved.module);
+    if (group) group.push(resolved);
+    else byClass.set(resolved.module, [resolved]);
+  }
+
+  const warnings: string[] = [];
+  for (const [klass, group] of byClass) {
+    if (group.length < 2) continue;
+    const counts = new Map<InjectionToken<unknown>, number>();
+    for (const resolved of group) {
+      for (const token of own.get(resolved.ref)?.keys() ?? []) {
+        counts.set(token, (counts.get(token) ?? 0) + 1);
+      }
+    }
+    const shared = [...counts]
+      .filter(([, seen]) => seen > 1)
+      .map(([token]) => describeToken(token));
+    if (shared.length === 0) continue;
+    warnings.push(
+      `${klass.name} is registered ${group.length} times, and each registration ` +
+        `binds ${shared.join(', ')} again. A configured module is keyed on the ` +
+        'object forRoot() returned, and it returns a new one per call - so these ' +
+        'are separate scopes holding separate instances. Call it once and share ' +
+        'the result, or mark the module global: true so one registration reaches ' +
+        'every scope.',
+    );
+  }
+  return warnings;
+};
+
+/**
  * Builds one scope per module reference, with visibility flattened.
  *
  * Order of assembly inside `visible` is the resolution order: the global scope is
@@ -185,7 +236,7 @@ export const buildScopes = (root: ModuleRef): ScopeGraph => {
     }
   }
 
-  const warnings: string[] = [];
+  const warnings: string[] = [...duplicateConfigurations(modules, own)];
   const scopes = new Map<ModuleRef, Scope>();
   const ordered: Scope[] = [];
 

--- a/packages/core/src/di/teardown.test.ts
+++ b/packages/core/src/di/teardown.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test';
+import { AppFactory } from './app.js';
+import type { OnBeforeShutdown, OnShutdown } from './lifecycle.js';
+import { teardownError, teardownFailures } from './lifecycle.js';
+import { Module } from './module.js';
+import { provide } from './provider.js';
+
+const order: string[] = [];
+
+class First implements OnShutdown, OnBeforeShutdown {
+  onBeforeShutdown(): void {
+    order.push('first:drain');
+  }
+  onShutdown(): void {
+    order.push('first:down');
+  }
+}
+
+class Breaks implements OnShutdown, OnBeforeShutdown {
+  onBeforeShutdown(): void {
+    order.push('breaks:drain');
+    throw new Error('drain exploded');
+  }
+  onShutdown(): Promise<void> {
+    order.push('breaks:down');
+    return Promise.reject(new Error('teardown exploded'));
+  }
+}
+
+class Last implements OnShutdown, OnBeforeShutdown {
+  onBeforeShutdown(): void {
+    order.push('last:drain');
+  }
+  onShutdown(): void {
+    order.push('last:down');
+  }
+}
+
+/**
+ * Registration order is resolution order, and `onShutdown` runs in reverse - so
+ * `Last` tears down first and `First` last. The failing provider sits in between,
+ * which is the only position that proves the loop did not stop at it.
+ */
+@Module({
+  providers: [
+    provide(First, { useFactory: () => new First() }),
+    provide(Breaks, { useFactory: () => new Breaks() }),
+    provide(Last, { useFactory: () => new Last() }),
+  ],
+})
+class Root {}
+
+describe('teardownError', () => {
+  it('passes a lone failure through unchanged', () => {
+    const only = new Error('one');
+    expect(teardownError([only])).toBe(only);
+  });
+
+  it('aggregates several, keeping every original reachable', () => {
+    const error = teardownError([new Error('a'), new Error('b')]);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toHaveLength(2);
+    expect((error as Error).message).toContain('2 providers');
+  });
+
+  it('unwraps an aggregate so a phase does not nest one inside another', () => {
+    const aggregate = teardownError([new Error('a'), new Error('b')]);
+    expect(teardownFailures(aggregate)).toHaveLength(2);
+    const single = new Error('lone');
+    expect(teardownFailures(single)).toEqual([single]);
+  });
+});
+
+describe('a teardown with a hook that throws', () => {
+  it('runs every remaining hook, resolves closed, and reports the failures', async () => {
+    order.length = 0;
+    const app = await AppFactory.create(Root);
+
+    let raised: unknown;
+    try {
+      await app.shutdown();
+    } catch (error) {
+      raised = error;
+    }
+
+    // Both phases ran end to end. Without the fix, `drain` rejected and `shutdown`
+    // never reached a single `onShutdown`.
+    expect(order).toEqual([
+      'first:drain',
+      'breaks:drain',
+      'last:drain',
+      'last:down',
+      'breaks:down',
+      'first:down',
+    ]);
+
+    // A promise nobody resolves is a shutdown that ends in SIGKILL.
+    await expect(app.closed).resolves.toBeUndefined();
+
+    expect(raised).toBeInstanceOf(AggregateError);
+    expect(
+      (raised as AggregateError).errors.map((error: Error) => error.message),
+    ).toEqual(['drain exploded', 'teardown exploded']);
+  });
+
+  it('surfaces a failing drain to a caller that drains on its own', async () => {
+    order.length = 0;
+    const app = await AppFactory.create(Root);
+    await expect(app.drain()).rejects.toThrow('drain exploded');
+    // Memoized, so a second call is the same answer rather than a second run.
+    await expect(app.drain()).rejects.toThrow('drain exploded');
+    expect(order.filter((entry) => entry.endsWith(':drain'))).toHaveLength(3);
+    await app.shutdown().catch(() => undefined);
+  });
+
+  it('still resolves closed when only onShutdown throws', async () => {
+    class OnlyDown implements OnShutdown {
+      onShutdown(): void {
+        throw new Error('down');
+      }
+    }
+
+    @Module({
+      providers: [provide(OnlyDown, { useFactory: () => new OnlyDown() })],
+    })
+    class Small {}
+
+    const app = await AppFactory.create(Small);
+    await expect(app.shutdown()).rejects.toThrow('down');
+    await expect(app.closed).resolves.toBeUndefined();
+  });
+});

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -74,6 +74,7 @@ export {
   ValidationError,
   type ErrorHandler,
   type ErrorMapper,
+  type HttpErrorOptions,
   type InputSource,
   type ValidationIssue,
 } from './server/errors.js';
@@ -116,6 +117,30 @@ export {
   StaticOptions,
   type StaticOptionsInit,
 } from './static/options.js';
+// A fixed-window rate limit. Here rather than in `@dunx/infra` because it is a
+// `Middleware` reading a `MetaKey` off a `RouteContext`, and `@dunx/infra` must not
+// depend on the web layer - the same boundary that made `@dunx/auth` its own
+// package. `RedisThrottleStore` takes its client structurally, so this costs the
+// package no dependency, exactly as `RedisRelay` does.
+export {
+  SKIP_THROTTLE,
+  SkipThrottle,
+  THROTTLE,
+  Throttle,
+  type ThrottleLimit,
+} from './throttle/decorators.js';
+export { ThrottleGuard } from './throttle/guard.js';
+export { ThrottleModule } from './throttle/module.js';
+export {
+  ThrottleOptions,
+  type ThrottleOptionsInit,
+} from './throttle/options.js';
+export {
+  MemoryThrottleStore,
+  RedisThrottleStore,
+  ThrottleStore,
+  type ThrottleRedis,
+} from './throttle/store.js';
 // One name, both meanings - the value for `HttpStatusCode.NOT_FOUND`, the type for
 // annotations. Exactly what an enum gives, without the enum.
 export { HttpStatusCode, type HttpStatusName } from './server/status.js';
@@ -148,6 +173,23 @@ export {
   type Invoke,
 } from './ws/discover.js';
 export { decode, encode, type Envelope } from './ws/envelope.js';
+// The socket half of the middleware chain. One interface with one method wrapping
+// `next()`, the same shape the HTTP `Middleware` has - and `SocketLoggingMiddleware`
+// is its `RequestLoggingMiddleware`, at `debug` because a gateway can take a frame
+// per connection per tick.
+export {
+  composeSocket,
+  observe,
+  type SocketContext,
+  type SocketDispatch,
+  type SocketFrame,
+  type SocketMiddleware,
+  type SocketNext,
+} from './ws/middleware.js';
+export {
+  SocketLoggingMiddleware,
+  type SocketLoggingOptions,
+} from './ws/logging.js';
 // `isGateway` is the filter that pairs with `discoverGateway` when walking a
 // module's providers, exported for the same reason `guardsOf` and `metaOf` are: a
 // reader outside this package needs the same channel the runtime uses.

--- a/packages/http/src/server/application.ts
+++ b/packages/http/src/server/application.ts
@@ -4,6 +4,8 @@ import {
   Logger,
   runtimeInfo,
   ShutdownHooks,
+  teardownError,
+  teardownFailures as toFailures,
   type App,
   type AppOptions,
   type Ctor,
@@ -15,6 +17,8 @@ import {
 import { joinPath, type DiscoveredRoute } from '../route/discover.js';
 import type { WebSocketRuntime } from '../ws/adapter.js';
 import { PubSub } from '../ws/pubsub.js';
+import type { SocketLoggingOptions } from '../ws/logging.js';
+import type { SocketMiddleware } from '../ws/middleware.js';
 import type { PubSubRelay, RelayOptions, RelayPhase } from '../ws/relay.js';
 import type { SocketData, SocketOptions } from '../ws/socket.js';
 import { attachAddressSource, ClientAddress } from './client-address.js';
@@ -79,6 +83,29 @@ export interface HttpOptions extends AppOptions {
    * themselves are declared in `@Module({ providers })`.
    */
   readonly websocket?: SocketOptions;
+  /**
+   * The socket half of `middleware`, resolved from the container the same way.
+   *
+   * Each entry wraps every dispatched gateway handler - open, each named message,
+   * the catch-all, close, drain, ping and pong - the way an HTTP middleware wraps a
+   * route. `socketLogging`'s middleware runs outermost, ahead of anything here.
+   */
+  readonly socketMiddleware?: readonly Ctor<SocketMiddleware>[];
+  /**
+   * One structured entry per socket frame, on by default at **`debug`**. `false`
+   * removes it; an options object tunes the level per event. See
+   * {@link SocketLoggingMiddleware}.
+   *
+   * `debug` rather than request logging's `info`, because a gateway can take a
+   * frame per connection per tick. The default `ConsoleLogger` threshold is
+   * `info`, so this writes nothing until an app lowers its level or names a louder
+   * one here.
+   *
+   * Installing it also takes `SocketOptions.onError`'s `console.error` default out
+   * of the way: a middleware wraps the handler, so the failure is already reported
+   * through the `Logger` with the gateway and the event on it.
+   */
+  readonly socketLogging?: boolean | SocketLoggingOptions;
   /**
    * Multi-node websocket fan-out. Absent - the default - means `PubSub` publishes
    * to this process only, which is exactly Bun's native pub/sub and costs nothing.
@@ -404,20 +431,39 @@ export class HttpApplication implements HttpApp {
     return this.#app.drain();
   }
 
+  /**
+   * The four phases, in order, and **none of them is skipped because an earlier
+   * one failed**. A drain hook that threw used to abort this before `server.stop()`
+   * had run, so the port stayed open and `closed` never resolved; each failure is
+   * collected now and thrown once the whole teardown is over.
+   */
   async shutdown(): Promise<void> {
     this.#shuttingDown ??= (async () => {
+      const failures: unknown[] = [];
+      const step = async (run: () => Promise<unknown>): Promise<void> => {
+        try {
+          await run();
+        } catch (error) {
+          failures.push(...toFailures(error));
+        }
+      };
+
       // While the port is still open and the routes still answer: a readiness
       // probe has to start failing *before* the server stops, or a load balancer
       // is still routing when the socket closes. `App.shutdown()` below calls
       // this too and it is memoized, so nothing drains twice.
-      await this.#app.drain();
-      await this.#server?.stop(this.#websocket !== undefined);
+      await step(() => this.#app.drain());
+      await step(async () => this.#server?.stop(this.#websocket !== undefined));
       this.#server = undefined;
       // Before the container: a relay this app owns holds two Redis sockets, and
       // `maxRetries: 0` means nothing else will ever close them.
-      await this.#app.get(PubSub).close();
-      await this.#app.shutdown();
-      this.#resolveClosed?.();
+      await step(() => this.#app.get(PubSub).close());
+      try {
+        await step(() => this.#app.shutdown());
+      } finally {
+        this.#resolveClosed?.();
+      }
+      if (failures.length > 0) throw teardownError(failures);
     })();
     return this.#shuttingDown;
   }

--- a/packages/http/src/server/errors.ts
+++ b/packages/http/src/server/errors.ts
@@ -1,15 +1,31 @@
 import { AppError, ConsoleLogger, type Ctor, type Logger } from '@dunx/core';
 import { HttpStatusCode } from './status.js';
 
+export interface HttpErrorOptions extends ErrorOptions {
+  /**
+   * Headers the error response carries. `Retry-After` on a 429,
+   * `WWW-Authenticate` on a 401, `Allow` on a 405 - each of them part of the
+   * status rather than an extra, and none of them expressible by a throw before
+   * this existed.
+   *
+   * {@link errorMapper} copies them onto the response. An app that replaces the
+   * mapper has to read them itself, which is the same contract `status` and
+   * `message` already have.
+   */
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
 export class HttpError extends AppError {
   override name = 'HttpError';
+  readonly headers: Readonly<Record<string, string>> | undefined;
 
   constructor(
     readonly status: number,
     message: string,
-    options?: ErrorOptions,
+    options?: HttpErrorOptions,
   ) {
     super(message, options);
+    this.headers = options?.headers;
   }
 }
 
@@ -140,13 +156,19 @@ export const errorMapper =
     if (error instanceof ValidationError) {
       return Response.json(
         { error: error.message, status: error.status, issues: error.issues },
-        { status: error.status },
+        {
+          status: error.status,
+          ...(error.headers && { headers: error.headers }),
+        },
       );
     }
     if (error instanceof HttpError) {
       return Response.json(
         { error: error.message, status: error.status },
-        { status: error.status },
+        {
+          status: error.status,
+          ...(error.headers && { headers: error.headers }),
+        },
       );
     }
     logger.error('Unhandled error', error);

--- a/packages/http/src/server/factory.ts
+++ b/packages/http/src/server/factory.ts
@@ -14,6 +14,8 @@ import { discoverRoutes, type DiscoveredRoute } from '../route/discover.js';
 import { ClientAddress } from './client-address.js';
 import { buildWebSocket } from '../ws/adapter.js';
 import { discoverGateways } from '../ws/discover.js';
+import { SocketLoggingMiddleware } from '../ws/logging.js';
+import type { SocketMiddleware } from '../ws/middleware.js';
 import { PubSub } from '../ws/pubsub.js';
 import {
   HttpApplication,
@@ -69,9 +71,26 @@ export class HttpFactory {
     // so a second module injecting it was a boot error naming the first - and the
     // app's own `app.get(ClientAddress)` could then reach an instance no server was
     // ever attached to.
+    // Bound for the same reason: its constructor takes an options object as well
+    // as two injectables, so it cannot self-bind.
+    const socketLogging = provide(SocketLoggingMiddleware, {
+      useFactory: (logger: Logger, context: RequestContext) =>
+        new SocketLoggingMiddleware(
+          logger,
+          context,
+          typeof options.socketLogging === 'object'
+            ? options.socketLogging
+            : {},
+        ),
+      inject: [Logger, RequestContext] as const,
+    });
+
     const services = [PubSub, ClientAddress];
-    const providers =
-      options.requestLogging === false ? services : [...services, logging];
+    const providers = [
+      ...services,
+      ...(options.requestLogging === false ? [] : [logging]),
+      ...(options.socketLogging === false ? [] : [socketLogging]),
+    ];
     const scope: DynamicModule = {
       module: HttpModule,
       global: true,
@@ -126,13 +145,42 @@ export class HttpFactory {
     const gateways = discoverGateways(modules, (token) => app.get(token));
     // Handler collisions and two gateways on one path are boot errors too, and the
     // websocket object is built once here rather than per connection.
+    //
+    // The socket middleware chain is resolved here and not at `listen()`, because
+    // `buildWebSocket` folds it into one closure per slot - the same trade the HTTP
+    // route table makes, moved a phase earlier because the handler object is.
     const websocket =
       gateways.length > 0
-        ? buildWebSocket(gateways, options.websocket)
+        ? buildWebSocket(
+            gateways,
+            options.websocket,
+            HttpFactory.#socketMiddleware(app, root, options),
+          )
         : undefined;
 
     // `root` is the app's own module, so global middleware and the error filter
     // resolve as the app sees them rather than as this wrapper does.
     return new HttpApplication(app, discovered, options, root, websocket);
+  }
+
+  /**
+   * Logging outermost, then whatever the app declared - the order the HTTP chain
+   * already uses, so a frame a guard refuses is still logged with the failure.
+   *
+   * Resolved permissively, like global HTTP middleware: the class is usually
+   * declared by whichever feature module owns it, and pinning the lookup to the
+   * root would make the app re-export every observer it lists.
+   */
+  static #socketMiddleware(
+    app: { get<T>(token: Ctor<T>, from?: ModuleRef): T },
+    root: ModuleRef,
+    options: HttpOptions,
+  ): readonly SocketMiddleware[] {
+    const declared = options.socketMiddleware ?? [];
+    const entries: readonly Ctor<SocketMiddleware>[] =
+      options.socketLogging === false
+        ? declared
+        : [SocketLoggingMiddleware, ...declared];
+    return entries.map((entry) => app.get(entry, root));
   }
 }

--- a/packages/http/src/server/routes.ts
+++ b/packages/http/src/server/routes.ts
@@ -163,6 +163,26 @@ const unmatchedContext = (req: Request, isPublic: boolean): RouteContext =>
  * matched. It puts the global middleware in front of a 404 in the framework's
  * own error shape.
  *
+ * **The miss is a `throw`, not a returned `Response`.** `miss` raises
+ * `HttpError(404)` and `compose` propagates it, so a middleware written as
+ * `const response = await next(); if (response.status === 404) ...` never reaches
+ * its own second line on an unmatched path - the rewrite it was written for is the
+ * one case it cannot see. A middleware that means to act on a miss has to catch:
+ *
+ * ```ts
+ * try {
+ *   return await next();
+ * } catch (error) {
+ *   if (!(error instanceof HttpError) || error.status !== 404) throw error;
+ *   return rewritten();
+ * }
+ * ```
+ *
+ * `ctx.get(UNMATCHED)` is the other half, and the cheaper one: it is set here and
+ * by no real route, so a middleware can tell "nothing matched this path" from "a
+ * handler answered 404 for a record that does not exist" **before** calling
+ * `next()` at all. Only the second of those is a `Response` to inspect.
+ *
  * Composed per request rather than at boot, because the context names the path
  * that missed. That allocation is on the 404 path only.
  */

--- a/packages/http/src/static/module.ts
+++ b/packages/http/src/static/module.ts
@@ -29,9 +29,43 @@ const files = (): Registration =>
  * default can know which. Anything outside the mount falls through untouched, so
  * the app's own routes and its 404 behave exactly as before.
  *
- * There is no `index.html` fallback and no SPA rewrite. Both are one route in the
- * app - `@Get('/*')` returning `Bun.file(...)` - and building them in would mean
+ * There is no `index.html` fallback and no SPA rewrite: building them in would mean
  * this middleware deciding what a 404 means for paths it does not own.
+ *
+ * An app that wants one writes a middleware **outside** this one, and the shape
+ * matters. An unmatched path is a **thrown** `HttpError(404)`, not a returned
+ * `Response` - see `buildFallback` - so reading `(await next()).status` never sees a
+ * miss, and `ctx.get(UNMATCHED)` is what does:
+ *
+ * ```ts
+ * export class SpaFallback implements Middleware {
+ *   async handle(req: BunRequest, ctx: RouteContext, next: Next) {
+ *     const missed = ctx.get(UNMATCHED) === true;
+ *     if (
+ *       !missed ||
+ *       req.method !== 'GET' ||
+ *       new URL(req.url).pathname.startsWith('/api') ||
+ *       !(req.headers.get('accept') ?? '').includes('text/html')
+ *     ) {
+ *       return next();
+ *     }
+ *     const index = Bun.file(`${root}/index.html`);
+ *     if (!(await index.exists())) return next();
+ *     // The document carries the hashed asset names, so a stale one points at
+ *     // bundles that no longer exist.
+ *     return new Response(index, {
+ *       headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-cache' },
+ *     });
+ *   }
+ * }
+ * ```
+ *
+ * Two more things that shape where it goes in the chain. `notFound: 'guarded'` -
+ * the default - reports a miss with no route metadata, so a global session guard
+ * refuses it and the status is a 401 rather than a 404; an app serving a SPA wants
+ * `notFound: 'public'`. And the fallback answers **before** any middleware listed
+ * after the guard, so the rewrite has to sit ahead of the guard to see the miss at
+ * all.
  */
 @Module({})
 export class StaticModule {

--- a/packages/http/src/throttle/decorators.ts
+++ b/packages/http/src/throttle/decorators.ts
@@ -1,0 +1,26 @@
+import { meta, metaKey, type MetaKey } from '../route/metadata.js';
+
+export interface ThrottleLimit {
+  /** Requests allowed per window, per subject. */
+  readonly limit: number;
+  readonly windowSeconds: number;
+}
+
+/**
+ * Read off a `RouteContext` the way `ROLES` and `PUBLIC` are, so an app can build
+ * its own guard on the same metadata rather than a parallel one.
+ */
+export const THROTTLE: MetaKey<ThrottleLimit> = metaKey('throttle');
+export const SKIP_THROTTLE: MetaKey<boolean> = metaKey('skip-throttle');
+
+/**
+ * A per-route limit, replacing the module's default for this handler.
+ *
+ * Valid on a method or on a class. A class-level limit covers every handler in the
+ * controller and a handler's own wins over it, because the route's metadata is
+ * `mergeMeta(klass, handler)` - the same precedence `@Roles` has.
+ */
+export const Throttle = (limit: ThrottleLimit) => meta(THROTTLE, limit);
+
+/** Exempts a handler, or a whole controller, from the limit entirely. */
+export const SkipThrottle = () => meta(SKIP_THROTTLE, true);

--- a/packages/http/src/throttle/guard.ts
+++ b/packages/http/src/throttle/guard.ts
@@ -1,0 +1,123 @@
+import { Logger } from '@dunx/core';
+import type { BunRequest } from 'bun';
+import { UNMATCHED } from '../route/metadata.js';
+import { ClientAddress } from '../server/client-address.js';
+import type { RouteContext } from '../server/context.js';
+import { HttpError } from '../server/errors.js';
+import type { Middleware, Next } from '../server/middleware.js';
+import { HttpStatusCode } from '../server/status.js';
+import { SKIP_THROTTLE, THROTTLE, type ThrottleLimit } from './decorators.js';
+import { ThrottleOptions } from './options.js';
+import { ThrottleStore } from './store.js';
+
+/**
+ * A fixed-window rate limit, one key per subject and handler.
+ *
+ * **Fails open.** A store that cannot be reached allows the request and warns
+ * **once per process** - a line per request would be its own outage, and refusing
+ * every request because the counter is down turns a degraded dependency into a
+ * dead service.
+ *
+ * **List it after any session guard.** An authenticated caller should be limited by
+ * user id and an anonymous one by address, and only the guard ahead of this one
+ * knows which - which is what `ThrottleOptions.subject` reads.
+ *
+ * The 429 is thrown, never returned, so it goes through the app's own `onError` and
+ * comes out in the app's error shape like every other status.
+ */
+export class ThrottleGuard implements Middleware {
+  #warned = false;
+
+  constructor(
+    private readonly options: ThrottleOptions,
+    private readonly store: ThrottleStore,
+    private readonly address: ClientAddress,
+    private readonly logger: Logger,
+  ) {}
+
+  async handle(
+    req: BunRequest,
+    ctx: RouteContext,
+    next: Next,
+  ): Promise<Response> {
+    // A path that matched nothing has no handler to limit, and counting it would
+    // let a burst of 404s spend a real caller's budget - one Redis round trip per
+    // miss, on the cheapest request to generate.
+    if (ctx.get(UNMATCHED) === true) return next();
+    if (ctx.get(SKIP_THROTTLE) === true) return next();
+
+    const limit: ThrottleLimit = ctx.get(THROTTLE) ?? this.options;
+    const key = this.#key(req, ctx);
+    const used = await this.#hit(key, limit.windowSeconds);
+    if (used === undefined) return next();
+
+    if (used > limit.limit) {
+      const after = (await this.#ttl(key)) ?? limit.windowSeconds;
+      throw new HttpError(
+        HttpStatusCode.TOO_MANY_REQUESTS,
+        `Rate limit exceeded: ${limit.limit} requests per ` +
+          `${limit.windowSeconds}s`,
+        this.options.headers
+          ? {
+              headers: {
+                'retry-after': String(after),
+                'ratelimit-limit': String(limit.limit),
+                'ratelimit-remaining': '0',
+                'ratelimit-reset': String(after),
+              },
+            }
+          : undefined,
+      );
+    }
+
+    const response = await next();
+    if (this.options.headers) {
+      response.headers.set('ratelimit-limit', String(limit.limit));
+      response.headers.set(
+        'ratelimit-remaining',
+        String(Math.max(0, limit.limit - used)),
+      );
+    }
+    return response;
+  }
+
+  /**
+   * Per **handler**, not per path: two verbs on one path get their own budgets,
+   * and a parameterised path does not fragment into a key per id.
+   */
+  #key(req: BunRequest, ctx: RouteContext): string {
+    const subject =
+      (this.options.subject ?? ((request) => this.address.of(request)))(
+        req,
+        ctx,
+      ) ?? 'anonymous';
+    return `${this.options.prefix}:throttle:${ctx.controller}:${ctx.handler}:${subject}`;
+  }
+
+  async #hit(key: string, windowSeconds: number): Promise<number | undefined> {
+    try {
+      return await this.store.hit(key, windowSeconds);
+    } catch (error) {
+      this.#degraded(error);
+      return undefined;
+    }
+  }
+
+  async #ttl(key: string): Promise<number | undefined> {
+    try {
+      return await this.store.ttl(key);
+    } catch (error) {
+      this.#degraded(error);
+      return undefined;
+    }
+  }
+
+  #degraded(error: unknown): void {
+    if (this.#warned) return;
+    this.#warned = true;
+    this.logger.warn(
+      'The rate limiter is unreachable, so requests are not being counted.',
+      { reason: (error as Error).message },
+    );
+  }
+}

--- a/packages/http/src/throttle/module.ts
+++ b/packages/http/src/throttle/module.ts
@@ -1,0 +1,115 @@
+import {
+  Logger,
+  Module,
+  provide,
+  type Deps,
+  type DynamicModule,
+  type FactoryProvider,
+  type Registration,
+} from '@dunx/core';
+import { ClientAddress } from '../server/client-address.js';
+import { ThrottleGuard } from './guard.js';
+import { ThrottleOptions, type ThrottleOptionsInit } from './options.js';
+import { MemoryThrottleStore, ThrottleStore } from './store.js';
+
+const EXPORTS = [ThrottleOptions, ThrottleStore, ThrottleGuard];
+
+/**
+ * Bound with its dependencies declared rather than left to `@dunx/transform`, the
+ * same choice `RedisModule` makes for `Redis`: this package's own test run has no
+ * preload, and a framework provider that only resolves in a transformed app is a
+ * provider that cannot be tested here.
+ */
+const guard = (): Registration =>
+  provide(ThrottleGuard, {
+    useFactory: (
+      options: ThrottleOptions,
+      store: ThrottleStore,
+      address: ClientAddress,
+      logger: Logger,
+    ) => new ThrottleGuard(options, store, address, logger),
+    inject: [ThrottleOptions, ThrottleStore, ClientAddress, Logger] as const,
+  });
+
+/**
+ * The store the options named, or the in-process one. Bound as a factory so the
+ * default is built at boot rather than at import, and so an app that never
+ * registers the module never allocates a Map.
+ */
+const store = (): Registration =>
+  provide(ThrottleStore, {
+    useFactory: (options: ThrottleOptions) =>
+      options.store ?? new MemoryThrottleStore(),
+    inject: [ThrottleOptions] as const,
+  });
+
+/**
+ * A first-class rate limit: the decorator, the guard, the counter and its options.
+ *
+ * `global: true`, because the guard is listed in `HttpOptions.middleware` - which
+ * is the app's own list, resolved from wherever the class is declared - and a
+ * non-global module would make every consumer import this one to reach a guard it
+ * never names.
+ *
+ * ```ts
+ * ThrottleModule.forRootAsync({
+ *   useFactory: (config: AppConfig, redis: RedisConnection) => ({
+ *     ...config.throttle,
+ *     prefix: config.app.name,
+ *     store: new RedisThrottleStore(redis),
+ *     subject: (req) => caller.optional()?.id ?? address.of(req),
+ *   }),
+ *   inject: [AppConfig, RedisConnection] as const,
+ * });
+ *
+ * HttpFactory.create(AppModule, { middleware: [SessionGuard, ThrottleGuard] });
+ * ```
+ *
+ * Position in the chain is the app's, the same decision `StaticFiles` leaves open,
+ * and for a sharper reason: ahead of a session guard the limit counts every caller
+ * as an address.
+ */
+@Module({})
+export class ThrottleModule {
+  static forRoot(init: ThrottleOptionsInit): DynamicModule {
+    return {
+      module: ThrottleModule,
+      global: true,
+      exports: EXPORTS,
+      providers: [
+        provide(ThrottleOptions, { useValue: new ThrottleOptions(init) }),
+        store(),
+        guard(),
+      ],
+    };
+  }
+
+  /** `forRoot` with the limit read off the container - a config value, usually. */
+  static forRootAsync<const D extends Deps>(
+    config: FactoryProvider<ThrottleOptionsInit, D> & {
+      readonly imports?: DynamicModule['imports'];
+    },
+  ): DynamicModule {
+    return {
+      module: ThrottleModule,
+      global: true,
+      ...(config.imports && { imports: config.imports }),
+      exports: EXPORTS,
+      providers: [
+        provide(ThrottleOptions, {
+          useFactory: async (...deps: readonly unknown[]) =>
+            new ThrottleOptions(
+              await (
+                config.useFactory as (
+                  ...args: readonly unknown[]
+                ) => ThrottleOptionsInit | Promise<ThrottleOptionsInit>
+              )(...deps),
+            ),
+          inject: config.inject ?? [],
+        }),
+        store(),
+        guard(),
+      ],
+    };
+  }
+}

--- a/packages/http/src/throttle/options.ts
+++ b/packages/http/src/throttle/options.ts
@@ -1,0 +1,83 @@
+import { AppError } from '@dunx/core';
+import type { BunRequest } from 'bun';
+import type { RouteContext } from '../server/context.js';
+import type { ThrottleLimit } from './decorators.js';
+import type { ThrottleStore } from './store.js';
+
+export interface ThrottleOptionsInit extends ThrottleLimit {
+  /**
+   * Namespaces every key this app writes. **Required, and an empty one throws.**
+   *
+   * There is no default on purpose. A scaffolded app that inherits the template's
+   * prefix and ships with it puts two applications in one Redis on one throttle
+   * namespace, each spending the other's budget - which is exactly what happened,
+   * and a friendly fallback is what let it.
+   */
+  readonly prefix: string;
+  /**
+   * Who is being limited. Defaults to the client address, or `'anonymous'` when
+   * even that is unknown.
+   *
+   * This is an option rather than an injected caller because the identity a limit
+   * counts by belongs to the app: an authenticated request is limited by user id
+   * and an anonymous one by address, and only the guard ahead of this one knows
+   * which. It is also what keeps `@dunx/http` from depending on `@dunx/auth`.
+   *
+   * ```ts
+   * subject: (req) => currentUser.optional()?.id ?? address.of(req)
+   * ```
+   */
+  readonly subject?: (req: BunRequest, ctx: RouteContext) => string | undefined;
+  /**
+   * Send `RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset`, plus
+   * `Retry-After` on a 429. @default true
+   */
+  readonly headers?: boolean;
+  /**
+   * The counter. Defaults to {@link MemoryThrottleStore}, which is per process -
+   * so two replicas each allow the full budget until this names a shared one.
+   */
+  readonly store?: ThrottleStore;
+}
+
+/**
+ * A class, not an interface, so it is a runtime value and can be a constructor
+ * parameter type the transform records - the same reason `StaticOptions` is one.
+ */
+export class ThrottleOptions {
+  readonly limit: number;
+  readonly windowSeconds: number;
+  readonly prefix: string;
+  readonly headers: boolean;
+  readonly subject:
+    | ((req: BunRequest, ctx: RouteContext) => string | undefined)
+    | undefined;
+  readonly store: ThrottleStore | undefined;
+
+  constructor(init: ThrottleOptionsInit) {
+    if (init.prefix.trim() === '') {
+      throw new AppError(
+        'ThrottleModule needs a prefix naming this application, and it has no ' +
+          'default: two apps sharing one Redis with one throttle namespace each ' +
+          "spend the other's budget. Pass something like { prefix: 'orders-api' }.",
+      );
+    }
+    if (!Number.isInteger(init.limit) || init.limit < 1) {
+      throw new AppError(
+        `ThrottleModule needs a limit of at least 1; got ${init.limit}.`,
+      );
+    }
+    if (!Number.isInteger(init.windowSeconds) || init.windowSeconds < 1) {
+      throw new AppError(
+        'ThrottleModule needs a windowSeconds of at least 1; got ' +
+          `${init.windowSeconds}.`,
+      );
+    }
+    this.limit = init.limit;
+    this.windowSeconds = init.windowSeconds;
+    this.prefix = init.prefix;
+    this.headers = init.headers ?? true;
+    this.subject = init.subject;
+    this.store = init.store;
+  }
+}

--- a/packages/http/src/throttle/store.ts
+++ b/packages/http/src/throttle/store.ts
@@ -1,0 +1,133 @@
+import { AppError } from '@dunx/core';
+
+/**
+ * The counter behind the guard.
+ *
+ * An `abstract class` rather than an interface: `@dunx/transform` records
+ * constructor parameter *types*, so an interface at an injection site is a boot
+ * error. Same reason `RedisConnection` and `Logger` are classes.
+ *
+ * **A fixed window, not a sliding one.** `hit` increments and returns the count for
+ * the window the key is already in; the window starts at the first hit and ends
+ * when the key expires. A sliding window needs a sorted set per subject and a
+ * range trim per request, which is a different cost for an accuracy a rate limit
+ * does not need.
+ */
+export abstract class ThrottleStore {
+  constructor() {
+    if (new.target === ThrottleStore) {
+      throw new AppError(
+        'ThrottleStore is a contract, not an implementation. Bind one with ' +
+          'ThrottleModule.forRoot({ store: new RedisThrottleStore(redis) }), or ' +
+          'leave it out for the in-process MemoryThrottleStore.',
+      );
+    }
+  }
+
+  /**
+   * The count for this key in the current window.
+   *
+   * **`undefined` means the store could not be reached**, and the guard reads that
+   * as "allow". A rate limiter that turns an unreachable Redis into a 503 has
+   * turned a degraded route into an outage.
+   */
+  abstract hit(key: string, windowSeconds: number): Promise<number | undefined>;
+
+  /** Seconds left in this key's window, for `Retry-After`. */
+  abstract ttl(key: string): Promise<number | undefined>;
+}
+
+/**
+ * The commands the Redis store needs, restated structurally so this package keeps
+ * its zero dependencies - the same trick `PubSubRelay` uses.
+ *
+ * `@dunx/infra`'s `RedisConnection` satisfies it, and so does a bare
+ * `Bun.RedisClient`, without either being named here.
+ */
+export interface ThrottleRedis {
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<unknown>;
+  ttl(key: string): Promise<number>;
+}
+
+/**
+ * The multi-process counter: one key per subject and handler.
+ *
+ * `INCR` then `EXPIRE`, and the `EXPIRE` **only on the call that returned 1**. That
+ * is what makes the window start at the first hit rather than being pushed forward
+ * by every subsequent one, and it is two round trips rather than a Lua script
+ * because `Bun.RedisClient` pipelines on its own.
+ */
+export class RedisThrottleStore extends ThrottleStore {
+  constructor(private readonly redis: ThrottleRedis) {
+    super();
+  }
+
+  async hit(key: string, windowSeconds: number): Promise<number | undefined> {
+    const used = await this.redis.incr(key);
+    if (used === 1) await this.redis.expire(key, windowSeconds);
+    return used;
+  }
+
+  async ttl(key: string): Promise<number | undefined> {
+    // Redis answers -1 for a key with no expiry and -2 for one that is gone.
+    // Neither is a duration, and reporting one as a `Retry-After` would be a
+    // negative wait.
+    const left = await this.redis.ttl(key);
+    return left > 0 ? left : undefined;
+  }
+}
+
+interface Window {
+  count: number;
+  expiresAt: number;
+}
+
+/**
+ * The single-process counter, and the default - so an app with no Redis still
+ * limits something rather than nothing.
+ *
+ * It is per process, which is the whole caveat: two replicas each allow the full
+ * budget. `RedisThrottleStore` is the answer for more than one.
+ *
+ * The map is bounded. An expired entry is dropped when its key is next touched,
+ * and once the map passes `maxKeys` every expired entry is swept - so a burst
+ * across many subjects cannot grow it without limit. Reaching the cap with nothing
+ * expired clears it, which resets a window early rather than holding memory a
+ * server does not have.
+ */
+export class MemoryThrottleStore extends ThrottleStore {
+  readonly #windows = new Map<string, Window>();
+  readonly #maxKeys: number;
+
+  constructor(maxKeys = 10_000) {
+    super();
+    this.#maxKeys = maxKeys;
+  }
+
+  hit(key: string, windowSeconds: number): Promise<number | undefined> {
+    const now = Date.now();
+    const existing = this.#windows.get(key);
+    if (existing !== undefined && existing.expiresAt > now) {
+      existing.count += 1;
+      return Promise.resolve(existing.count);
+    }
+    if (this.#windows.size >= this.#maxKeys) this.#sweep(now);
+    this.#windows.set(key, { count: 1, expiresAt: now + windowSeconds * 1000 });
+    return Promise.resolve(1);
+  }
+
+  ttl(key: string): Promise<number | undefined> {
+    const window = this.#windows.get(key);
+    if (window === undefined) return Promise.resolve(undefined);
+    const left = Math.ceil((window.expiresAt - Date.now()) / 1000);
+    return Promise.resolve(left > 0 ? left : undefined);
+  }
+
+  #sweep(now: number): void {
+    for (const [key, window] of this.#windows) {
+      if (window.expiresAt <= now) this.#windows.delete(key);
+    }
+    if (this.#windows.size >= this.#maxKeys) this.#windows.clear();
+  }
+}

--- a/packages/http/src/throttle/throttle.test.ts
+++ b/packages/http/src/throttle/throttle.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from 'bun:test';
+import { ConsoleLogger, Module } from '@dunx/core';
+import { UNMATCHED, type MetaKey } from '../route/metadata.js';
+import { Controller, Get, Post } from '../route/decorators.js';
+import { ClientAddress } from '../server/client-address.js';
+import type { RouteContext } from '../server/context.js';
+import { HttpFactory } from '../server/factory.js';
+import { SkipThrottle, Throttle } from './decorators.js';
+import { ThrottleGuard } from './guard.js';
+import { ThrottleModule } from './module.js';
+import { ThrottleOptions } from './options.js';
+import {
+  MemoryThrottleStore,
+  RedisThrottleStore,
+  ThrottleStore,
+  type ThrottleRedis,
+} from './store.js';
+
+/** A Redis that answers, so the multi-process path is exercised without one. */
+class FakeRedis implements ThrottleRedis {
+  readonly counts = new Map<string, number>();
+  readonly expiries = new Map<string, number>();
+  expireCalls = 0;
+
+  incr(key: string): Promise<number> {
+    const next = (this.counts.get(key) ?? 0) + 1;
+    this.counts.set(key, next);
+    return Promise.resolve(next);
+  }
+
+  expire(key: string, seconds: number): Promise<unknown> {
+    this.expireCalls += 1;
+    this.expiries.set(key, seconds);
+    return Promise.resolve(true);
+  }
+
+  ttl(key: string): Promise<number> {
+    return Promise.resolve(this.expiries.get(key) ?? -2);
+  }
+}
+
+class BrokenRedis implements ThrottleRedis {
+  incr(): Promise<number> {
+    return Promise.reject(new Error('Connection closed'));
+  }
+  expire(): Promise<unknown> {
+    return Promise.reject(new Error('Connection closed'));
+  }
+  ttl(): Promise<number> {
+    return Promise.reject(new Error('Connection closed'));
+  }
+}
+
+class Counting extends ConsoleLogger {
+  warnings = 0;
+  override warn(): void {
+    this.warnings += 1;
+  }
+}
+
+describe('ThrottleOptions', () => {
+  const base = { limit: 2, windowSeconds: 60 };
+
+  it('refuses an empty prefix rather than inventing one', () => {
+    expect(() => new ThrottleOptions({ ...base, prefix: '' })).toThrow(
+      /needs a prefix/,
+    );
+    expect(() => new ThrottleOptions({ ...base, prefix: '   ' })).toThrow(
+      /needs a prefix/,
+    );
+  });
+
+  it('refuses a limit or a window below one', () => {
+    expect(
+      () => new ThrottleOptions({ ...base, limit: 0, prefix: 'app' }),
+    ).toThrow(/limit of at least 1/);
+    expect(
+      () => new ThrottleOptions({ ...base, windowSeconds: 0, prefix: 'app' }),
+    ).toThrow(/windowSeconds of at least 1/);
+  });
+
+  it('sends headers unless told not to', () => {
+    expect(new ThrottleOptions({ ...base, prefix: 'app' }).headers).toBe(true);
+    expect(
+      new ThrottleOptions({ ...base, prefix: 'app', headers: false }).headers,
+    ).toBe(false);
+  });
+});
+
+describe('RedisThrottleStore', () => {
+  it('expires only on the hit that created the key', async () => {
+    const redis = new FakeRedis();
+    const store = new RedisThrottleStore(redis);
+    expect(await store.hit('k', 60)).toBe(1);
+    expect(await store.hit('k', 60)).toBe(2);
+    expect(await store.hit('k', 60)).toBe(3);
+    // A second EXPIRE would push the window forward on every request, which is a
+    // window that never ends.
+    expect(redis.expireCalls).toBe(1);
+  });
+
+  it('reads a missing or immortal key as no window rather than a negative wait', async () => {
+    const store = new RedisThrottleStore(new FakeRedis());
+    expect(await store.ttl('never-set')).toBeUndefined();
+  });
+});
+
+describe('MemoryThrottleStore', () => {
+  it('counts within a window and starts over after it', async () => {
+    const store = new MemoryThrottleStore();
+    expect(await store.hit('k', 1)).toBe(1);
+    expect(await store.hit('k', 1)).toBe(2);
+    expect(await store.ttl('k')).toBe(1);
+    await Bun.sleep(1100);
+    expect(await store.hit('k', 1)).toBe(1);
+  });
+
+  it('stays bounded when every key is a fresh subject', async () => {
+    const store = new MemoryThrottleStore(4);
+    for (let i = 0; i < 40; i += 1) await store.hit(`k${i}`, 60);
+    // Nothing has expired, so the sweep clears rather than growing without limit.
+    expect(await store.hit('k39', 60)).toBeLessThanOrEqual(2);
+  });
+
+  it('is a contract, and says so when asked to be an implementation', () => {
+    expect(() => new (ThrottleStore as unknown as new () => unknown)()).toThrow(
+      /contract, not an implementation/,
+    );
+  });
+});
+
+const server = async (init: {
+  limit: number;
+  windowSeconds: number;
+  prefix?: string;
+  headers?: boolean;
+  store?: ThrottleStore;
+  subject?: ThrottleOptions['subject'];
+}) => {
+  @Controller('/things')
+  class Things {
+    @Get('/')
+    list(): { ok: boolean } {
+      return { ok: true };
+    }
+
+    @Post('/')
+    create(): { ok: boolean } {
+      return { ok: true };
+    }
+
+    @Get('/tight')
+    @Throttle({ limit: 1, windowSeconds: 60 })
+    tight(): { ok: boolean } {
+      return { ok: true };
+    }
+
+    @Get('/free')
+    @SkipThrottle()
+    free(): { ok: boolean } {
+      return { ok: true };
+    }
+  }
+
+  @Module({
+    imports: [
+      ThrottleModule.forRoot({
+        limit: init.limit,
+        windowSeconds: init.windowSeconds,
+        prefix: init.prefix ?? 'test-app',
+        ...(init.headers === undefined ? {} : { headers: init.headers }),
+        ...(init.store === undefined ? {} : { store: init.store }),
+        ...(init.subject === undefined ? {} : { subject: init.subject }),
+      }),
+    ],
+    controllers: [Things],
+  })
+  class Root {}
+
+  const app = await HttpFactory.create(Root, {
+    middleware: [ThrottleGuard],
+    requestLogging: false,
+    bootLogging: false,
+  });
+  const base = await app.listen(0);
+  return { app, base };
+};
+
+describe('ThrottleGuard', () => {
+  it('allows the budget and then answers 429 with Retry-After', async () => {
+    const { app, base } = await server({
+      limit: 2,
+      windowSeconds: 60,
+      store: new RedisThrottleStore(new FakeRedis()),
+    });
+
+    const first = await fetch(`${base}things`);
+    expect(first.status).toBe(200);
+    expect(first.headers.get('ratelimit-limit')).toBe('2');
+    expect(first.headers.get('ratelimit-remaining')).toBe('1');
+
+    expect((await fetch(`${base}things`)).status).toBe(200);
+
+    const refused = await fetch(`${base}things`);
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get('retry-after')).toBe('60');
+    expect(refused.headers.get('ratelimit-remaining')).toBe('0');
+    expect(await refused.json()).toMatchObject({ status: 429 });
+
+    await app.shutdown();
+  });
+
+  it('counts per handler, so two verbs on one path do not share a budget', async () => {
+    const { app, base } = await server({ limit: 1, windowSeconds: 60 });
+    expect((await fetch(`${base}things`)).status).toBe(200);
+    expect((await fetch(`${base}things`, { method: 'POST' })).status).toBe(201);
+    expect((await fetch(`${base}things`)).status).toBe(429);
+    await app.shutdown();
+  });
+
+  it("lets a handler's own @Throttle replace the default", async () => {
+    const { app, base } = await server({ limit: 10, windowSeconds: 60 });
+    expect((await fetch(`${base}things/tight`)).status).toBe(200);
+    expect((await fetch(`${base}things/tight`)).status).toBe(429);
+    await app.shutdown();
+  });
+
+  it('exempts a @SkipThrottle handler entirely', async () => {
+    const { app, base } = await server({ limit: 1, windowSeconds: 60 });
+    for (let i = 0; i < 5; i += 1) {
+      expect((await fetch(`${base}things/free`)).status).toBe(200);
+    }
+    await app.shutdown();
+  });
+
+  /**
+   * The miss carries `UNMATCHED`, and counting it would let a burst of 404s spend a
+   * real caller's budget for one Redis round trip each.
+   */
+  it('does not spend a budget on an unmatched path', async () => {
+    const redis = new FakeRedis();
+    const { app, base } = await server({
+      limit: 1,
+      windowSeconds: 60,
+      store: new RedisThrottleStore(redis),
+    });
+    for (let i = 0; i < 3; i += 1) {
+      expect((await fetch(`${base}nope`)).status).toBe(404);
+    }
+    expect(redis.counts.size).toBe(0);
+    expect((await fetch(`${base}things`)).status).toBe(200);
+    await app.shutdown();
+  });
+
+  it('counts by the subject the app names', async () => {
+    const redis = new FakeRedis();
+    const { app, base } = await server({
+      limit: 1,
+      windowSeconds: 60,
+      store: new RedisThrottleStore(redis),
+      subject: (req) => req.headers.get('x-user') ?? undefined,
+    });
+    expect(
+      (await fetch(`${base}things`, { headers: { 'x-user': 'a' } })).status,
+    ).toBe(200);
+    expect(
+      (await fetch(`${base}things`, { headers: { 'x-user': 'b' } })).status,
+    ).toBe(200);
+    expect(
+      (await fetch(`${base}things`, { headers: { 'x-user': 'a' } })).status,
+    ).toBe(429);
+    expect([...redis.counts.keys()]).toEqual([
+      'test-app:throttle:Things:list:a',
+      'test-app:throttle:Things:list:b',
+    ]);
+    await app.shutdown();
+  });
+
+  it('sends no rate-limit headers when headers is false', async () => {
+    const { app, base } = await server({
+      limit: 1,
+      windowSeconds: 60,
+      headers: false,
+    });
+    const ok = await fetch(`${base}things`);
+    expect(ok.headers.get('ratelimit-limit')).toBeNull();
+    const refused = await fetch(`${base}things`);
+    expect(refused.status).toBe(429);
+    expect(refused.headers.get('retry-after')).toBeNull();
+    await app.shutdown();
+  });
+});
+
+const contextOf = (overrides: Partial<Record<'unmatched', boolean>> = {}) => {
+  const ctx: RouteContext = {
+    controller: 'Things',
+    handler: 'list',
+    method: 'GET',
+    path: '/things',
+    get: <T>(key: MetaKey<T>): T | undefined =>
+      key.id === UNMATCHED.id && overrides.unmatched === true
+        ? (true as T)
+        : undefined,
+  };
+  return ctx;
+};
+
+describe('ThrottleGuard, against a counter that is down', () => {
+  /**
+   * An unreachable counter degrades the route and never the process, and it warns
+   * **once** - a line per request would be its own outage.
+   */
+  it('fails open and warns once per process', async () => {
+    const logger = new Counting();
+    const guard = new ThrottleGuard(
+      new ThrottleOptions({
+        limit: 1,
+        windowSeconds: 60,
+        prefix: 'app',
+        subject: () => 'unit',
+      }),
+      new RedisThrottleStore(new BrokenRedis()),
+      new ClientAddress(),
+      logger,
+    );
+    const req = new Request('http://x/things') as never;
+    const ok = () => Promise.resolve(new Response('ok'));
+
+    for (let i = 0; i < 4; i += 1) {
+      expect((await guard.handle(req, contextOf(), ok)).status).toBe(200);
+    }
+    expect(logger.warnings).toBe(1);
+  });
+
+  it('skips an unmatched path before it ever reaches the store', async () => {
+    const logger = new Counting();
+    const guard = new ThrottleGuard(
+      new ThrottleOptions({
+        limit: 1,
+        windowSeconds: 60,
+        prefix: 'app',
+        subject: () => 'unit',
+      }),
+      new RedisThrottleStore(new BrokenRedis()),
+      new ClientAddress(),
+      logger,
+    );
+    const response = await guard.handle(
+      new Request('http://x/nope') as never,
+      contextOf({ unmatched: true }),
+      () => Promise.resolve(new Response('miss', { status: 404 })),
+    );
+    expect(response.status).toBe(404);
+    // Nothing was counted, so nothing failed and nothing warned.
+    expect(logger.warnings).toBe(0);
+  });
+});

--- a/packages/http/src/ws/adapter.ts
+++ b/packages/http/src/ws/adapter.ts
@@ -1,6 +1,13 @@
 import type { BunRequest, Server, WebSocketHandler } from 'bun';
 import type { DiscoveredGateway, Invoke } from './discover.js';
 import { decode, encode } from './envelope.js';
+import { HandlerKind } from './marker.js';
+import {
+  composeSocket,
+  type SocketContext,
+  type SocketFrame,
+  type SocketMiddleware,
+} from './middleware.js';
 import { buildGateways, someHandler, type GatewayRuntime } from './runtime.js';
 import type {
   Socket,
@@ -13,9 +20,13 @@ import type {
 // property read rather than a path lookup. Symbol-keyed, so it stays out of
 // anything that enumerates `socket.data`.
 const RUNTIME: unique symbol = Symbol.for('dunx.ws.runtime');
+// The chain for a frame no named handler claimed, built per gateway at boot. Only
+// present when there is middleware to run.
+const UNCLAIMED: unique symbol = Symbol.for('dunx.ws.unclaimed');
 
 interface Routed extends SocketData<unknown> {
   readonly [RUNTIME]: GatewayRuntime;
+  readonly [UNCLAIMED]?: UnclaimedDispatch;
 }
 
 /**
@@ -57,6 +68,9 @@ export interface GatewaySummary {
 const defaultOnError: SocketErrorHandler = (error, socket) => {
   console.error(`[dunx/http] ${socket.data.path} handler failed:`, error);
 };
+
+/** The failure already went through the chain, which is where it was recorded. */
+const reportedByMiddleware: SocketErrorHandler = () => undefined;
 
 const runtimeOf = (socket: Socket): GatewayRuntime =>
   (socket.data as Routed)[RUNTIME];
@@ -100,13 +114,134 @@ const settle = (
   if (then) then(result);
 };
 
+/**
+ * Where the socket and the payload sit in a handler's own arguments, which differ
+ * by kind: `open`, `close` and `drain` take the socket first, while a message, a
+ * ping and a pong take their data first. Resolved once per slot at boot, so no
+ * frame is built by branching on the kind.
+ */
+const framing = (
+  kind: HandlerKind,
+): ((args: readonly unknown[]) => SocketFrame) => {
+  if (kind === HandlerKind.CLOSE) {
+    return (args) => ({
+      socket: args[0] as Socket,
+      data: { code: args[1], reason: args[2] },
+    });
+  }
+  if (kind === HandlerKind.OPEN || kind === HandlerKind.DRAIN) {
+    return (args) => ({ socket: args[0] as Socket, data: undefined });
+  }
+  return (args) => ({ socket: args[1] as Socket, data: args[0] });
+};
+
+const NOTHING: Invoke = () => undefined;
+
+/**
+ * One slot's handler with the middleware chain folded in front of it.
+ *
+ * `invoke` may be absent: `open` and `close` are wrapped even for a gateway that
+ * declares neither, so a connection and its end are never invisible to an
+ * observer. The inner call is then a no-op and the chain still runs.
+ */
+const through = (
+  gateway: GatewayRuntime,
+  middleware: readonly SocketMiddleware[],
+  kind: HandlerKind,
+  event: string | undefined,
+  invoke: Invoke | undefined,
+): Invoke => {
+  const ctx: SocketContext = {
+    gateway: gateway.name,
+    path: gateway.path,
+    kind,
+    event,
+  };
+  const dispatch = composeSocket(middleware, ctx);
+  const frameOf = framing(kind);
+  const run = invoke ?? NOTHING;
+  return (...args) => dispatch(frameOf(args), () => run(...args));
+};
+
+const withMiddleware = (
+  gateway: GatewayRuntime,
+  middleware: readonly SocketMiddleware[],
+): GatewayRuntime => {
+  const wrap = (
+    kind: HandlerKind,
+    event: string | undefined,
+    invoke: Invoke | undefined,
+  ) => through(gateway, middleware, kind, event, invoke);
+  const optional = (kind: HandlerKind, invoke: Invoke | undefined) =>
+    invoke === undefined ? undefined : wrap(kind, undefined, invoke);
+
+  return {
+    ...gateway,
+    open: wrap(HandlerKind.OPEN, undefined, gateway.open),
+    close: wrap(HandlerKind.CLOSE, undefined, gateway.close),
+    // Left alone when the gateway declares none. Bun answers a ping with a pong
+    // itself, and installing a handler to observe one would take that away.
+    drain: optional(HandlerKind.DRAIN, gateway.drain),
+    ping: optional(HandlerKind.PING, gateway.ping),
+    pong: optional(HandlerKind.PONG, gateway.pong),
+    raw: optional(HandlerKind.MESSAGE, gateway.raw),
+    events: new Map(
+      [...gateway.events].map(([event, invoke]) => [
+        event,
+        wrap(HandlerKind.MESSAGE, event, invoke),
+      ]),
+    ),
+  };
+};
+
+/**
+ * The chain for a frame nothing claimed - an event no `@OnMessage` declares, on a
+ * gateway with no raw catch-all. The socket analogue of the HTTP not-found
+ * fallback: without it an unknown event is silently dropped, which is the one thing
+ * a client debugging its own wire format cannot see.
+ *
+ * The context is built per frame because the event name is the frame's, and that
+ * allocation is on this path only.
+ */
+type UnclaimedDispatch = (
+  frame: SocketFrame,
+  event: string | undefined,
+) => unknown;
+
+const unclaimedDispatch =
+  (
+    gateway: GatewayRuntime,
+    middleware: readonly SocketMiddleware[],
+  ): UnclaimedDispatch =>
+  (frame, event) =>
+    composeSocket(middleware, {
+      gateway: gateway.name,
+      path: gateway.path,
+      kind: HandlerKind.MESSAGE,
+      event,
+    })(frame, () => undefined);
+
 export const buildWebSocket = (
   discovered: readonly DiscoveredGateway[],
   options: SocketOptions = {},
+  middleware: readonly SocketMiddleware[] = [],
 ): WebSocketRuntime => {
   const byPath = buildGateways(discovered);
-  const gateways = [...byPath.values()];
-  const onError = options.onError ?? defaultOnError;
+  const wrapped =
+    middleware.length === 0
+      ? byPath
+      : new Map(
+          [...byPath].map(([path, gateway]) => [
+            path,
+            withMiddleware(gateway, middleware),
+          ]),
+        );
+  const gateways = [...wrapped.values()];
+  // A middleware wraps the handler, so it has already seen a failure by the time
+  // one escapes - and the console fallback would be a second report of it.
+  const onError =
+    options.onError ??
+    (middleware.length === 0 ? defaultOnError : reportedByMiddleware);
   // The rest is exactly the set of keys Bun's WebSocketHandler accepts.
   const { onError: _onError, ...socketOptions } = options;
 
@@ -128,6 +263,7 @@ export const buildWebSocket = (
 
     message(ws, message) {
       const gateway = runtimeOf(ws);
+      let event: string | undefined;
       if (gateway.events.size > 0) {
         const envelope = decode(message);
         const handler = envelope && gateway.events.get(envelope.event);
@@ -137,9 +273,23 @@ export const buildWebSocket = (
           });
           return;
         }
+        event = envelope?.event;
       }
       if (gateway.raw) {
         run(gateway.raw, [message, ws], ws, (value) => replyRaw(ws, value));
+        return;
+      }
+      const unclaimed = (ws.data as Routed)[UNCLAIMED];
+      if (!unclaimed) return;
+      try {
+        settle(
+          unclaimed({ socket: ws, data: message }, event),
+          ws,
+          onError,
+          undefined,
+        );
+      } catch (error) {
+        onError(error, ws);
       }
     },
 
@@ -181,13 +331,29 @@ export const buildWebSocket = (
     }),
   };
 
+  const unclaimed = new Map<GatewayRuntime, UnclaimedDispatch>(
+    middleware.length === 0
+      ? []
+      : gateways.map((gateway) => [
+          gateway,
+          unclaimedDispatch(gateway, middleware),
+        ]),
+  );
+
   const accept = (
     req: Request,
     server: Server<SocketData>,
     gateway: GatewayRuntime,
     context: unknown,
   ): Response | undefined => {
-    const data: Routed = { path: gateway.path, context, [RUNTIME]: gateway };
+    const fallback = unclaimed.get(gateway);
+    const data: Routed = {
+      path: gateway.path,
+      context,
+      id: crypto.randomUUID(),
+      [RUNTIME]: gateway,
+      ...(fallback === undefined ? {} : { [UNCLAIMED]: fallback }),
+    };
     return server.upgrade(req, { data })
       ? undefined
       : new Response('Expected a WebSocket upgrade', { status: 426 });

--- a/packages/http/src/ws/logging.ts
+++ b/packages/http/src/ws/logging.ts
@@ -1,0 +1,181 @@
+import { Logger, LogLevel, RequestContext } from '@dunx/core';
+import { HandlerKind } from './marker.js';
+import {
+  observe,
+  type SocketContext,
+  type SocketFrame,
+  type SocketMiddleware,
+  type SocketNext,
+} from './middleware.js';
+
+export interface SocketLoggingOptions {
+  /**
+   * The level every message frame is logged at. Default **`'debug'`**.
+   *
+   * `'debug'`, not `'info'`, because a socket is not a request: a gateway can take
+   * a frame per player per tick, and one `info` line each would bury everything
+   * else the process writes. The default `ConsoleLogger` threshold is `'info'`, so
+   * this is off until an app lowers its level or names a louder one here.
+   */
+  readonly level?: LogLevel;
+  /** What a throwing or rejecting handler is logged at. @default 'error' */
+  readonly errorLevel?: LogLevel;
+  /**
+   * Per-event level, keyed by the `@OnMessage(event)` name. `false` skips the
+   * event entirely, and skipping is complete: no entry, no timing, no scope.
+   *
+   * ```ts
+   * socketLogging: { events: { placeBet: 'info', cursorMove: false } }
+   * ```
+   */
+  readonly events?: Readonly<Record<string, LogLevel | false>>;
+  /**
+   * Open, close, drain, ping and pong. Defaults to `level`; `false` drops them.
+   *
+   * Separate from `level` because the two answer different questions - how much
+   * traffic a socket carries, against how many sockets there are - and an app that
+   * silences the first usually still wants the second.
+   */
+  readonly lifecycle?: LogLevel | false;
+  /**
+   * Log the frame's payload. Default **`false`**.
+   *
+   * A payload is caller-supplied and arrives without validation, so it is both the
+   * field most likely to carry a credential and the one most likely to be large.
+   */
+  readonly payload?: boolean;
+  /** Payloads past this many characters are logged as a size. @default 512 */
+  readonly maxPayloadLength?: number;
+  /**
+   * Wrap each dispatch in an `AsyncRequestContext` scope. Default **`true`**.
+   *
+   * The scope is what makes a line a service logs four frames down carry
+   * `connectionId` and `event` without being handed the socket.
+   */
+  readonly correlate?: boolean;
+}
+
+const LIFECYCLE_LABEL: Readonly<Record<string, string>> = {
+  [HandlerKind.OPEN]: 'connect',
+  [HandlerKind.CLOSE]: 'disconnect',
+};
+
+const elapsedMs = (started: number): number =>
+  Math.round((Bun.nanoseconds() - started) / 1e6);
+
+/**
+ * One structured entry per dispatched frame, carrying the frame and its outcome.
+ *
+ * The socket counterpart of `RequestLoggingMiddleware`, and the same single-entry
+ * shape: the middleware wraps the handler, so the frame and what it answered are
+ * one line rather than an inbound line to correlate with an outbound one.
+ *
+ * It also replaces what a gateway would otherwise hand-write. A throwing handler
+ * reaches the `Logger` here with the gateway, the path and the event on it -
+ * `SocketOptions.onError`'s default is a bare `console.error` off the logging
+ * pipeline entirely, and installing this takes that fallback out of the way.
+ */
+export class SocketLoggingMiddleware implements SocketMiddleware {
+  readonly #level: LogLevel;
+  readonly #errorLevel: LogLevel;
+  readonly #events: Readonly<Record<string, LogLevel | false>>;
+  readonly #lifecycle: LogLevel | false;
+  readonly #payload: boolean;
+  readonly #limit: number;
+  readonly #correlate: boolean;
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly context: RequestContext,
+    options: SocketLoggingOptions = {},
+  ) {
+    this.#level = options.level ?? LogLevel.DEBUG;
+    this.#errorLevel = options.errorLevel ?? LogLevel.ERROR;
+    this.#events = options.events ?? {};
+    this.#lifecycle = options.lifecycle ?? this.#level;
+    this.#payload = options.payload ?? false;
+    this.#limit = options.maxPayloadLength ?? 512;
+    this.#correlate = options.correlate ?? true;
+  }
+
+  /** `false` means this frame is not logged at all. */
+  #levelFor(ctx: SocketContext): LogLevel | false {
+    if (ctx.kind !== HandlerKind.MESSAGE) return this.#lifecycle;
+    if (ctx.event === undefined) return this.#level;
+    return this.#events[ctx.event] ?? this.#level;
+  }
+
+  handle(frame: SocketFrame, ctx: SocketContext, next: SocketNext): unknown {
+    const level = this.#levelFor(ctx);
+    if (level === false) return next();
+
+    const label = ctx.event ?? LIFECYCLE_LABEL[ctx.kind] ?? ctx.kind;
+    const connectionId = frame.socket.data.id;
+    const started = Bun.nanoseconds();
+    const write = (error: unknown, value: unknown): void => {
+      const entry = {
+        gateway: ctx.gateway,
+        path: ctx.path,
+        event: label,
+        connectionId,
+        elapsedMs: elapsedMs(started),
+        ...(this.#payload ? { payload: this.#brief(frame.data) } : {}),
+        ...(error === undefined
+          ? { replied: value !== undefined }
+          : { err: error }),
+      };
+      const line = `${ctx.path} ${label}`;
+      this.#emit(error === undefined ? level : this.#errorLevel, line, entry);
+    };
+
+    if (!this.#correlate) return observe(next, write);
+    return this.context.runWithContext(
+      { connectionId, event: label, flow: 'ws', context: ctx.gateway },
+      () => observe(next, write),
+    );
+  }
+
+  /**
+   * A `switch` rather than `this.logger[level](...)`. The indexed call needs a
+   * `bind` to keep its receiver, which would be one closure allocated per frame -
+   * and a gateway taking a frame per tick is exactly where that shows up.
+   */
+  #emit(level: LogLevel, line: string, entry: Record<string, unknown>): void {
+    switch (level) {
+      case LogLevel.VERBOSE:
+        this.logger.verbose(line, entry);
+        return;
+      case LogLevel.DEBUG:
+        this.logger.debug(line, entry);
+        return;
+      case LogLevel.INFO:
+        this.logger.info(line, entry);
+        return;
+      case LogLevel.WARN:
+        this.logger.warn(line, entry);
+        return;
+      case LogLevel.ERROR:
+        this.logger.error(line, entry);
+        return;
+      default:
+        this.logger.fatal(line, entry);
+    }
+  }
+
+  /**
+   * A payload as one loggable value: an object as itself, anything longer than the
+   * limit as its size. Serialising to measure it is the cost `payload: false`
+   * avoids.
+   */
+  #brief(data: unknown): unknown {
+    if (data === undefined || this.#limit === 0) return undefined;
+    if (typeof data === 'string') {
+      return data.length > this.#limit ? `[${data.length} chars]` : data;
+    }
+    if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+      return `[${data.byteLength} bytes]`;
+    }
+    const text = JSON.stringify(data) ?? '';
+    return text.length > this.#limit ? `[${text.length} chars]` : data;
+  }
+}

--- a/packages/http/src/ws/middleware.test.ts
+++ b/packages/http/src/ws/middleware.test.ts
@@ -1,0 +1,461 @@
+import { describe, expect, it } from 'bun:test';
+import { Logger, LogLevel, Module, provide, RequestContext } from '@dunx/core';
+import { HttpFactory } from '../server/factory.js';
+import { Gateway, OnClose, OnMessage, OnOpen } from './decorators.js';
+import {
+  SocketLoggingMiddleware,
+  type SocketLoggingOptions,
+} from './logging.js';
+import {
+  composeSocket,
+  observe,
+  type SocketContext,
+  type SocketFrame,
+  type SocketMiddleware,
+  type SocketNext,
+} from './middleware.js';
+import type { Socket } from './socket.js';
+
+interface Seen {
+  readonly kind: string;
+  readonly event: string | undefined;
+  readonly gateway: string;
+  readonly path: string;
+  readonly data: unknown;
+  readonly connectionId: string;
+  readonly error: unknown;
+  readonly value: unknown;
+}
+
+/** Records every dispatch it wraps, and leaves the outcome exactly as it found it. */
+class Recorder implements SocketMiddleware {
+  readonly seen: Seen[] = [];
+
+  handle(frame: SocketFrame, ctx: SocketContext, next: SocketNext): unknown {
+    return observe(next, (error, value) => {
+      this.seen.push({
+        kind: ctx.kind,
+        event: ctx.event,
+        gateway: ctx.gateway,
+        path: ctx.path,
+        data: frame.data,
+        connectionId: frame.socket.data.id,
+        error,
+        value,
+      });
+    });
+  }
+}
+
+@Gateway('/ws')
+class Chat {
+  @OnOpen()
+  opened(socket: Socket): void {
+    socket.send('ready');
+  }
+
+  @OnMessage('echo')
+  echo(data: unknown): unknown {
+    return data;
+  }
+
+  @OnMessage('boom')
+  boom(): never {
+    throw new Error('handler exploded');
+  }
+
+  @OnMessage('slow')
+  async slow(data: unknown): Promise<unknown> {
+    await Bun.sleep(1);
+    return data;
+  }
+
+  @OnClose()
+  closed(): undefined {
+    return undefined;
+  }
+}
+
+const recorder = new Recorder();
+
+@Module({
+  providers: [Chat, provide(Recorder, { useValue: recorder })],
+  exports: [Recorder],
+})
+class ChatModule {}
+
+interface Client {
+  send(frame: string): void;
+  next(ms?: number): Promise<string>;
+  close(): void;
+}
+
+const connect = async (base: string): Promise<Client> => {
+  const socket = new WebSocket(
+    new URL('/ws', base).href.replace(/^http/, 'ws'),
+  );
+  const frames: string[] = [];
+  const waiting: ((frame: string) => void)[] = [];
+  socket.addEventListener('message', (event: MessageEvent) => {
+    const frame = String(event.data);
+    const waiter = waiting.shift();
+    if (waiter) waiter(frame);
+    else frames.push(frame);
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener('open', () => resolve(), { once: true });
+    socket.addEventListener('error', () => reject(new Error('no connect')), {
+      once: true,
+    });
+  });
+  return {
+    send: (frame) => socket.send(frame),
+    next: (ms = 2000) =>
+      new Promise<string>((resolve, reject) => {
+        const queued = frames.shift();
+        if (queued !== undefined) {
+          resolve(queued);
+          return;
+        }
+        const timer = setTimeout(() => reject(new Error('timed out')), ms);
+        waiting.push((frame) => {
+          clearTimeout(timer);
+          resolve(frame);
+        });
+      }),
+    close: () => socket.close(),
+  };
+};
+
+describe('composeSocket', () => {
+  const ctx: SocketContext = {
+    gateway: 'G',
+    path: '/ws',
+    kind: 'message',
+    event: 'x',
+  };
+  const frame = { socket: {} as Socket, data: 1 };
+
+  it('runs the handler when there is no middleware', () => {
+    expect(composeSocket([], ctx)(frame, () => 'handled')).toBe('handled');
+  });
+
+  it('runs outermost first and innermost last', () => {
+    const order: string[] = [];
+    const at = (name: string): SocketMiddleware => ({
+      handle: (_frame, _ctx, next) => {
+        order.push(`${name} in`);
+        const result = next();
+        order.push(`${name} out`);
+        return result;
+      },
+    });
+    composeSocket([at('a'), at('b')], ctx)(frame, () => {
+      order.push('handler');
+      return undefined;
+    });
+    expect(order).toEqual(['a in', 'b in', 'handler', 'b out', 'a out']);
+  });
+
+  it('lets a middleware answer the frame without the handler', () => {
+    const refuse: SocketMiddleware = { handle: () => 'refused' };
+    let ran = false;
+    const result = composeSocket([refuse], ctx)(frame, () => {
+      ran = true;
+      return 'handled';
+    });
+    expect(result).toBe('refused');
+    expect(ran).toBe(false);
+  });
+});
+
+describe('observe', () => {
+  it('reports a synchronous value and returns it untouched', () => {
+    let seen: unknown;
+    expect(
+      observe(
+        () => 7,
+        (_error, value) => {
+          seen = value;
+        },
+      ),
+    ).toBe(7);
+    expect(seen).toBe(7);
+  });
+
+  it('reports a synchronous throw and rethrows it', () => {
+    let seen: unknown;
+    expect(() =>
+      observe(
+        () => {
+          throw new Error('nope');
+        },
+        (error) => {
+          seen = error;
+        },
+      ),
+    ).toThrow('nope');
+    expect((seen as Error).message).toBe('nope');
+  });
+
+  it('reports a rejection and keeps it rejected', async () => {
+    let seen: unknown;
+    const result = observe(
+      () => Promise.reject(new Error('later')),
+      (error) => {
+        seen = error;
+      },
+    );
+    await expect(result as Promise<unknown>).rejects.toThrow('later');
+    expect((seen as Error).message).toBe('later');
+  });
+});
+
+describe('a gateway with socket middleware', () => {
+  it('sees the whole lifecycle of a connection', async () => {
+    recorder.seen.length = 0;
+    const app = await HttpFactory.create(ChatModule, {
+      socketMiddleware: [Recorder],
+      socketLogging: false,
+      bootLogging: false,
+      requestLogging: false,
+    });
+    const base = await app.listen(0);
+    const client = await connect(base);
+    expect(await client.next()).toBe('ready');
+
+    client.send(JSON.stringify({ event: 'echo', data: { hi: 1 } }));
+    expect(JSON.parse(await client.next())).toEqual({
+      event: 'echo',
+      data: { hi: 1 },
+    });
+
+    client.send(JSON.stringify({ event: 'slow', data: 'wait' }));
+    expect(JSON.parse(await client.next())).toEqual({
+      event: 'slow',
+      data: 'wait',
+    });
+
+    client.send(JSON.stringify({ event: 'boom' }));
+    client.send(JSON.stringify({ event: 'nosuchthing', data: 2 }));
+    await Bun.sleep(30);
+    client.close();
+    await Bun.sleep(30);
+    await app.shutdown();
+
+    const echo = recorder.seen.find((entry) => entry.event === 'echo');
+    expect(echo?.gateway).toBe('Chat');
+    expect(echo?.path).toBe('/ws');
+    expect(echo?.data).toEqual({ hi: 1 });
+    expect(echo?.value).toEqual({ hi: 1 });
+    expect(echo?.error).toBeUndefined();
+    expect(echo?.connectionId).toMatch(/^[0-9a-f-]{36}$/);
+
+    // The awaited handler is reported on its own channel, with the value it
+    // eventually answered rather than the promise it returned first.
+    expect(recorder.seen.find((entry) => entry.event === 'slow')?.value).toBe(
+      'wait',
+    );
+
+    const failed = recorder.seen.find((entry) => entry.event === 'boom');
+    expect((failed?.error as Error | undefined)?.message).toBe(
+      'handler exploded',
+    );
+
+    // An event no @OnMessage claims still reaches the chain, so a client's typo is
+    // visible rather than silently dropped.
+    expect(recorder.seen.some((entry) => entry.event === 'nosuchthing')).toBe(
+      true,
+    );
+
+    expect(recorder.seen.map((entry) => entry.kind)).toContain('open');
+    expect(recorder.seen.map((entry) => entry.kind)).toContain('close');
+    // Every entry on one connection shares its id.
+    expect(new Set(recorder.seen.map((entry) => entry.connectionId)).size).toBe(
+      1,
+    );
+  });
+
+  /**
+   * `open` and `close` are wrapped even when the gateway declares neither, so a
+   * connection is never invisible to an observer.
+   */
+  it('sees connect and disconnect on a gateway that declares neither', async () => {
+    const seen: string[] = [];
+    class Watch implements SocketMiddleware {
+      handle(_frame: SocketFrame, ctx: SocketContext, next: SocketNext) {
+        seen.push(ctx.kind);
+        return next();
+      }
+    }
+
+    @Gateway('/bare')
+    class Bare {
+      @OnMessage('ping')
+      ping(): string {
+        return 'pong';
+      }
+    }
+
+    @Module({ providers: [Bare, Watch], exports: [Watch] })
+    class BareModule {}
+
+    const app = await HttpFactory.create(BareModule, {
+      socketMiddleware: [Watch],
+      socketLogging: false,
+      bootLogging: false,
+      requestLogging: false,
+    });
+    const base = await app.listen(0);
+    const socket = new WebSocket(
+      new URL('/bare', base).href.replace(/^http/, 'ws'),
+    );
+    await new Promise<void>((resolve) =>
+      socket.addEventListener('open', () => resolve(), { once: true }),
+    );
+    socket.close();
+    await Bun.sleep(40);
+    await app.shutdown();
+
+    expect(seen).toContain('open');
+    expect(seen).toContain('close');
+  });
+});
+
+class Captured extends Logger {
+  readonly lines: { level: string; message: string; entry: unknown }[] = [];
+  readonly logLevel = LogLevel.VERBOSE;
+
+  #write(level: string) {
+    return (message: unknown, ...rest: unknown[]): void => {
+      this.lines.push({ level, message: String(message), entry: rest[0] });
+    };
+  }
+
+  verbose = this.#write('verbose') as Logger['verbose'];
+  debug = this.#write('debug') as Logger['debug'];
+  info = this.#write('info') as Logger['info'];
+  log = this.#write('info') as Logger['log'];
+  warn = this.#write('warn') as Logger['warn'];
+  error = this.#write('error') as Logger['error'];
+  fatal = this.#write('fatal') as Logger['fatal'];
+}
+
+class Passthrough extends RequestContext {
+  fields: Record<string, unknown> = {};
+  getContext() {
+    return this.fields;
+  }
+  updateContext(fields: Record<string, unknown>) {
+    Object.assign(this.fields, fields);
+  }
+  runWithContext<T>(context: Record<string, unknown>, callback: () => T): T {
+    this.fields = { ...context };
+    return callback();
+  }
+}
+
+const logged = (options: SocketLoggingOptions) => {
+  const logger = new Captured();
+  const middleware = new SocketLoggingMiddleware(
+    logger,
+    new Passthrough(),
+    options,
+  );
+  return { logger, middleware };
+};
+
+const frameOf = (): SocketFrame => ({
+  socket: { data: { id: 'conn-1', path: '/ws', context: null } } as Socket,
+  data: { amount: 10 },
+});
+
+const ctxOf = (event: string | undefined, kind = 'message'): SocketContext => ({
+  gateway: 'Chat',
+  path: '/ws',
+  kind: kind as SocketContext['kind'],
+  event,
+});
+
+describe('SocketLoggingMiddleware', () => {
+  it('writes at debug by default, and never at info', () => {
+    const { logger, middleware } = logged({});
+    middleware.handle(frameOf(), ctxOf('placeBet'), () => 'ack');
+    expect(logger.lines).toHaveLength(1);
+    expect(logger.lines[0]?.level).toBe('debug');
+    expect(logger.lines[0]?.message).toBe('/ws placeBet');
+    expect(logger.lines[0]?.entry).toMatchObject({
+      gateway: 'Chat',
+      path: '/ws',
+      event: 'placeBet',
+      connectionId: 'conn-1',
+      replied: true,
+    });
+  });
+
+  it('takes a level per event, and false skips one entirely', () => {
+    const { logger, middleware } = logged({
+      events: { placeBet: LogLevel.INFO, tick: false },
+    });
+    middleware.handle(frameOf(), ctxOf('placeBet'), () => undefined);
+    middleware.handle(frameOf(), ctxOf('tick'), () => undefined);
+    middleware.handle(frameOf(), ctxOf('other'), () => undefined);
+    expect(logger.lines.map((line) => `${line.level}:${line.message}`)).toEqual(
+      ['info:/ws placeBet', 'debug:/ws other'],
+    );
+  });
+
+  it('names connect and disconnect, and lifecycle can be silenced on its own', () => {
+    const { logger, middleware } = logged({});
+    middleware.handle(frameOf(), ctxOf(undefined, 'open'), () => undefined);
+    middleware.handle(frameOf(), ctxOf(undefined, 'close'), () => undefined);
+    expect(logger.lines.map((line) => line.message)).toEqual([
+      '/ws connect',
+      '/ws disconnect',
+    ]);
+
+    const quiet = logged({ lifecycle: false });
+    quiet.middleware.handle(frameOf(), ctxOf(undefined, 'open'), () => 1);
+    expect(quiet.logger.lines).toHaveLength(0);
+  });
+
+  it('logs a throwing handler at error and rethrows it', () => {
+    const { logger, middleware } = logged({});
+    expect(() =>
+      middleware.handle(frameOf(), ctxOf('boom'), () => {
+        throw new Error('nope');
+      }),
+    ).toThrow('nope');
+    expect(logger.lines[0]?.level).toBe('error');
+    expect(logger.lines[0]?.entry).toMatchObject({ err: expect.any(Error) });
+  });
+
+  it('omits the payload unless asked, and caps it when it is', () => {
+    const quiet = logged({});
+    quiet.middleware.handle(frameOf(), ctxOf('bet'), () => undefined);
+    expect(quiet.logger.lines[0]?.entry).not.toHaveProperty('payload');
+
+    const loud = logged({ payload: true, maxPayloadLength: 4 });
+    loud.middleware.handle(
+      { socket: frameOf().socket, data: 'a much longer string' },
+      ctxOf('bet'),
+      () => undefined,
+    );
+    expect(loud.logger.lines[0]?.entry).toMatchObject({
+      payload: '[20 chars]',
+    });
+  });
+
+  it('puts the connection and the event in the async scope', () => {
+    const logger = new Captured();
+    const context = new Passthrough();
+    const middleware = new SocketLoggingMiddleware(logger, context, {});
+    middleware.handle(frameOf(), ctxOf('placeBet'), () => undefined);
+    expect(context.getContext()).toMatchObject({
+      connectionId: 'conn-1',
+      event: 'placeBet',
+      flow: 'ws',
+      context: 'Chat',
+    });
+  });
+});

--- a/packages/http/src/ws/middleware.ts
+++ b/packages/http/src/ws/middleware.ts
@@ -1,0 +1,121 @@
+import type { HandlerKind } from './marker.js';
+import type { Socket } from './socket.js';
+
+/**
+ * Which handler a frame is on its way to, resolved at boot.
+ *
+ * The websocket half of {@link RouteContext}: it names the gateway rather than the
+ * controller, and the envelope event rather than the method and path. One object
+ * per slot, built once, so a middleware costs no allocation per frame beyond the
+ * frame itself.
+ */
+export interface SocketContext {
+  /** The gateway class's name. */
+  readonly gateway: string;
+  /** The path it upgraded on, exactly as mounted. */
+  readonly path: string;
+  readonly kind: HandlerKind;
+  /**
+   * The `@OnMessage(event)` name. `undefined` for a lifecycle hook and for the raw
+   * `@OnMessage()` catch-all, which claims every frame no named handler took.
+   */
+  readonly event: string | undefined;
+}
+
+/**
+ * The frame itself: the socket it arrived on, and the argument the handler is
+ * about to be given.
+ *
+ * `data` is the envelope's `data` for a named message, the whole frame for the raw
+ * catch-all, `{ code, reason }` for a close, the buffer for a ping or a pong, and
+ * `undefined` for an open or a drain.
+ */
+export interface SocketFrame {
+  readonly socket: Socket;
+  readonly data: unknown;
+}
+
+/**
+ * Runs the rest of the chain and finally the gateway handler, returning whatever
+ * it returned - which for a named message is the value dunx sends back.
+ *
+ * It is **not** `Promise<unknown>`, unlike the HTTP `Next`. A gateway handler may
+ * be synchronous and the dispatcher does not allocate a promise to hide that, so a
+ * middleware that needs the outcome handles both channels. {@link observe} is that
+ * dance, written once.
+ */
+export type SocketNext = () => unknown;
+
+/**
+ * The single extension point on the socket side, shaped like {@link Middleware} on
+ * the HTTP side: one method, wrapping `next()`.
+ *
+ * It sees every dispatched handler - open, each named message, the catch-all,
+ * close, drain, ping and pong - and open and close arrive even for a gateway that
+ * declares no `@OnOpen`/`@OnClose`, so a connection is never invisible to it.
+ *
+ * A throwing or rejecting handler passes through here, which is where a guard
+ * refuses and where an observer records the failure. Rethrow to leave the outcome
+ * to `SocketOptions.onError`; return a value instead to answer the frame.
+ *
+ * Three things it cannot see, because they never reach the dispatcher: a
+ * `socket.send` a handler makes itself, a `PubSub` broadcast, and the upgrade -
+ * which is an HTTP request answered by the gateway's own route.
+ */
+export interface SocketMiddleware {
+  handle(frame: SocketFrame, ctx: SocketContext, next: SocketNext): unknown;
+}
+
+/** One slot's folded chain. The handler's own arguments ride in `run`. */
+export type SocketDispatch = (frame: SocketFrame, run: SocketNext) => unknown;
+
+/**
+ * Folded into one closure per slot at boot, the same shape `compose` gives an HTTP
+ * route - so dispatch stays a property read and a call, with no array iteration
+ * per frame.
+ */
+export const composeSocket = (
+  middleware: readonly SocketMiddleware[],
+  ctx: SocketContext,
+): SocketDispatch =>
+  middleware.reduceRight<SocketDispatch>(
+    (next, current) => (frame, run) =>
+      current.handle(frame, ctx, () => next(frame, run)),
+    (_frame, run) => run(),
+  );
+
+/**
+ * Calls `next()` and reports how it went, on whichever channel it went out on,
+ * leaving the result untouched.
+ *
+ * `error` is `undefined` on success. A synchronous throw and a rejection both
+ * reach `done` and are then rethrown, so a middleware that only observes cannot
+ * accidentally swallow a failure.
+ */
+export const observe = (
+  next: SocketNext,
+  done: (error: unknown, value: unknown) => void,
+): unknown => {
+  let result: unknown;
+  try {
+    result = next();
+  } catch (error) {
+    done(error, undefined);
+    throw error;
+  }
+
+  if (result instanceof Promise) {
+    return result.then(
+      (value: unknown) => {
+        done(undefined, value);
+        return value;
+      },
+      (error: unknown) => {
+        done(error, undefined);
+        throw error;
+      },
+    );
+  }
+  done(undefined, result);
+  return result;
+};

--- a/packages/http/src/ws/socket.ts
+++ b/packages/http/src/ws/socket.ts
@@ -8,6 +8,12 @@ import type { ServerWebSocket, WebSocketHandler } from 'bun';
 export interface SocketData<T = unknown> {
   readonly path: string;
   readonly context: T;
+  /**
+   * This connection, for as long as it lasts. Minted at the upgrade, because Bun's
+   * socket carries no identity of its own and a log line for a frame is only
+   * joinable to the connect and the disconnect around it if something does.
+   */
+  readonly id: string;
 }
 
 /**
@@ -38,6 +44,12 @@ export type SocketOptions = Readonly<
     | 'sendPings'
   >
 > & {
-  /** Where a throwing or rejecting handler goes. @default console.error */
+  /**
+   * Where a throwing or rejecting handler goes. @default console.error
+   *
+   * The default is **not** installed when `socketMiddleware` is non-empty: a
+   * middleware wraps the handler, so it already saw the failure and a second
+   * report on the console would be a duplicate.
+   */
   readonly onError?: SocketErrorHandler;
 };

--- a/packages/infra/src/pagination/keyset.ts
+++ b/packages/infra/src/pagination/keyset.ts
@@ -6,32 +6,33 @@ import type { PageOptions } from './options.js';
 import { pageOf, type Page } from './page.js';
 
 /**
- * Keyset (cursor) pagination over a drizzle table.
- *
- * Keyset rather than `OFFSET`: an offset scan re-reads and discards every row
- * before the page, so page 500 costs 500 pages of work, and a row inserted between
- * two requests shifts every subsequent page by one - the same item appears twice or
- * not at all. A cursor names the last row seen, so the database seeks straight to it
- * and a concurrent insert changes nothing about what the reader has already read.
- *
- * `await` on the query builder, not `.all()`. drizzle's builders are thenable on the
- * synchronous `bun:sqlite` driver as well as the asynchronous `Bun.SQL` one
- * (measured), so one code path serves both dialects `@dunx/infra/db` supports. The
- * implementation this was ported from called `.all()` and was SQLite-only.
+ * The chain `paginate` walks, parameterised by what the driver hands back at the
+ * end of it. Anything with drizzle's `select()` fits, so both dialects and a
+ * transaction handle do.
  */
-export interface PaginateParams<TTable extends Table> {
-  /** Anything with drizzle's `select()`, so both dialects and a transaction fit. */
-  readonly db: {
-    select: () => {
-      from: (table: TTable) => {
-        where: (condition: SQL | undefined) => {
-          orderBy: (...columns: SQL[]) => {
-            limit: (rows: number) => PromiseLike<unknown[]>;
-          };
+export interface PaginateSource<TTable extends Table, TResult> {
+  select: () => {
+    from: (table: TTable) => {
+      where: (condition: SQL | undefined) => {
+        orderBy: (...columns: SQL[]) => {
+          limit: (rows: number) => TResult;
         };
       };
     };
   };
+}
+
+/**
+ * What a synchronous driver's builder answers: `all()` returning the rows, not a
+ * promise of them. `drizzle-orm/bun-sqlite` in synchronous mode is the case;
+ * `drizzle-orm/bun-sql` has no `all` at all, and an asynchronous SQLite driver's
+ * `all()` returns a promise, so neither is assignable here.
+ */
+export interface SyncRows {
+  all: () => unknown[];
+}
+
+interface PaginateBase<TTable extends Table> {
   readonly table: TTable;
   readonly options: PageOptions;
   /**
@@ -54,21 +55,52 @@ export interface PaginateParams<TTable extends Table> {
   readonly idColumn?: string | undefined;
 }
 
-const ORDER_PRECEDENCE = ['updatedAt', 'createdAt', 'id'] as const;
+/**
+ * Keyset (cursor) pagination over a drizzle table.
+ *
+ * Keyset rather than `OFFSET`: an offset scan re-reads and discards every row
+ * before the page, so page 500 costs 500 pages of work, and a row inserted between
+ * two requests shifts every subsequent page by one - the same item appears twice or
+ * not at all. A cursor names the last row seen, so the database seeks straight to it
+ * and a concurrent insert changes nothing about what the reader has already read.
+ *
+ * This is the asynchronous shape: `await` on the query builder, which is what
+ * `drizzle-orm/bun-sql` answers. See {@link SyncPaginateParams} for the
+ * synchronous one.
+ */
+export interface PaginateParams<
+  TTable extends Table,
+> extends PaginateBase<TTable> {
+  readonly db: PaginateSource<TTable, PromiseLike<unknown[]>>;
+}
 
 /**
- * Rows plus the cursors to move either way.
+ * The same parameters against a synchronous driver.
  *
- * One row more than asked for is fetched and then dropped: its existence is what
- * answers `hasNextPage` without a second `COUNT(*)` over the same predicate.
+ * `db` is the discriminant, and it is the driver's own type rather than a flag:
+ * a builder that answers `all(): unknown[]` is a synchronous one, so `paginate`
+ * returns a `Page` rather than a promise of one and a repository over
+ * `drizzle-orm/bun-sqlite` needs no `async` on its `list`.
  */
-export const paginate = async <
+export interface SyncPaginateParams<
   TTable extends Table,
-  TRow extends Record<string, unknown>,
->(
-  params: PaginateParams<TTable>,
-): Promise<Page<TRow>> => {
-  const { db, table, options, where } = params;
+> extends PaginateBase<TTable> {
+  readonly db: PaginateSource<TTable, SyncRows>;
+}
+
+const ORDER_PRECEDENCE = ['updatedAt', 'createdAt', 'id'] as const;
+
+/** Everything the query and the envelope need, decided before either is built. */
+interface Plan {
+  readonly conditions: readonly SQL[];
+  readonly order: readonly SQL[];
+  readonly sortKey: string;
+  readonly idKey: string;
+  readonly backward: boolean;
+}
+
+const plan = <TTable extends Table>(params: PaginateBase<TTable>): Plan => {
+  const { table, options, where } = params;
   const columns = getTableColumns(table) as unknown as Record<string, Column>;
   const idKey = params.idColumn ?? 'id';
   const idColumn = columns[idKey];
@@ -116,18 +148,27 @@ export const paginate = async <
   }
 
   const direction = descending ? desc : asc;
-  const order =
-    sortKey === idKey
-      ? [direction(idColumn)]
-      : [direction(sortColumn), direction(idColumn)];
+  return {
+    conditions,
+    order:
+      sortKey === idKey
+        ? [direction(idColumn)]
+        : [direction(sortColumn), direction(idColumn)],
+    sortKey,
+    idKey,
+    backward,
+  };
+};
 
-  const rows = (await db
-    .select()
-    .from(table)
-    .where(conditions.length === 0 ? undefined : and(...conditions))
-    .orderBy(...order)
-    .limit(options.take + 1)) as TRow[];
-
+/**
+ * One row more than asked for is fetched and then dropped: its existence is what
+ * answers `hasNextPage` without a second `COUNT(*)` over the same predicate.
+ */
+const envelope = <TRow extends Record<string, unknown>>(
+  rows: TRow[],
+  options: PageOptions,
+  { sortKey, idKey, backward }: Plan,
+): Page<TRow> => {
   const more = rows.length > options.take;
   if (more) rows.pop();
   if (backward) rows.reverse();
@@ -141,6 +182,68 @@ export const paginate = async <
       encodeCursor(row[sortKey] as Date | string | number, String(row[idKey])),
   });
 };
+
+/**
+ * Rows plus the cursors to move either way, on whichever channel the driver
+ * answers on.
+ *
+ * **The return type follows `db`.** A synchronous driver gets a `Page` and an
+ * asynchronous one a `Promise<Page>`, decided by overload rather than by a flag,
+ * so a repository over `drizzle-orm/bun-sqlite` is synchronous end to end - which
+ * is what keeps a read-check-write inside `transactionSync` atomic instead of
+ * forcing an `async list` onto every repository that shares the file.
+ *
+ * The two are not distinguished at runtime by the builder's *shape*: an
+ * asynchronous SQLite driver has an `all()` too. What is checked is the value it
+ * returns, so a promise is adopted rather than mistaken for rows.
+ *
+ * An argument error - a table with no tie-break column - throws rather than
+ * rejecting, on both channels. It is a `TypeError` about the call, not a database
+ * failure, and the synchronous overload has nowhere to reject from.
+ */
+export function paginate<
+  TTable extends Table,
+  TRow extends Record<string, unknown>,
+>(params: SyncPaginateParams<TTable>): Page<TRow>;
+export function paginate<
+  TTable extends Table,
+  TRow extends Record<string, unknown>,
+>(params: PaginateParams<TTable>): Promise<Page<TRow>>;
+export function paginate<
+  TTable extends Table,
+  TRow extends Record<string, unknown>,
+>(
+  params: SyncPaginateParams<TTable> | PaginateParams<TTable>,
+): Page<TRow> | Promise<Page<TRow>> {
+  const { db, table, options } = params;
+  const prepared = plan(params);
+
+  const query = (db as PaginateSource<TTable, unknown>)
+    .select()
+    .from(table)
+    .where(
+      prepared.conditions.length === 0
+        ? undefined
+        : and(...prepared.conditions),
+    )
+    .orderBy(...prepared.order)
+    .limit(options.take + 1);
+
+  const rows = isSync(query) ? query.all() : query;
+  return Array.isArray(rows)
+    ? envelope(rows as TRow[], options, prepared)
+    : Promise.resolve(rows as PromiseLike<unknown[]>).then((resolved) =>
+        envelope(resolved as TRow[], options, prepared),
+      );
+}
+
+/**
+ * Whether the builder offers `all()`. Calling it is what decides the channel: a
+ * synchronous driver returns the rows and an asynchronous one a promise of them,
+ * and the array check downstream is what tells those apart.
+ */
+const isSync = (query: unknown): query is SyncRows =>
+  typeof (query as SyncRows | undefined)?.all === 'function';
 
 /**
  * A cursor carries the sort value as a string. A timestamp column has to go back to

--- a/packages/infra/src/pagination/pagination.test.ts
+++ b/packages/infra/src/pagination/pagination.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { like } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
 import { drizzle, type BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { CursorError, decodeCursor, encodeCursor } from './cursor.js';
@@ -209,7 +210,7 @@ describe('parsePageOptions', () => {
 
 describe('paginate', () => {
   it('returns the first page newest-first, with no previous cursor', async () => {
-    const first = await page();
+    const first = page();
     expect(first.data.map((row) => row.id)).toEqual(['e', 'd']);
     expect(first.meta.hasNextPage).toBe(true);
     expect(first.meta.hasPreviousPage).toBe(false);
@@ -222,7 +223,7 @@ describe('paginate', () => {
     const seen: string[] = [];
     let cursor: string | undefined;
     for (let guard = 0; guard < 10; guard += 1) {
-      const result = await page(cursor === undefined ? {} : { cursor });
+      const result = page(cursor === undefined ? {} : { cursor });
       seen.push(...result.data.map((row) => row.id));
       if (!result.meta.hasNextPage) break;
       cursor = result.meta.nextCursor ?? undefined;
@@ -231,11 +232,11 @@ describe('paginate', () => {
   });
 
   it('walks backwards to the page it came from', async () => {
-    const first = await page();
-    const second = await page({ cursor: first.meta.nextCursor ?? undefined });
+    const first = page();
+    const second = page({ cursor: first.meta.nextCursor ?? undefined });
     expect(second.data.map((row) => row.id)).toEqual(['c', 'b']);
 
-    const back = await page({
+    const back = page({
       cursor: second.meta.previousCursor ?? undefined,
       direction: PaginationDirection.BACKWARD,
     });
@@ -245,9 +246,9 @@ describe('paginate', () => {
   });
 
   it('honours ascending order', async () => {
-    const first = await page({ order: PaginationOrder.ASC });
+    const first = page({ order: PaginationOrder.ASC });
     expect(first.data.map((row) => row.id)).toEqual(['a', 'b']);
-    const next = await page({
+    const next = page({
       order: PaginationOrder.ASC,
       cursor: first.meta.nextCursor ?? undefined,
     });
@@ -255,7 +256,7 @@ describe('paginate', () => {
   });
 
   it('reports the last page and mints no next cursor on it', async () => {
-    const last = await page({ take: 5 });
+    const last = page({ take: 5 });
     expect(last.data).toHaveLength(5);
     expect(last.meta.hasNextPage).toBe(false);
     // A next cursor here would be a token that returns nothing.
@@ -277,7 +278,7 @@ describe('paginate', () => {
     const seen: string[] = [];
     let cursor: string | undefined;
     for (let guard = 0; guard < 10; guard += 1) {
-      const result = await page(cursor === undefined ? {} : { cursor });
+      const result = page(cursor === undefined ? {} : { cursor });
       seen.push(...result.data.map((row) => row.id));
       if (!result.meta.hasNextPage) break;
       cursor = result.meta.nextCursor ?? undefined;
@@ -288,29 +289,33 @@ describe('paginate', () => {
 
   /** A row inserted mid-walk must not shift a page, which is offset's failure. */
   it('is unaffected by an insert between pages', async () => {
-    const first = await page();
+    const first = page();
     db.insert(notes)
       .values({ id: 'z', title: 'inserted', createdAt: new Date(9000) })
       .run();
 
-    const second = await page({ cursor: first.meta.nextCursor ?? undefined });
+    const second = page({ cursor: first.meta.nextCursor ?? undefined });
     // 'z' sorts newest, so it belongs before the cursor and must not appear here,
     // and nothing already read is repeated.
     expect(second.data.map((row) => row.id)).toEqual(['c', 'b']);
   });
 
   it('ANDs a base filter with the cursor', async () => {
-    const filtered = await page({ take: 10 }, like(notes.title, '%a%'));
+    const filtered = page({ take: 10 }, like(notes.title, '%a%'));
     expect(filtered.data.map((row) => row.id)).toEqual(['a']);
   });
 
   it('sorts by an explicit column', async () => {
-    const byId = await page({ take: 5, order: PaginationOrder.ASC });
+    const byId = page({ take: 5, order: PaginationOrder.ASC });
     expect(byId.data.map((row) => row.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
   });
 
-  it('says so when the tie-break column is missing', async () => {
-    await expect(
+  /**
+   * Thrown rather than rejected, on both channels: it is a `TypeError` about the
+   * call and the synchronous overload has nowhere to reject from.
+   */
+  it('says so when the tie-break column is missing', () => {
+    expect(() =>
       paginate({
         db: db as never,
         table: notes,
@@ -321,7 +326,7 @@ describe('paginate', () => {
         },
         idColumn: 'nope',
       }),
-    ).rejects.toThrow(/no "nope" column/);
+    ).toThrow(/no "nope" column/);
   });
 
   /**
@@ -345,7 +350,7 @@ describe('paginate', () => {
     const seen: number[] = [];
     let cursor: string | undefined;
     for (let guard = 0; guard < 10; guard += 1) {
-      const result = await paginate<typeof table, { id: number }>({
+      const result = paginate<typeof table, { id: number }>({
         db: numeric as never,
         table,
         options: {
@@ -365,10 +370,83 @@ describe('paginate', () => {
 
   it('returns an empty page rather than failing on an empty table', async () => {
     seed([]);
-    const empty = await page();
+    const empty = page();
     expect(empty.data).toEqual([]);
     expect(empty.meta.hasNextPage).toBe(false);
     expect(empty.meta.nextCursor).toBeNull();
     expect(empty.meta.previousCursor).toBeNull();
+  });
+});
+
+/**
+ * The return type follows `db`, and so does the value: a synchronous driver is
+ * answered synchronously, which is what lets a repository over
+ * `drizzle-orm/bun-sqlite` keep `list` off the async channel.
+ */
+describe('paginate, on a synchronous driver', () => {
+  const options = {
+    take: 2,
+    order: PaginationOrder.DESC,
+    direction: PaginationDirection.FORWARD,
+  } as const;
+
+  it('answers without a promise', () => {
+    const result = paginate<typeof notes, Note>({ db, table: notes, options });
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(result.data.map((row) => row.id)).toEqual(['e', 'd']);
+    expect(result.meta.hasNextPage).toBe(true);
+  });
+
+  it('walks every page without an await', () => {
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 10; guard += 1) {
+      const result = paginate<typeof notes, Note>({
+        db,
+        table: notes,
+        options: { ...options, ...(cursor === undefined ? {} : { cursor }) },
+      });
+      seen.push(...result.data.map((row) => row.id));
+      if (!result.meta.hasNextPage) break;
+      cursor = result.meta.nextCursor ?? undefined;
+    }
+    expect(seen).toEqual(['e', 'd', 'c', 'b', 'a']);
+  });
+
+  /**
+   * `Bun.SQL`'s builder is thenable and has no `all()`, so it takes the
+   * asynchronous overload - and an asynchronous SQLite driver, whose `all()`
+   * answers a promise, takes it too. Both are covered by adopting the value rather
+   * than trusting the shape.
+   */
+  it('still awaits a driver that answers a promise', async () => {
+    const thenable = {
+      select: () => ({
+        from: (table: typeof notes) => ({
+          where: (condition: SQL | undefined) => ({
+            orderBy: (...columns: SQL[]) => ({
+              limit: (rows: number) =>
+                Promise.resolve(
+                  db
+                    .select()
+                    .from(table)
+                    .where(condition)
+                    .orderBy(...columns)
+                    .limit(rows)
+                    .all() as unknown[],
+                ),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const pending = paginate<typeof notes, Note>({
+      db: thenable,
+      table: notes,
+      options,
+    });
+    expect(pending).toBeInstanceOf(Promise);
+    expect((await pending).data.map((row) => row.id)).toEqual(['e', 'd']);
   });
 });

--- a/packages/infra/src/queue/worker.ts
+++ b/packages/infra/src/queue/worker.ts
@@ -3,6 +3,8 @@ import {
   collectModules,
   Logger,
   ShutdownHooks,
+  teardownError,
+  teardownFailures,
   type App,
   type InjectionToken,
   type ModuleRef,
@@ -275,11 +277,32 @@ class WorkerApplication implements WorkerApp {
     return this.#app.drain();
   }
 
+  /**
+   * Consumers first, then providers - and **every step runs**.
+   *
+   * A worker that could not stop its consumer used to skip the container teardown
+   * entirely and leave `closed` pending, so the process hung on a Redis that had
+   * already gone. Each failure is collected and thrown once the phase is over.
+   */
   async shutdown(): Promise<void> {
     this.#shuttingDown ??= (async () => {
-      await this.#consumer.stop();
-      await this.#app.shutdown();
-      this.#resolveClosed?.();
+      const failures: unknown[] = [];
+      try {
+        await this.#consumer.stop();
+      } catch (error) {
+        this.#app
+          .get(Logger)
+          .error('The queue consumer could not be stopped', error);
+        failures.push(error);
+      }
+      try {
+        await this.#app.shutdown();
+      } catch (error) {
+        failures.push(...teardownFailures(error));
+      } finally {
+        this.#resolveClosed?.();
+      }
+      if (failures.length > 0) throw teardownError(failures);
     })();
     return this.#shuttingDown;
   }

--- a/tools/create-app/templates/features/database/ledger.controller.ts
+++ b/tools/create-app/templates/features/database/ledger.controller.ts
@@ -96,7 +96,7 @@ export class LedgerController {
    * `/ledger/page` cannot be swallowed by `/ledger/:id`.
    */
   @Get('/page', pagedEntries)
-  page(input: Input<typeof pagedEntries>): Promise<Page<Entry>> {
+  page(input: Input<typeof pagedEntries>): Page<Entry> {
     return this.ledger.page(input.query);
   }
 

--- a/tools/create-app/templates/features/database/ledger.service.ts
+++ b/tools/create-app/templates/features/database/ledger.service.ts
@@ -63,10 +63,11 @@ export class Ledger implements OnInit, OnShutdown {
    * so `paginate` falls back to the primary key - `id` is unique on its own, so no
    * tie-break column is needed.
    *
-   * `async` although bun-sqlite is synchronous, because `paginate` awaits the query
-   * builder - the one code path that serves both dialects.
+   * Synchronous, because `paginate`'s return type follows its `db`: a
+   * `drizzle-orm/bun-sqlite` handle answers `all()` rather than a promise, so this
+   * method needs no `async` and neither does its caller.
    */
-  page(options: PageOptions): Promise<Page<Entry>> {
+  page(options: PageOptions): Page<Entry> {
     return paginate<typeof ledger, Entry>({
       db: this.db,
       table: ledger,


### PR DESCRIPTION
Five gaps a real application (firecracker, a crash game on 2.1.1) hit in anger, plus one bug found while documenting them.

**Merging this publishes 2.2.0.** HEAD is a `release(minor):` commit, so CI's release step will bump all ten packages 2.1.1 → 2.2.0, write the changelog, tag, and publish. `bun run version:dry-run` confirms the bump type is read correctly from the commit.

## What is in it

- **`paginate` follows its driver.** Overloads discriminated on the shape of `db`: `bun-sqlite` returns a `Page`, `bun-sql` a `Promise<Page>`. The runtime adopts the value rather than trusting the shape, so an async SQLite `all()` still awaits. A consuming app no longer has to make every repository method async to satisfy one helper.
- **A throttle**, in `@dunx/http` rather than `@dunx/infra`: it is a `Middleware` reading a `MetaKey` off a `RouteContext`, and `@dunx/infra` must not depend on the web layer. The Redis client is taken structurally, so this adds no dependency. `HttpError` gains `headers` so a thrown 429 can carry `Retry-After`.
- **WebSocket middleware**, mirroring the HTTP shape — one interface, one method wrapping `next()`, folded per slot at boot — plus a logging middleware defaulting to `debug` with per-event levels. `SocketData` gains an `id`, because Bun's socket has no identity and frames could not otherwise be joined to their connect and disconnect.
- **Modules compose instead of erroring.** A class carrying both `@Module` and `forRoot()` used to concatenate its metadata and register every import twice. Options now union, a configured provider overrides the declared binding for the same token, and `exports: [SomeModule]` resolves to the configured import — which retires the hoisted-`const` workaround apps were using. Registering one class twice against the same token now warns at boot.
- **Teardown finishes.** One throwing `onShutdown` aborted the loop, so every remaining provider kept its resources and `closed` never resolved: a hung shutdown ending in SIGKILL. Every hook now settles, failures log against the provider that threw, `closed` resolves in a `finally`, and the aggregate is thrown after. `drain()` had the same flaw through `Promise.all`, and `HttpApplication.shutdown` left the port open.

## Behaviour changes, called out rather than hidden

1. `paginate`'s sync return type on a sync driver.
2. `paginate` throws rather than rejects on a missing tie-break.
3. `shutdown()`/`drain()` reject with an `AggregateError` instead of the first failure.

## Not changed

Static serving. An unmatched path is reported by **throwing**, which is by design — the 401-vs-404 symptom a consuming app reported turned out to be app-side, an `(await next()).status` check that therefore never ran. The throw-vs-return contract is now documented in `buildFallback`, and `StaticModule`'s misleading `@Get('/*')` suggestion is replaced with a worked `UNMATCHED` fallback.

## Docs

Seventeen documents plus the README, rewritten and verified claim by claim against `packages/*/src`. **52 docs-vs-code discrepancies** came out of that; several look like code defects rather than writing defects and are recorded as such. Largest change is the queue guide, which sent readers to a `WorkerFactory` and a `src/worker.ts` that `examples/full` no longer has, while never mentioning `QueueModule.forRoot({ consume: true })`.

Four flagged-but-unfixed: no `x-request-id` on failure responses (real, but the mapper runs outside the chain so it is not a cheap fix), the `OPTIONS` method-miss falling through the global chain, and `override` of an unbound *class* token binding silently. Each needs its own decision.

## Verification

- `bun run typecheck` — exit 0, 19 workspaces.
- `bun run test` — exit 0, 1,624 tests, 0 failures (48 new: 17 throttle, 14 WS, 11 module, 6 teardown, 7 pagination).
- `bun run lint:check` — exit 0, warnings all pre-existing.
- `bun run format:check` — clean.

Exit codes captured directly, not inferred through a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)