### PR TITLE
release(patch): request ids on failures, a silent-socket-error warning, and three corrected docs

### DIFF
--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -80,11 +80,12 @@ patterns to try `/t/7/` against. Matching there would mean a second JavaScript
 router beside Bun's.
 
 **CORS preflight is mounted, not inferred.** An `OPTIONS` request does reach the
-fallback, but answering preflight from there would mean reconstructing which verbs
-the path declares after Bun has already failed to match it. `enableCors()` mounts an
-explicit `OPTIONS` handler on every path instead, built at boot from the verbs that
-path actually declares. It cannot collide with one of yours, because there is no
-`OPTIONS` verb decorator.
+fallback. Answering preflight there would mean reconstructing which verbs the path
+declares, after Bun has already failed to match it.
+
+`enableCors()` mounts an explicit `OPTIONS` handler on every path instead, built at
+boot from the verbs that path declares. It cannot collide with one of yours: there is
+no `OPTIONS` verb decorator.
 
 **A route collision is a boot error.** Bun silently lets one route win, so dunx
 rejects a duplicate method-and-path pair before it can, naming both handlers:

--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -46,8 +46,21 @@ router, and writing one is a standing prohibition rather than a backlog item.
 
 Four consequences you will actually notice.
 
-**An unmatched method returns 404 where most frameworks return 405.** Bun's
-native behaviour, unmodified.
+**An unmatched method returns 404 where most frameworks return 405.** Bun answers a
+method miss natively only when nothing else can claim the request. dunx always
+installs the `fetch` fallback described below, so a method miss reaches it, runs the
+whole global middleware chain and comes back as the framework's 404 - the same shape
+as an unmatched path. Measured:
+
+```
+GET     /thing   200   the route
+OPTIONS /thing   ->    the fallback
+POST    /thing   ->    the fallback
+GET     /nope    ->    the fallback
+```
+
+The status is 404 either way; what differs is that your middleware sees it, so
+request logging, throttling and CORS all get a look at a method miss.
 
 **Paths are matched exactly, so a trailing slash is a different path.** `GET /t`
 is a 200 and `GET /t/` is a 404, and the same goes for `/t/sub/` and `POST /t/`.
@@ -66,11 +79,12 @@ The inbound URL is the only remaining half, and dunx could only touch it in the
 patterns to try `/t/7/` against. Matching there would mean a second JavaScript
 router beside Bun's.
 
-**CORS preflight cannot be inferred.** Since a method miss is a native 404, there
-is no fall-through for an `OPTIONS` request to land in. `enableCors()` therefore
-mounts an explicit `OPTIONS` handler on every path, built at boot from the verbs
-that path actually declares. It cannot collide with one of yours, because there is
-no `OPTIONS` verb decorator.
+**CORS preflight is mounted, not inferred.** An `OPTIONS` request does reach the
+fallback, but answering preflight from there would mean reconstructing which verbs
+the path declares after Bun has already failed to match it. `enableCors()` mounts an
+explicit `OPTIONS` handler on every path instead, built at boot from the verbs that
+path actually declares. It cannot collide with one of yours, because there is no
+`OPTIONS` verb decorator.
 
 **A route collision is a boot error.** Bun silently lets one route win, so dunx
 rejects a duplicate method-and-path pair before it can, naming both handlers:

--- a/docs/guide/11-testing.md
+++ b/docs/guide/11-testing.md
@@ -21,7 +21,7 @@ Use it when the thing under test is a service, which is most of the time.
 
 ```ts
 import { describe, expect, test } from 'bun:test';
-import { provide } from '@dunx/core';
+import { provide, token } from '@dunx/core';
 import { createTestApp } from '@dunx/testing';
 
 class FixedForecast extends ForecastClient {
@@ -118,34 +118,56 @@ this graph with these bindings replaced", which is also how a deployment variant
 would be expressed. `HttpOptions extends AppOptions`, so
 `HttpFactory.create` inherits it without a second mechanism.
 
-### An unmatched override is an error
+### An unmatched override is an error - unless it is a class
 
 ```ts
 test('an override naming a token nobody binds is an error', async () => {
-  class NotBoundAnywhere {}
+  const Clock = token<Date>('Clock');
 
   const message = await createTestApp({
     modules: [WeatherModule],
-    overrides: [provide(NotBoundAnywhere, { useValue: {} })],
+    overrides: [provide(Clock, { useValue: new Date(0) })],
   }).then(
     () => 'it resolved',
     (error: unknown) => (error as Error).message,
   );
 
-  expect(message).toContain('Nothing to override for NotBoundAnywhere');
+  expect(message).toContain('Nothing to override for Clock');
 });
 ```
 
-The full message:
+The full message, and the second clause is the important one:
 
-> Nothing to override for NotBoundAnywhere: no module in the graph binds it. An
-> override replaces a binding - it cannot add one, because a token nobody bound is
-> a token nothing under test resolves.
+> Nothing to override for Clock: no module in the graph binds it, **and it is not a
+> class, so nothing self-binds it either**. An override replaces a binding - it
+> cannot add one, because a token nobody bound is a token nothing under test
+> resolves.
 
 A silent no-op here is the worst possible failure, because it leaves a suite
 asserting against the real provider it believed it had swapped, and it passes. The
-check names **every** unmatched token rather than the first, so a renamed class
-does not turn into three rounds of the same error.
+check names **every** unmatched token rather than the first, so a renamed token does
+not turn into three rounds of the same error.
+
+**A class is deliberately exempt, and that is a real gap in the safety net.** A class
+self-binds: it needs no declaration to be resolvable, so an override for one is
+replacing the binding that _would_ have happened on demand, and registering it
+eagerly would construct a stub for a collaborator the graph under test never reaches.
+That is why `Injector.registerLazy` exists.
+
+The cost is that a **typo'd class override is accepted in silence** - there is no
+binding for it to fail to match, and nothing under test asks for it, so it simply
+never fires. Measured:
+
+```
+override a declared class      -> resolves, replacement used
+override a class nobody binds  -> resolves, no error
+override a token() nobody binds -> throws "Nothing to override"
+```
+
+So the check protects `token()` bindings and cannot protect class ones. If a class
+override appears not to work, the first thing to suspect is the class itself: two
+copies of a package means two class objects, and the one you imported in the suite is
+not the one the module bound.
 
 The most common way to hit it is a token whose module you forgot to list in
 `modules`. The second most common is a second copy of `@dunx/core` in the

--- a/packages/http/src/health/health.test.ts
+++ b/packages/http/src/health/health.test.ts
@@ -44,6 +44,33 @@ describe('the report', () => {
     expect(report.checks[1]?.detail).toBe('1 ms');
   });
 
+  /**
+   * The uptime is a duration, so it comes off a monotonic clock. It used to come off
+   * `Date.now()`, which meant any backwards adjustment of the wall clock - NTP, a
+   * suspend and resume, a VM resyncing with its host - produced a negative uptime.
+   * A probe was caught answering `uptimeMs: -242` under WSL2.
+   */
+  test('survives the wall clock stepping backwards', async () => {
+    const health = registry([indicator('a', () => ({ state: 'up' }))]);
+    const realNow = Date.now;
+    Date.now = () => realNow() - 60_000;
+
+    try {
+      const report = await health.liveness();
+      expect(report.uptimeMs).toBeGreaterThanOrEqual(0);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  test('reports uptime as a whole number of milliseconds', async () => {
+    const report = await registry([
+      indicator('a', () => ({ state: 'up' })),
+    ]).liveness();
+
+    expect(Number.isInteger(report.uptimeMs)).toBe(true);
+  });
+
   test('a throwing check is down, carrying its message', async () => {
     const report = await registry([
       indicator('boom', () => {

--- a/packages/http/src/health/registry.ts
+++ b/packages/http/src/health/registry.ts
@@ -20,6 +20,7 @@ export interface HealthCheckReport {
 export interface HealthReport {
   readonly status: ProbeState;
   readonly draining: boolean;
+  /** Measured on a monotonic clock, so it never goes backwards. */
   readonly uptimeMs: number;
   readonly checks: readonly HealthCheckReport[];
 }
@@ -99,7 +100,15 @@ export interface HealthOptionsInit {
 
 /** Runs the indicators and shapes the report. Never throws. */
 export class HealthRegistry {
-  readonly #startedAt = Date.now();
+  /**
+   * `performance.now()`, not `Date.now()`. A duration taken from the wall clock is
+   * wrong whenever the wall clock is adjusted: an NTP correction, a suspend and
+   * resume, or a VM resyncing with its host all step it, and a backwards step made
+   * this report a *negative* uptime. That is not hypothetical - it was caught by a
+   * probe answering `uptimeMs: -242` under WSL2, where the guest clock is resynced
+   * routinely, which also made `uptimeMs >= 0` a flaky assertion.
+   */
+  readonly #startedAt = performance.now();
 
   constructor(
     private readonly options: HealthOptions,
@@ -128,7 +137,9 @@ export class HealthRegistry {
     return {
       status: worst(checks),
       draining: this.readiness_.draining,
-      uptimeMs: Date.now() - this.#startedAt,
+      // Rounded, because a monotonic clock is fractional and a millisecond count
+      // with seventeen decimal places reads like a bug in the probe.
+      uptimeMs: Math.round(performance.now() - this.#startedAt),
       checks,
     };
   }

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -83,8 +83,8 @@ export {
   type HttpApp,
   type HttpOptions,
 } from './server/factory.js';
+export { REQUEST_ID_HEADER } from './server/request-id.js';
 export {
-  REQUEST_ID_HEADER,
   RequestLoggingMiddleware,
   type RequestLoggingOptions,
 } from './server/request-logging.js';

--- a/packages/http/src/server/factory.ts
+++ b/packages/http/src/server/factory.ts
@@ -158,6 +158,12 @@ export class HttpFactory {
           )
         : undefined;
 
+    // Boot warnings go out here for the same reason the container's own do: they
+    // are about the wiring, and the app that wired it is about to start serving.
+    for (const warning of websocket?.warnings ?? []) {
+      app.get(Logger).warn(warning);
+    }
+
     // `root` is the app's own module, so global middleware and the error filter
     // resolve as the app sees them rather than as this wrapper does.
     return new HttpApplication(app, discovered, options, root, websocket);

--- a/packages/http/src/server/request-id.test.ts
+++ b/packages/http/src/server/request-id.test.ts
@@ -1,0 +1,195 @@
+import type { BunRequest } from 'bun';
+import { describe, expect, it } from 'bun:test';
+import { Module } from '@dunx/core';
+import { Controller, Get, Post } from '../route/decorators.js';
+import { UseGuards } from '../route/metadata.js';
+import type {
+  Input,
+  StandardSchemaResult,
+  StandardSchemaV1,
+} from '../route/schema.js';
+import type { RouteContext } from './context.js';
+import { HttpError } from './errors.js';
+import { HttpFactory, type HttpApp } from './factory.js';
+import type { Middleware, Next } from './middleware.js';
+import { REQUEST_ID_HEADER } from './request-id.js';
+import { HttpStatusCode } from './status.js';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** The same shape `request-logging.test.ts` reads, and it silences the run. */
+const captured = async (
+  run: () => Promise<void>,
+): Promise<Record<string, unknown>[]> => {
+  const lines: string[] = [];
+  const { log, error } = console;
+  const record = (...args: unknown[]): void => {
+    lines.push(...args.map(String).join(' ').split('\n'));
+  };
+  console.log = record;
+  console.error = record;
+  try {
+    await run();
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+  return lines
+    .filter((line) => line.startsWith('{'))
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+};
+
+const Note: StandardSchemaV1<unknown, { text: string }> = {
+  '~standard': {
+    version: 1,
+    vendor: 'test',
+    validate: (value): StandardSchemaResult<{ text: string }> => {
+      const text = (value as Record<string, unknown> | null)?.['text'];
+      return typeof text === 'string'
+        ? { value: { text } }
+        : { issues: [{ message: 'text must be a string', path: ['text'] }] };
+    },
+  },
+};
+
+const createNote = { body: Note } as const;
+
+class Denies implements Middleware {
+  handle(_req: BunRequest, _ctx: RouteContext, _next: Next): Promise<Response> {
+    throw new HttpError(HttpStatusCode.UNAUTHORIZED, 'No credentials');
+  }
+}
+
+@Controller('notes')
+class NotesController {
+  @Post('/', createNote)
+  create(input: Input<typeof createNote>): { text: string } {
+    return input.body;
+  }
+
+  @Get('/guarded')
+  @UseGuards(Denies)
+  guarded(): never {
+    throw new Error('the guard answers first');
+  }
+
+  @Get('/broken')
+  broken(): never {
+    throw new Error('unhandled');
+  }
+}
+
+@Module({ controllers: [NotesController] })
+class NotesModule {}
+
+const withApp = async (
+  run: (app: HttpApp, url: string) => Promise<void>,
+  options: Parameters<typeof HttpFactory.create>[1] = {},
+): Promise<void> => {
+  const app = await HttpFactory.create(NotesModule, options);
+  const url = await app.listen(0);
+  try {
+    await run(app, url);
+  } finally {
+    await app.shutdown();
+  }
+};
+
+/**
+ * One request, one header. The holder keeps TypeScript's narrowing from the
+ * initialiser, the way the request logging suite's does.
+ */
+const idOf = async (
+  path: string,
+  init: RequestInit = {},
+  options: Parameters<typeof HttpFactory.create>[1] = {},
+): Promise<{
+  header?: string | undefined;
+  entries: Record<string, unknown>[];
+}> => {
+  const seen: { header?: string | undefined } = {};
+  const entries = await captured(async () => {
+    await withApp(async (_app, url) => {
+      const response = await fetch(new URL(path, url), init);
+      seen.header = response.headers.get(REQUEST_ID_HEADER) ?? undefined;
+    }, options);
+  });
+  return { ...seen, entries };
+};
+
+const posted = (body: unknown): RequestInit => ({
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+/**
+ * The error mapper runs outside the middleware chain and builds a fresh
+ * `Response`, so every one of these went out with no id on it - the responses a
+ * caller most needs in order to find the line the logger wrote for them.
+ */
+describe('the request id on a failure', () => {
+  it('is on a status a guard threw', async () => {
+    const { header } = await idOf('notes/guarded');
+    expect(header).toMatch(UUID);
+  });
+
+  it('is on a validation 400', async () => {
+    const { header } = await idOf('notes', posted({ text: 7 }));
+    expect(header).toMatch(UUID);
+  });
+
+  it('is on a mapped 500, and matches the entry that recorded it', async () => {
+    const { header, entries } = await idOf('notes/broken');
+    expect(header).toMatch(UUID);
+    const entry = entries.find(
+      (line) => line['message'] === 'GET /notes/broken 500',
+    );
+    expect(entry?.['requestId']).toBe(header);
+  });
+
+  it('is on an unmatched path', async () => {
+    const { header } = await idOf('nothing-here');
+    expect(header).toMatch(UUID);
+  });
+
+  it('honours an inbound uuid', async () => {
+    const given = '3f8c1b0e-9a4d-4c2f-8e11-6b7a2d5c9f03';
+    const { header } = await idOf('notes/broken', {
+      headers: { [REQUEST_ID_HEADER]: given },
+    });
+    expect(header).toBe(given);
+  });
+
+  it('replaces an inbound id that is not a uuid', async () => {
+    const { header } = await idOf('notes/broken', {
+      headers: { [REQUEST_ID_HEADER]: 'MY-OWN-ID' },
+    });
+    expect(header).not.toBe('MY-OWN-ID');
+    expect(header).toMatch(UUID);
+  });
+
+  /** Nothing minted an id, so there is none to put on the failure either. */
+  it('is absent when request logging is off', async () => {
+    const mapped = await idOf('notes/broken', {}, { requestLogging: false });
+    expect(mapped.header).toBeUndefined();
+    const missed = await idOf('nothing-here', {}, { requestLogging: false });
+    expect(missed.header).toBeUndefined();
+  });
+
+  it('is absent on an ignored path, inbound or not', async () => {
+    const options = { requestLogging: { ignore: ['/notes/broken'] } };
+    const { header } = await idOf('notes/broken', {}, options);
+    expect(header).toBeUndefined();
+    const echoed = await idOf(
+      'notes/broken',
+      {
+        headers: {
+          [REQUEST_ID_HEADER]: '3f8c1b0e-9a4d-4c2f-8e11-6b7a2d5c9f03',
+        },
+      },
+      options,
+    );
+    expect(echoed.header).toBeUndefined();
+  });
+});

--- a/packages/http/src/server/request-id.ts
+++ b/packages/http/src/server/request-id.ts
@@ -1,0 +1,67 @@
+export const REQUEST_ID_HEADER = 'x-request-id';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * An inbound id is honoured so a trace survives across services - but only if it
+ * is a UUID, which is what this would have minted. It is a caller-supplied string
+ * that ends up in every line the request writes, so a newline, a megabyte, or a
+ * deliberate collision with somebody else's trace is replaced by a fresh one
+ * rather than trusted. A production template validated it the same way.
+ *
+ * The length check first: it is what keeps garbage away from the regex, and the
+ * common case has no header at all.
+ */
+const traceId = (inbound: string | null): string =>
+  inbound !== null && inbound.length === 36 && UUID.test(inbound)
+    ? inbound
+    : crypto.randomUUID();
+
+/**
+ * Where the id sits between the middleware that minted it and the mapper that has
+ * to put it on a failure. Symbol-keyed and on the request itself, the same channel
+ * the socket's gateway runtime travels on: it stays out of anything that
+ * enumerates the object, and a property write measured 9.5 ns against 29 ns for a
+ * `WeakMap` entry, on a path already accounted for in microseconds.
+ */
+const ID: unique symbol = Symbol.for('dunx.http.requestId');
+
+interface Tagged {
+  [ID]?: string;
+}
+
+/**
+ * The request id, and the only thing that decides a request has one.
+ *
+ * `RequestLoggingMiddleware` sets the header on a response it returns, and a
+ * failure is never one: `buildRoutes` and `buildFallback` catch outside the chain
+ * and build a fresh `Response` from the error mapper. So a guard's 401, a
+ * validation 400, a mapped 500 and every unmatched 404 went out with no id on
+ * them, which are the responses a caller most needs in order to find the log line
+ * the middleware just wrote.
+ *
+ * Recorded against the request rather than threaded through the mapper, because
+ * `ErrorMapper` is `(error, req) => Response` and an app writes its own.
+ * {@link stamp} then reads back whatever {@link assign} recorded, so an app that
+ * turned request logging off, or a path it told the middleware to ignore, is still
+ * answered without a header: nothing minted an id, so there is none to stamp.
+ */
+export class RequestIds {
+  /**
+   * Called by `RequestLoggingMiddleware` and by nothing else. Splitting minting
+   * from recording would let a second caller invent an id the log line does not
+   * carry.
+   */
+  static assign(req: Request): string {
+    const id = traceId(req.headers.get(REQUEST_ID_HEADER));
+    (req as Tagged)[ID] = id;
+    return id;
+  }
+
+  /** The response, with this request's id on it if it was ever given one. */
+  static stamp(response: Response, req: Request): Response {
+    const id = (req as Tagged)[ID];
+    if (id !== undefined) response.headers.set(REQUEST_ID_HEADER, id);
+    return response;
+  }
+}

--- a/packages/http/src/server/request-logging.ts
+++ b/packages/http/src/server/request-logging.ts
@@ -7,9 +7,8 @@ import type { BunRequest } from 'bun';
 import type { RouteContext } from './context.js';
 import { HttpError } from './errors.js';
 import type { Middleware, Next } from './middleware.js';
+import { REQUEST_ID_HEADER, RequestIds } from './request-id.js';
 import { HttpStatusCode } from './status.js';
-
-export const REQUEST_ID_HEADER = 'x-request-id';
 
 export interface RequestLoggingOptions {
   /** Bodies past this many characters are logged as a size. Default 2048. `0` omits them. */
@@ -87,24 +86,6 @@ export interface RequestLoggingOptions {
    */
   readonly correlate?: boolean;
 }
-
-const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * An inbound id is honoured so a trace survives across services - but only if it
- * is a UUID, which is what this middleware would have minted. It is a
- * caller-supplied string that ends up in every line the request writes, so a
- * newline, a megabyte, or a deliberate collision with somebody else's trace is
- * replaced by a fresh one rather than trusted. A production template validated it the
- * same way.
- *
- * The length check first: it is what keeps garbage away from the regex, and the
- * common case has no header at all.
- */
-const traceId = (inbound: string | null): string =>
-  inbound !== null && inbound.length === 36 && UUID.test(inbound)
-    ? inbound
-    : crypto.randomUUID();
 
 const parse = (text: string, limit: number): unknown => {
   if (limit === 0) return undefined;
@@ -199,7 +180,7 @@ export class RequestLoggingMiddleware implements Middleware {
     }
 
     const started = Bun.nanoseconds();
-    const requestId = traceId(req.headers.get(REQUEST_ID_HEADER));
+    const requestId = RequestIds.assign(req);
     const scope: ScopeFields = {
       requestId,
       method: ctx.method,
@@ -285,7 +266,7 @@ export class RequestLoggingMiddleware implements Middleware {
     path: string,
     next: Next,
   ): Promise<Response> {
-    const requestId = traceId(req.headers.get(REQUEST_ID_HEADER));
+    const requestId = RequestIds.assign(req);
     const stamp = (response: Response): Response => {
       response.headers.set(REQUEST_ID_HEADER, requestId);
       return response;

--- a/packages/http/src/server/routes.ts
+++ b/packages/http/src/server/routes.ts
@@ -9,6 +9,7 @@ import { buildContext, type RouteContext } from './context.js';
 import { preflight, withCors, type CorsOptions } from './cors.js';
 import { defaultErrorMapper, HttpError, type ErrorMapper } from './errors.js';
 import { buildInputReader, type InputReader } from './input.js';
+import { RequestIds } from './request-id.js';
 import {
   compose,
   type Middleware,
@@ -207,7 +208,7 @@ export const buildFallback = (
         miss,
       )(req);
     } catch (error) {
-      return onError(error, req);
+      return RequestIds.stamp(onError(error, req), req);
     }
   };
 
@@ -335,7 +336,11 @@ export const buildRoutes = (
       try {
         return await chained(req);
       } catch (error) {
-        return onError(error, req);
+        // The mapper builds a fresh Response, so the id the logging middleware
+        // put on the one it returns is not on this one. Stamped here, where the
+        // request that carries it is still in scope; a request that was never
+        // given an id is left alone.
+        return RequestIds.stamp(onError(error, req), req);
       }
     };
 

--- a/packages/http/src/ws/adapter.ts
+++ b/packages/http/src/ws/adapter.ts
@@ -56,6 +56,11 @@ export interface WebSocketRuntime {
    * "Consuming N job(s)" entry already set.
    */
   readonly gateways: readonly GatewaySummary[];
+  /**
+   * What `HttpFactory.create` logs at boot, the way the container logs its own
+   * scope warnings. Empty for a server that reports socket errors, or says it does.
+   */
+  readonly warnings: readonly string[];
 }
 
 export interface GatewaySummary {
@@ -71,6 +76,20 @@ const defaultOnError: SocketErrorHandler = (error, socket) => {
 
 /** The failure already went through the chain, which is where it was recorded. */
 const reportedByMiddleware: SocketErrorHandler = () => undefined;
+
+/**
+ * Dropping the fallback is right for middleware that reports, and it is the
+ * middleware's word that says so. Without it the wiring reads the same either way,
+ * and an observer that ignores a throw takes a wrong report down to no report:
+ * that is how it was found, in an app that had added socket logging and then had
+ * to add a reporter after noticing failures had gone quiet.
+ */
+const unreported = (middleware: readonly SocketMiddleware[]): string =>
+  'Socket middleware is installed and none of it sets reportsErrors, so a ' +
+  'throwing gateway handler is reported nowhere: the console fallback is off ' +
+  'whenever middleware wraps the handler. Set reportsErrors on the one that ' +
+  'records a failure, or pass websocket.onError. Installed: ' +
+  `${middleware.map((entry) => entry.constructor.name).join(', ')}.`;
 
 const runtimeOf = (socket: Socket): GatewayRuntime =>
   (socket.data as Routed)[RUNTIME];
@@ -242,6 +261,9 @@ export const buildWebSocket = (
   const onError =
     options.onError ??
     (middleware.length === 0 ? defaultOnError : reportedByMiddleware);
+  const reports =
+    options.onError !== undefined ||
+    middleware.some((entry) => entry.reportsErrors === true);
   // The rest is exactly the set of keys Bun's WebSocketHandler accepts.
   const { onError: _onError, ...socketOptions } = options;
 
@@ -385,6 +407,7 @@ export const buildWebSocket = (
       gateways.map((gateway) => [gateway.path, upgradeHandler(gateway)]),
     ),
     paths: [...byPath.keys()],
+    warnings: middleware.length > 0 && !reports ? [unreported(middleware)] : [],
     gateways: gateways.map((gateway) => ({
       name: gateway.name,
       path: gateway.path,

--- a/packages/http/src/ws/error-reporting.test.ts
+++ b/packages/http/src/ws/error-reporting.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'bun:test';
+import { Module } from '@dunx/core';
+import { HttpFactory } from '../server/factory.js';
+import { buildWebSocket } from './adapter.js';
+import { Gateway, OnMessage } from './decorators.js';
+import { discoverGateway, type DiscoveredGateway } from './discover.js';
+import type {
+  SocketContext,
+  SocketFrame,
+  SocketMiddleware,
+  SocketNext,
+} from './middleware.js';
+import type { SocketErrorHandler } from './socket.js';
+
+@Gateway('/ws')
+class Chat {
+  @OnMessage('boom')
+  boom(): never {
+    throw new Error('handler exploded');
+  }
+}
+
+const discovered: readonly DiscoveredGateway[] = [discoverGateway(new Chat())];
+
+/** An observer that watches every dispatch and does nothing with a failure. */
+class Silent implements SocketMiddleware {
+  handle(_frame: SocketFrame, _ctx: SocketContext, next: SocketNext): unknown {
+    return next();
+  }
+}
+
+class Reporter implements SocketMiddleware {
+  readonly reportsErrors = true;
+
+  handle(_frame: SocketFrame, _ctx: SocketContext, next: SocketNext): unknown {
+    return next();
+  }
+}
+
+@Module({ providers: [Chat, Silent] })
+class ChatModule {}
+
+const captured = async (run: () => Promise<void>): Promise<string[]> => {
+  const lines: string[] = [];
+  const { log, error } = console;
+  const record = (...args: unknown[]): void => {
+    lines.push(...args.map(String).join(' ').split('\n'));
+  };
+  console.log = record;
+  console.error = record;
+  try {
+    await run();
+  } finally {
+    console.log = log;
+    console.error = error;
+  }
+  return lines;
+};
+
+const messageOf = (line: string): unknown =>
+  line.startsWith('{')
+    ? (JSON.parse(line) as { message?: unknown }).message
+    : undefined;
+
+const warning = (lines: readonly string[]): unknown =>
+  lines
+    .map(messageOf)
+    .find((message) => String(message).startsWith('Socket middleware is'));
+
+type Options = Parameters<typeof HttpFactory.create>[1];
+
+/** Boots, optionally serves, and gives back everything the process printed. */
+const booted = async (
+  options: Options,
+  run: (url: string) => Promise<void> = async () => undefined,
+): Promise<string[]> =>
+  captured(async () => {
+    const app = await HttpFactory.create(ChatModule, {
+      bootLogging: false,
+      ...options,
+    });
+    try {
+      await run(await app.listen(0));
+    } finally {
+      await app.shutdown();
+    }
+  });
+
+/** Sends one frame the gateway throws on, and waits for the throw to land. */
+const provoke = async (url: string): Promise<void> => {
+  const socket = new WebSocket(new URL('/ws', url).href.replace(/^http/, 'ws'));
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener('open', () => resolve(), { once: true });
+    socket.addEventListener('error', () => reject(new Error('no connect')), {
+      once: true,
+    });
+  });
+  socket.send(JSON.stringify({ event: 'boom' }));
+  await Bun.sleep(20);
+  socket.close();
+};
+
+const failures = (lines: readonly string[]): readonly string[] =>
+  lines.filter((line) => line.includes('handler failed'));
+
+/**
+ * The fallback is dropped on the assumption that a middleware reports what it
+ * saw, and nothing could check the assumption: an observer that ignores a throw
+ * takes a wrong report down to no report at all, silently.
+ */
+describe('unreported socket errors', () => {
+  it('warns when middleware exists and nothing says it reports', () => {
+    const { warnings } = buildWebSocket(discovered, {}, [new Silent()]);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('reportsErrors');
+    expect(warnings[0]).toContain('Installed: Silent.');
+  });
+
+  it('is silent when a middleware declares that it reports', () => {
+    const middleware = [new Silent(), new Reporter()];
+
+    expect(buildWebSocket(discovered, {}, middleware).warnings).toEqual([]);
+  });
+
+  it('is silent when the app passed its own onError', () => {
+    const onError: SocketErrorHandler = () => undefined;
+
+    expect(
+      buildWebSocket(discovered, { onError }, [new Silent()]).warnings,
+    ).toEqual([]);
+  });
+
+  it('is silent with no middleware at all, where the fallback is installed', () => {
+    expect(buildWebSocket(discovered, {}, []).warnings).toEqual([]);
+  });
+
+  it('reaches the logger at boot', async () => {
+    const lines = await booted({
+      socketLogging: false,
+      socketMiddleware: [Silent],
+    });
+
+    expect(warning(lines)).toContain('Installed: Silent.');
+  });
+
+  /** The default chain reports, so the default app has nothing to be told. */
+  it('does not fire for the socket logging middleware dunx installs', async () => {
+    expect(warning(await booted({}))).toBeUndefined();
+  });
+
+  /**
+   * The warning is the whole change. Which handler answers a failure is not: an
+   * app that does report would start seeing every one of them twice.
+   */
+  it('changes nothing about where a failure goes', async () => {
+    const silenced = await booted(
+      { socketLogging: false, socketMiddleware: [Silent] },
+      provoke,
+    );
+    expect(failures(silenced)).toEqual([]);
+
+    const fallback = await booted({ socketLogging: false }, provoke);
+    expect(failures(fallback)).toHaveLength(1);
+    expect(warning(fallback)).toBeUndefined();
+  });
+});

--- a/packages/http/src/ws/logging.ts
+++ b/packages/http/src/ws/logging.ts
@@ -76,6 +76,8 @@ const elapsedMs = (started: number): number =>
  * pipeline entirely, and installing this takes that fallback out of the way.
  */
 export class SocketLoggingMiddleware implements SocketMiddleware {
+  /** A throwing handler reaches the `Logger` here, at `errorLevel`. */
+  readonly reportsErrors = true;
   readonly #level: LogLevel;
   readonly #errorLevel: LogLevel;
   readonly #events: Readonly<Record<string, LogLevel | false>>;

--- a/packages/http/src/ws/middleware.ts
+++ b/packages/http/src/ws/middleware.ts
@@ -63,6 +63,21 @@ export type SocketNext = () => unknown;
  * which is an HTTP request answered by the gateway's own route.
  */
 export interface SocketMiddleware {
+  /**
+   * That a failure passing through here is reported somewhere. Default
+   * **`false`**.
+   *
+   * `SocketOptions.onError`'s `console.error` fallback is not installed while any
+   * socket middleware exists, because a middleware wraps the handler and would
+   * report the same failure a second time. Whether it does is something only the
+   * middleware knows: one that ignores a throw turns error reporting off for the
+   * whole server, and nothing about the wiring says so.
+   *
+   * Setting it is how a middleware says it does report. Leaving it unset with no
+   * `websocket.onError` beside it is what `HttpFactory.create` warns about at
+   * boot.
+   */
+  readonly reportsErrors?: boolean;
   handle(frame: SocketFrame, ctx: SocketContext, next: SocketNext): unknown;
 }
 

--- a/packages/http/src/ws/socket.ts
+++ b/packages/http/src/ws/socket.ts
@@ -50,6 +50,11 @@ export type SocketOptions = Readonly<
    * The default is **not** installed when `socketMiddleware` is non-empty: a
    * middleware wraps the handler, so it already saw the failure and a second
    * report on the console would be a duplicate.
+   *
+   * Seeing a failure and reporting it are not the same thing, so a middleware that
+   * reports says so with `SocketMiddleware.reportsErrors`. Middleware that sets it
+   * nowhere, and no `onError` here, is a boot warning: the fallback is gone and
+   * nothing replaced it.
    */
   readonly onError?: SocketErrorHandler;
 };


### PR DESCRIPTION
Five commits, all driven by a real application (firecracker) on 2.2.0.

**Merging this publishes 2.2.1.** The trigger is this pull request's *title*, not the head commit: GitHub writes the title onto the first body line of the merge commit, and `mergeSubject` reads it there. That path only started working in 2.2.0 — before it, merging a release pull request could never release, because `getReleaseTrigger` saw only `Merge pull request #n from ...`. Squash-merging works too, since the title becomes the subject. Rebase-merging would **not**, because no commit on this branch carries a `release:` subject.

## Fixes

**`x-request-id` was missing from every failure response.** The middleware mints the id and stamps responses it returns, but an error never comes back through the chain — the mapper runs in `buildRoutes`' catch and `buildFallback`'s, and builds a fresh `Response`. So a guard's 401, a validation 400, a mapped 500 and every unmatched-path 404 came back with no id at all: exactly the responses where a caller most needs one to correlate with a log line, and nothing covered it.

New `server/request-id.ts` owns the header, `traceId`, and both halves — `RequestIds.assign(req)` in the middleware, `RequestIds.stamp(response, req)` at the two catch sites. Two behaviours fall out rather than being special-cased: with `requestLogging: false`, or on an ignored path without `correlateIgnored`, nothing is minted, so those failures stay header-free; and the existing inbound-uuid rule is inherited. Threading the id through `ErrorMapper` was rejected — it would change a signature apps implement, and the ALS scope is already exited by the time the catch runs.

**A socket middleware silently disabled error reporting.** `onError` falls back to `reportedByMiddleware` — literally `() => undefined` — as soon as any middleware exists. The reasoning is sound (a middleware wraps the handler, so the console default would double-report) but the assumption is unverifiable: an app that adds a logging middleware which ignores failures goes from a wrong report to **no report at all**, silently. That happened, and cost a debugging session.

`SocketMiddleware` gains an optional `reportsErrors`; `SocketLoggingMiddleware` sets it, so the default chain never warns. When middleware exists, no `options.onError` was given, and nothing declares `reportsErrors`, `buildWebSocket` returns a warning that `HttpFactory.create` logs — mirroring how `AppFactory.create` surfaces scope warnings. **`onError` selection is unchanged**; this only makes the silent case visible.

## Docs — three claims the code does not make

- **Guide 05 said a method miss is a native 404 with no fall-through for `OPTIONS` to land in.** dunx installs the `fetch` fallback in *both* branches of `Bun.serve`, so a method miss always reaches it and runs the whole global chain. Measured: `OPTIONS` and `POST` against a GET-only route both fall through. Status is 404 either way, but request logging, throttling and CORS *do* see it. Guide 08 already had this right; the contradiction is resolved in its favour.
- **Guide 11 demonstrated the unmatched-override error with a class and asserted it throws.** It does not. A class self-binds, so an override for one replaces the binding that would have happened on demand — `Injector.registerLazy` does that deliberately. The error's own text says `and it is not a class, so nothing self-binds it either`, and the guide quoted a version with that clause removed, which is what made deliberate behaviour read as a bug. The example now uses `token()`, and the class exemption is documented as what it is: intentional, and a gap that makes a typo'd class override silent.
- `'trust proxy'` needed nothing — it is already typed `boolean | number` and the migration guide already says it counts hops.

## Also

`uptimeMs` came off `Date.now()`, so a backwards clock adjustment made it negative — caught in the wild at `-242` under WSL2. It is `performance.now()` now, which the per-check timing five lines below already used.

## Verification

From the repo root, real exit codes: `typecheck` 0 · `test` 0, 19 workspaces · `lint:check` 0 · `format:check` 0 · `bun test ./scripts` 0 · `build` 0.

Each new test was proved to fail without its fix by stashing only the source: the request-id suite drops to 6 fail / 2 pass, and the socket suite to 5 fail / 2 pass. In both cases the still-passing pair are the must-not-change guards.
