### PR TITLE
fix(infra): forRootAsync imports, the live S3 suite, and services in one job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,42 +38,9 @@ jobs:
   unit:
     name: Packages, tools and scripts
     runs-on: ubuntu-latest
-    # `@dunx/infra`'s suites gate on whether their backing service answers and skip
-    # when it does not, so CI ran neither: 49 tests skipped here against 5 on a
-    # machine with valkey up, which put `infra` at 84.6% lines against the 90.7% the
-    # floor was set from. The gate was reading a different denominator than the
-    # machine that set it.
-    #
-    # Postgres covers `db/connection.ts` and `db/sql/connection.ts`, which had no
-    # test run anywhere: `drizzle-orm/bun-sql` is a sanctioned integration and
-    # `DUNX_DB_TEST_URL` was set in no environment. Adding a live-service suite means
-    # adding its service here, or the floor measures less than it looks like.
-    env:
-      DUNX_DB_TEST_URL: postgres://dunx:dunx@localhost:5432/dunx
-    services:
-      valkey:
-        image: valkey/valkey:8-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "valkey-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-      postgres:
-        image: postgres:17-alpine
-        env:
-          POSTGRES_USER: dunx
-          POSTGRES_PASSWORD: dunx
-          POSTGRES_DB: dunx
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U dunx"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-
+    # No services here on purpose. The suites that need one skip without it, and
+    # `coverage` runs the same files with every service attached. Declaring them
+    # twice is what broke the release job: it ran the gate with none.
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -146,6 +113,14 @@ jobs:
     # adding its service here, or the floor measures less than it looks like.
     env:
       DUNX_DB_TEST_URL: postgres://dunx:dunx@localhost:5432/dunx
+      DUNX_S3_TEST_BUCKET: dunx-test
+      DUNX_S3_TEST_ENDPOINT: http://localhost:9000
+      # Read by `Bun.S3Client` for any client that sets none. `S3_ENDPOINT` is
+      # deliberately *not* set: the offline presign suite asserts on AWS hosts, and
+      # exporting that turned two of its tests into assertions about MinIO.
+      AWS_ACCESS_KEY_ID: dunxtest
+      AWS_SECRET_ACCESS_KEY: dunxtestsecret
+      AWS_REGION: us-east-1
     services:
       valkey:
         image: valkey/valkey:8-alpine
@@ -173,6 +148,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+
+      # MinIO cannot be a `services:` container: it needs `server /data` as its
+      # command and a service block has no way to pass one. `files/s3.ts` was 35.1%
+      # lines with nothing exercising `Bun.S3Client` at all; the round-trip against
+      # a real bucket takes it to 87.8%.
+      - name: Start MinIO and create the bucket
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=dunxtest -e MINIO_ROOT_PASSWORD=dunxtestsecret \
+            minio/minio server /data
+          for _ in $(seq 1 40); do
+            if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl -sf http://localhost:9000/minio/health/live >/dev/null
+          docker run --rm --network host \
+            -e MC_HOST_local=http://dunxtest:dunxtestsecret@localhost:9000 \
+            minio/mc mb --ignore-existing local/dunx-test
 
       - name: Build
         run: bun run ci build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,19 @@ contravariant and the token carries no type argument to recover.
 `RedisModule`, `FilesModule` and `DbModule` for the same reason: reading options
 off `ConfigService` is the one thing a zero-argument `forRoot` function cannot do.
 
+**Its config type is `AsyncModuleConfig`, not `FactoryProvider`, and the difference
+is `imports`.** A dynamic module is its own scope, so a factory injecting a provider
+needs the module that exports it in _that module's_ imports; importing it alongside
+does not reach the factory. `ScheduleModule` and `RedisModule` took a bare
+`FactoryProvider` and forwarded nothing, so injecting from a non-global module was a
+boot error there while working everywhere else. The documented case survived only
+because `ConfigModule.forRoot` is `global: true`.
+
+Still on the older shape, and the same gap: `HttpModule`'s client `forRootAsync`
+takes a `FactoryProvider` and forwards no `imports` at all, while `compression`,
+`health`, `static`, `throttle` and `@dunx/openapi` restate `AsyncModuleConfig`
+inline as `FactoryProvider<T, D> & { imports?: DynamicModule['imports'] }`.
+
 ## Request logging
 
 `@dunx/http` installs `RequestLoggingMiddleware` **by default**, outermost in the
@@ -573,14 +586,21 @@ then not cover it.
   or above it green, so the gate and the badge cannot disagree. The `coverage`
   phase fails naming each workspace under it and writes a per-package table into
   the GitHub job summary; `coverage/lcov.info` is uploaded as an artifact.
-- **The floor assumes the backing services are reachable**, so the `unit` and
-  `coverage` jobs run `valkey/valkey:8-alpine` and `postgres:17-alpine` and set
-  `DUNX_DB_TEST_URL`. `@dunx/infra`'s suites gate on whether their service answers
-  and skip when it does not: 49 tests skipped in CI against 5 locally put `infra` at
-  84.6% lines rather than 90.7%, which is the gate reading a different denominator
-  than the machine that set it. **A new live-service suite needs its service added
-  to those jobs**, or the floor measures less than it looks like. `files/s3.ts` at
-  35% is the remaining one, gated on a bucket nothing sets.
+- **The floor assumes the backing services are reachable, and the `coverage` job is
+  the one place that declares them**: `valkey/valkey:8-alpine`,
+  `postgres:17-alpine`, and MinIO through a `docker run` step, because a `services:`
+  block cannot pass the `server /data` command MinIO needs. `@dunx/infra`'s suites
+  gate on whether their service answers and skip when it does not, so without them
+  49 tests skip and `infra` reads 84.6% lines rather than 94.9%: the gate measuring
+  a different denominator than the machine that set it. **A new live-service suite
+  adds its service there**, and nowhere else. Declaring them on two jobs is what
+  broke the release job, which ran the gate with none of them.
+- `unit` deliberately has **no** services: those suites skip without one, and
+  `coverage` runs the same files with all of them. `unit` is the fast signal.
+- `S3_ENDPOINT` is **not** exported, even though `Bun.S3Client` reads it. The
+  offline presign suite asserts on AWS hosts, and exporting it turned two of those
+  tests into assertions about MinIO. The live block takes
+  `DUNX_S3_TEST_ENDPOINT` explicitly instead.
 - **Test scaffolding is counted as shipped code unless excluded.**
   `coverageSkipTestFiles` drops `*.test.ts` and stops there, so
   `coveragePathIgnorePatterns` also covers `**/*.fixture.ts`, `**/cli-fixture-*/**`

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -983,3 +983,20 @@ While measuring that: **`bun test` writes its report to stderr**, and a script's
 `console.log` goes to stdout. Reading the two pipes to strings and concatenating
 them put `bun run test:cov`'s coverage table 370 lines _above_ the test run that
 produced it. `scripts/ci.ts` drains both pipes into one buffer as the chunks arrive.
+
+### `Bun.S3Client` reads `S3_ENDPOINT` for every client that sets none
+
+Pointing the live `@dunx/infra/files` suite at MinIO by exporting `S3_ENDPOINT`
+broke two tests that had nothing to do with it. `S3StorageOptions` passes its
+options straight through, and anything omitted falls back to the environment, so
+the offline `presign` suite - which sets explicit fake credentials and region but
+no endpoint - started signing URLs against `localhost:9000` and failed its
+assertions on `s3.eu-west-1.amazonaws.com`.
+
+The live block takes `DUNX_S3_TEST_ENDPOINT` instead and passes it explicitly, so
+the endpoint reaches one client rather than all of them. Credentials can stay
+ambient: those tests set theirs, so `AWS_ACCESS_KEY_ID` in the environment changes
+nothing.
+
+Against MinIO the whole suite passes as written, no path-style flag needed, and
+`files/s3.ts` goes from 35.1% lines to 87.8% on one round-trip test.

--- a/packages/infra/src/files/s3.test.ts
+++ b/packages/infra/src/files/s3.test.ts
@@ -16,6 +16,13 @@ const storage = (prefix = ''): S3Storage =>
 
 /** Real credentials in the environment turn the integration block on. */
 const liveBucket = Bun.env['DUNX_S3_TEST_BUCKET'];
+/**
+ * An S3-compatible endpoint, for running the block against MinIO rather than AWS.
+ * Its own variable rather than `S3_ENDPOINT`, which `Bun.S3Client` reads for every
+ * client that does not set one: exporting that turned the offline `presign` tests
+ * below into assertions about MinIO's host, and two of them failed.
+ */
+const liveEndpoint = Bun.env['DUNX_S3_TEST_ENDPOINT'];
 
 /** See local.test.ts - bun:test's `.rejects` chain is not typed as thenable. */
 const rejection = (promise: Promise<unknown>): Promise<unknown> =>
@@ -176,7 +183,13 @@ describe.skipIf(liveBucket === undefined)(
     // out - but the fallback keeps `bucket` a plain string for the typechecker.
     const live = (): S3Storage =>
       new S3Storage(
-        new S3StorageOptions({ bucket: liveBucket ?? '' }, 'dunx-files-test'),
+        new S3StorageOptions(
+          {
+            bucket: liveBucket ?? '',
+            ...(liveEndpoint === undefined ? {} : { endpoint: liveEndpoint }),
+          },
+          'dunx-files-test',
+        ),
       );
     const key = `${crypto.randomUUID()}.txt`;
 

--- a/packages/infra/src/redis/module.test.ts
+++ b/packages/infra/src/redis/module.test.ts
@@ -1,4 +1,4 @@
-import { AppFactory, inject, Module } from '@dunx/core';
+import { AppFactory, inject, Module, provide, token } from '@dunx/core';
 import { describe, expect, it } from 'bun:test';
 import { RedisConnection } from './connection.js';
 import { RedisError, RedisErrorCode } from './errors.js';
@@ -114,6 +114,59 @@ describe('RedisModule.forRootAsync', () => {
       AppFactory.create(RedisModule.forRootAsync(() => ({ url: 'nope' }))),
     );
     expect(message).toContain('not a valid URL');
+  });
+
+  /**
+   * The scoped-container case: this dynamic module is its own scope, so a factory
+   * cannot see a provider merely because the module calling `forRootAsync` imports
+   * it. A token rather than a class, because an unbound class self-binds into
+   * whichever scope asks first and would resolve with or without the fix.
+   */
+  it('injects from a module named in its own imports', async () => {
+    const URL_TOKEN = token<string>('RedisUrl');
+
+    @Module({
+      providers: [provide(URL_TOKEN, { useValue: unreachable })],
+      exports: [URL_TOKEN],
+    })
+    class UrlModule {}
+
+    const app = await AppFactory.create(
+      RedisModule.forRootAsync({
+        imports: [UrlModule],
+        useFactory: (url: string) => ({ url }),
+        inject: [URL_TOKEN],
+      }),
+    );
+
+    expect(app.get(RedisOptions).url).toBe(unreachable);
+    await app.shutdown();
+  });
+
+  it('forwards those imports to a named connection too', async () => {
+    const URL_TOKEN = token<string>('RedisUrl');
+
+    @Module({
+      providers: [provide(URL_TOKEN, { useValue: unreachable })],
+      exports: [URL_TOKEN],
+    })
+    class UrlModule {}
+
+    const app = await AppFactory.create(
+      RedisModule.forRootAsync(
+        {
+          imports: [UrlModule],
+          useFactory: (url: string) => ({ url }),
+          inject: [URL_TOKEN],
+        },
+        'sessions',
+      ),
+    );
+
+    expect(app.get(redisConnection('sessions'))).toBeInstanceOf(
+      RedisConnection,
+    );
+    await app.shutdown();
   });
 
   it('binds a named token when given a name', async () => {

--- a/packages/infra/src/redis/module.ts
+++ b/packages/infra/src/redis/module.ts
@@ -2,7 +2,9 @@ import {
   provide,
   token,
   type Deps,
+  type ModuleRef,
   type DynamicModule,
+  type AsyncModuleConfig,
   type FactoryProvider,
   type Token,
 } from '@dunx/core';
@@ -58,6 +60,7 @@ const connectionFrom = (
 const namedModule = (
   name: string,
   options: RedisOptions | FactoryProvider<RedisOptions, Deps>,
+  imports: readonly ModuleRef[] = [],
 ): DynamicModule => {
   const optionsToken = token<RedisOptions>(`RedisOptions(${name})`);
   // Branch on the call, not the argument: a union of provider shapes matches
@@ -69,6 +72,7 @@ const namedModule = (
 
   return {
     module: RedisModule,
+    imports,
     exports: [optionsToken, redisConnection(name)],
     providers: [
       optionsProvider,
@@ -118,25 +122,32 @@ export class RedisModule {
     name?: string,
   ): DynamicModule;
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<RedisOptionsInit, D>,
+    config: AsyncModuleConfig<RedisOptionsInit, D>,
     name?: string,
   ): DynamicModule;
   static forRootAsync(
     source:
       | (() => RedisOptionsInit | Promise<RedisOptionsInit>)
-      | FactoryProvider<RedisOptionsInit, Deps>,
+      | AsyncModuleConfig<RedisOptionsInit, Deps>,
     name?: string,
   ): DynamicModule {
     const load = typeof source === 'function' ? source : source.useFactory;
     const inject = typeof source === 'function' ? [] : (source.inject ?? []);
+    // The container is scoped: this dynamic module is its own scope, so a factory
+    // injecting a provider needs the module that exports it in *these* imports.
+    // Importing it into whatever module calls forRootAsync does not reach here.
+    const imports = typeof source === 'function' ? [] : (source.imports ?? []);
     const useFactory = async (
       ...deps: readonly unknown[]
     ): Promise<RedisOptions> => new RedisOptions(await load(...deps));
 
-    if (name !== undefined) return namedModule(name, { useFactory, inject });
+    if (name !== undefined) {
+      return namedModule(name, { useFactory, inject }, imports);
+    }
 
     return {
       module: RedisModule,
+      imports,
       exports: [RedisOptions, RedisConnection],
       providers: [
         provide(RedisOptions, { useFactory, inject }),

--- a/packages/infra/src/schedule/module.test.ts
+++ b/packages/infra/src/schedule/module.test.ts
@@ -1,0 +1,120 @@
+import { AppFactory, Logger, Module, provide, token } from '@dunx/core';
+import { describe, expect, it } from 'bun:test';
+import { ScheduleModule } from './module.js';
+import { ScheduleOptions } from './options.js';
+import { Quiet } from './quiet.fixture.js';
+import { ScheduleRegistry } from './registry.js';
+
+describe('ScheduleModule.forRootAsync', () => {
+  it('injects what it names from a global provider', async () => {
+    class Settings {
+      readonly tz = 'Europe/Sofia';
+    }
+
+    @Module({
+      imports: [
+        ScheduleModule.forRootAsync({
+          useFactory: (settings: Settings) => ({
+            tz: settings.tz,
+            keepAlive: false,
+            enabled: false,
+          }),
+          inject: [Settings],
+        }),
+      ],
+      providers: [Settings, provide(Logger, { useValue: new Quiet() })],
+      exports: [Logger, Settings],
+      global: true,
+    })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+
+    expect(app.get(ScheduleOptions).tz).toBe('Europe/Sofia');
+    expect(app.get(ScheduleOptions).enabled).toBe(false);
+    expect(app.get(ScheduleRegistry)).toBeInstanceOf(ScheduleRegistry);
+    await app.shutdown();
+  });
+
+  it('takes a bare loader and awaits it', async () => {
+    @Module({
+      imports: [
+        ScheduleModule.forRootAsync(async () => {
+          await Bun.sleep(1);
+          return { keepAlive: false, enabled: false, tz: 'UTC' };
+        }),
+      ],
+      providers: [provide(Logger, { useValue: new Quiet() })],
+      exports: [Logger],
+      global: true,
+    })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+
+    expect(app.get(ScheduleOptions).tz).toBe('UTC');
+    expect(app.get(ScheduleOptions).keepAlive).toBe(false);
+    await app.shutdown();
+  });
+
+  /**
+   * The scoped-container case: this dynamic module is its own scope, so the factory
+   * cannot see a provider merely because the module that called `forRootAsync`
+   * imports it. `imports` here is what puts it in reach, and without it this is a
+   * boot error naming both modules.
+   */
+  it('injects from a module named in its own imports, not published globally', async () => {
+    // A token, not a class: an unbound class self-binds into whichever scope asks
+    // first, so a class here resolves whether or not `imports` reached the factory
+    // and the test would pass against the bug it is guarding.
+    const ZONE = token<string>('Zone');
+
+    @Module({
+      providers: [provide(ZONE, { useValue: 'Australia/Perth' })],
+      exports: [ZONE],
+    })
+    class TzModule {}
+
+    @Module({
+      imports: [
+        ScheduleModule.forRootAsync({
+          imports: [TzModule],
+          useFactory: (zone: string) => ({
+            tz: zone,
+            keepAlive: false,
+            enabled: false,
+          }),
+          inject: [ZONE],
+        }),
+      ],
+      providers: [provide(Logger, { useValue: new Quiet() })],
+      exports: [Logger],
+      global: true,
+    })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+
+    expect(app.get(ScheduleOptions).tz).toBe('Australia/Perth');
+    await app.shutdown();
+  });
+
+  it('defaults inject away when the config omits it', async () => {
+    @Module({
+      imports: [
+        ScheduleModule.forRootAsync({
+          useFactory: () => ({ keepAlive: false, enabled: false }),
+        }),
+      ],
+      providers: [provide(Logger, { useValue: new Quiet() })],
+      exports: [Logger],
+      global: true,
+    })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+
+    expect(app.get(ScheduleOptions).enabled).toBe(false);
+    await app.shutdown();
+  });
+});

--- a/packages/infra/src/schedule/module.ts
+++ b/packages/infra/src/schedule/module.ts
@@ -4,7 +4,7 @@ import {
   provide,
   type Deps,
   type DynamicModule,
-  type FactoryProvider,
+  type AsyncModuleConfig,
   type Registration,
 } from '@dunx/core';
 import { ScheduleOptions, type ScheduleOptionsInit } from './options.js';
@@ -67,18 +67,23 @@ export class ScheduleModule {
     load: () => ScheduleOptionsInit | Promise<ScheduleOptionsInit>,
   ): DynamicModule;
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<ScheduleOptionsInit, D>,
+    config: AsyncModuleConfig<ScheduleOptionsInit, D>,
   ): DynamicModule;
   static forRootAsync(
     source:
       | (() => ScheduleOptionsInit | Promise<ScheduleOptionsInit>)
-      | FactoryProvider<ScheduleOptionsInit, Deps>,
+      | AsyncModuleConfig<ScheduleOptionsInit, Deps>,
   ): DynamicModule {
     const load = typeof source === 'function' ? source : source.useFactory;
     const inject = typeof source === 'function' ? [] : (source.inject ?? []);
+    // The container is scoped: this dynamic module is its own scope, so a factory
+    // injecting a provider needs the module that exports it in *these* imports.
+    // Importing it into whatever module calls forRootAsync does not reach here.
+    const imports = typeof source === 'function' ? [] : (source.imports ?? []);
 
     return {
       module: ScheduleModule,
+      imports,
       exports: [ScheduleOptions, ScheduleRegistry],
       providers: providers(
         provide(ScheduleOptions, {

--- a/packages/infra/src/schedule/quiet.fixture.ts
+++ b/packages/infra/src/schedule/quiet.fixture.ts
@@ -1,0 +1,31 @@
+import { Logger, LogLevel } from '@dunx/core';
+
+/** Silent, so a suite asserting on schedules is not read through boot noise. */
+export class Quiet extends Logger {
+  readonly logLevel = LogLevel.DEBUG;
+  readonly lines: string[] = [];
+  readonly warnings: string[] = [];
+  readonly errors: string[] = [];
+
+  override info(message: unknown): void {
+    this.lines.push(String(message));
+  }
+  override log(message: unknown): void {
+    this.lines.push(String(message));
+  }
+  override debug(message: unknown): void {
+    this.lines.push(String(message));
+  }
+  override verbose(message: unknown): void {
+    this.lines.push(String(message));
+  }
+  override warn(message: unknown): void {
+    this.warnings.push(String(message));
+  }
+  override error(message: unknown): void {
+    this.errors.push(String(message));
+  }
+  override fatal(message: unknown): void {
+    this.errors.push(String(message));
+  }
+}

--- a/packages/infra/src/schedule/schedule.test.ts
+++ b/packages/infra/src/schedule/schedule.test.ts
@@ -1,43 +1,14 @@
 import { describe, expect, it } from 'bun:test';
-import { AppFactory, Logger, LogLevel, Module, provide } from '@dunx/core';
+import { AppFactory, Logger, Module, provide } from '@dunx/core';
 
 import { supportsTz } from './capability.js';
+import { Quiet } from './quiet.fixture.js';
 import { Cron, Interval, OnceOnBoot } from './decorators.js';
 import { ScheduleErrorCode } from './errors.js';
 import { CronExpression, Overlap, ScheduleKind } from './marker.js';
 import { ScheduleModule } from './module.js';
 import { ScheduleOptions } from './options.js';
 import { ScheduleRegistry } from './registry.js';
-
-/** Silent, so a suite asserting on schedules is not read through boot noise. */
-class Quiet extends Logger {
-  readonly logLevel = LogLevel.DEBUG;
-  readonly lines: string[] = [];
-  readonly warnings: string[] = [];
-  readonly errors: string[] = [];
-
-  override info(message: unknown): void {
-    this.lines.push(String(message));
-  }
-  override log(message: unknown): void {
-    this.lines.push(String(message));
-  }
-  override debug(message: unknown): void {
-    this.lines.push(String(message));
-  }
-  override verbose(message: unknown): void {
-    this.lines.push(String(message));
-  }
-  override warn(message: unknown): void {
-    this.warnings.push(String(message));
-  }
-  override error(message: unknown): void {
-    this.errors.push(String(message));
-  }
-  override fatal(message: unknown): void {
-    this.errors.push(String(message));
-  }
-}
 
 class Reports {
   ran: string[] = [];
@@ -394,80 +365,3 @@ describe('zones, on a Bun that honours tz', () => {
  * `inject`: reading `tz` or `enabled` off a `ConfigService` is the one thing a
  * zero-argument `forRoot` cannot do.
  */
-describe('ScheduleModule.forRootAsync', () => {
-  /**
-   * From a globally published provider, which is what the API allows: this
-   * `forRootAsync` takes a `FactoryProvider`, not an `AsyncModuleConfig`, so it has
-   * no `imports` to forward. The documented case works because
-   * `ConfigModule.forRoot` is `global: true`.
-   */
-  it('injects what it names', async () => {
-    class Settings {
-      readonly tz = 'Europe/Sofia';
-    }
-
-    @Module({
-      imports: [
-        ScheduleModule.forRootAsync({
-          useFactory: (settings: Settings) => ({
-            tz: settings.tz,
-            keepAlive: false,
-            enabled: false,
-          }),
-          inject: [Settings],
-        }),
-      ],
-      providers: [Settings, provide(Logger, { useValue: new Quiet() })],
-      exports: [Logger, Settings],
-      global: true,
-    })
-    class Root {}
-
-    const app = await AppFactory.create(Root);
-
-    expect(app.get(ScheduleOptions).tz).toBe('Europe/Sofia');
-    expect(app.get(ScheduleOptions).enabled).toBe(false);
-    expect(app.get(ScheduleRegistry)).toBeInstanceOf(ScheduleRegistry);
-    await app.shutdown();
-  });
-
-  it('takes a bare loader and awaits it', async () => {
-    @Module({
-      imports: [
-        ScheduleModule.forRootAsync(async () => {
-          await Bun.sleep(1);
-          return { keepAlive: false, enabled: false, tz: 'UTC' };
-        }),
-      ],
-      providers: [provide(Logger, { useValue: new Quiet() })],
-      exports: [Logger],
-      global: true,
-    })
-    class Root {}
-
-    const app = await AppFactory.create(Root);
-
-    expect(app.get(ScheduleOptions).tz).toBe('UTC');
-    expect(app.get(ScheduleOptions).keepAlive).toBe(false);
-    await app.shutdown();
-  });
-
-  it('defaults inject away when the config omits it', async () => {
-    @Module({
-      imports: [
-        ScheduleModule.forRootAsync({
-          useFactory: () => ({ keepAlive: false, enabled: false }),
-        }),
-      ],
-      providers: [provide(Logger, { useValue: new Quiet() })],
-      exports: [Logger],
-      global: true,
-    })
-    class Root {}
-
-    const app = await AppFactory.create(Root);
-
-    expect(app.get(ScheduleOptions).enabled).toBe(false);
-    await app.shutdown();
-  });
-});


### PR DESCRIPTION
The two follow-ups from #5, plus the root cause of the release failure that came
out of the first one.

## `forRootAsync` could not take `imports` on two modules

Seven of the nine configured modules take an `AsyncModuleConfig`. `ScheduleModule`
and `RedisModule` took a bare `FactoryProvider` and forwarded nothing, so a factory
injecting a provider from a **non-global** module was a boot error there while
working everywhere else. The documented case survived only because
`ConfigModule.forRoot` is `global: true`.

`AsyncModuleConfig`'s own doc comment says exactly why it exists: a dynamic module
is its own scope, so the module exporting the token has to be in *that* module's
imports; importing it alongside does not reach the factory. `RedisModule` forwards
them to a named connection too.

**The first version of the test passed against the bug.** An unbound class
self-binds into whichever scope asks first, so a plain `class Tz {}` resolved with
or without the fix. Both tests use a `token()` instead, and each was checked to fail
with the forwarding removed:

```
AppError: Cannot resolve Zone in module "ScheduleModule". Nothing in the module
graph declares it.
```

## The S3 suite now runs, against MinIO

`files/s3.ts` was **35.1% lines** with nothing exercising `Bun.S3Client` anywhere:
`DUNX_S3_TEST_BUCKET` was set in no environment. One round-trip against a real
bucket takes it to **87.8%**, and `@dunx/infra` from 92.6% to **94.9% lines**.

MinIO is a `docker run` step rather than a `services:` container, because it needs
`server /data` as its command and a service block cannot pass one.

The live block takes `DUNX_S3_TEST_ENDPOINT` explicitly rather than exporting
`S3_ENDPOINT`. `Bun.S3Client` reads that for **every** client that sets none, so
exporting it made the offline presign suite sign URLs against localhost and fail two
assertions about `s3.eu-west-1.amazonaws.com`. Verified against MinIO locally before
touching CI, the same way Postgres was.

## Services are declared in one job now

This is the root cause of the release failure on main, not just its symptom. `unit`
had valkey and postgres for no benefit: those suites skip without a service, and
`coverage` runs the same files with every one attached. Declaring them on two jobs
is what left the release job running the gate with none of them, reading `infra` at
85.8% and failing a release with nothing wrong with it.

`coverage` is the one place that declares a service. One place to add the next one.

## Coverage

| package | lines | functions | margin |
| --- | --- | --- | --- |
| mcp | 92.2% | 96.4% | +2.2 |
| core | 94.7% | 91.0% | **+1.0** |
| infra | 94.9% | 93.8% | +3.8 |
| dashboard | 95.8% | 100% | +5.8 |
| http | 96.6% | 94.6% | +4.6 |
| openapi | 97.6% | 96.0% | +6.0 |
| total | **96.1%** | **94.6%** | |

`core` at +1.0 on functions is now the thinnest, and it is structural rather than a
testing gap: abstract member signatures count as unhit functions and no test can
reach them, which is most of the distance between its 94.7% lines and 91.0%
functions. Worth knowing before anyone raises the floor past 90.

## Left alone deliberately

**The same gap exists in `@dunx/http` and `@dunx/openapi`, in two flavours.**
`compression`, `health`, `static`, `throttle` and `@dunx/openapi` restate
`AsyncModuleConfig` inline as
`FactoryProvider<T, D> & { imports?: DynamicModule['imports'] }`, which is a Rule 2
duplication of a type that already exists. And **`HttpModule`'s client
`forRootAsync` takes a bare `FactoryProvider` and forwards no `imports` at all** -
the identical bug to the two fixed here. Six files, no behaviour change for the five
that already work; worth its own change rather than widening this one.

**No `examples/full` update.** The capability is an option becoming available where
it was not, and nothing in that app is a non-global provider a schedule or cache
factory would naturally want, so demonstrating it would mean adding a module that
exists only to be imported. Covered end to end against a real container in the
tests instead. Per Rule 4's "or say in the review why it is not worth a line".
