### PR TITLE
fix(http,openapi): forRootAsync imports, and one AsyncModuleConfig everywhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,18 +421,31 @@ contravariant and the token carries no type argument to recover.
 `RedisModule`, `FilesModule` and `DbModule` for the same reason: reading options
 off `ConfigService` is the one thing a zero-argument `forRoot` function cannot do.
 
-**Its config type is `AsyncModuleConfig`, not `FactoryProvider`, and the difference
-is `imports`.** A dynamic module is its own scope, so a factory injecting a provider
-needs the module that exports it in _that module's_ imports; importing it alongside
-does not reach the factory. `ScheduleModule` and `RedisModule` took a bare
-`FactoryProvider` and forwarded nothing, so injecting from a non-global module was a
-boot error there while working everywhere else. The documented case survived only
-because `ConfigModule.forRoot` is `global: true`.
+**Every `forRootAsync` takes an `AsyncModuleConfig`, never a bare
+`FactoryProvider`, and the difference is `imports`.** A dynamic module is its own
+scope, so a factory injecting a provider needs the module that exports it in _that
+module's_ imports; importing it alongside does not reach the factory.
+`FactoryProvider` is the shape `provide()` takes, not the shape a module factory
+takes: reaching for it in a `forRootAsync` signature is the mistake.
 
-Still on the older shape, and the same gap: `HttpModule`'s client `forRootAsync`
-takes a `FactoryProvider` and forwards no `imports` at all, while `compression`,
-`health`, `static`, `throttle` and `@dunx/openapi` restate `AsyncModuleConfig`
-inline as `FactoryProvider<T, D> & { imports?: DynamicModule['imports'] }`.
+Nine modules got this wrong in two ways. `ScheduleModule`, `RedisModule` and
+`HttpModule`'s client took a bare `FactoryProvider` and forwarded nothing, so
+injecting from a non-global module was a boot error there while working elsewhere;
+the documented cases survived only because `ConfigModule.forRoot` is `global: true`.
+`compression`, `health`, `static`, `throttle` and `@dunx/openapi` restated
+`AsyncModuleConfig` inline as
+`FactoryProvider<T, D> & { imports?: DynamicModule['imports'] }`, which is Rule 2 on
+a type that already existed. All of them are uniform now.
+
+`@dunx/openapi` is the one with an extra term: it wraps the app root, so it forwards
+`[options.root, ...(options.imports ?? [])]`.
+
+Two things to know when testing this. A **`token()`** is required, not a class: an
+unbound class self-binds into whichever scope asks first, so a class resolves
+whether or not `imports` reached the factory and the test passes against the bug it
+guards. And the forwarding is one line per module, so
+`packages/http/src/async-imports.test.ts` asserts it structurally for the modules
+whose resolution is covered elsewhere.
 
 ## Request logging
 

--- a/packages/http/src/async-imports.test.ts
+++ b/packages/http/src/async-imports.test.ts
@@ -1,0 +1,73 @@
+import { Module } from '@dunx/core';
+import { describe, expect, it } from 'bun:test';
+import { CompressionModule } from './compression/module.js';
+import { HealthModule } from './health/module.js';
+import { StaticModule } from './static/module.js';
+import { ThrottleModule } from './throttle/module.js';
+
+/**
+ * Every `forRootAsync` puts its caller's `imports` on the module it returns.
+ *
+ * A dynamic module is its own scope, so a factory injecting a provider needs the
+ * module that exports it right there; importing it alongside does not reach the
+ * factory. `AsyncModuleConfig` is what declares that field, and these four used to
+ * restate it inline as `FactoryProvider<T, D> & { imports?: ... }`.
+ *
+ * Structural on purpose. The forwarding is one line per module and nothing else
+ * asserted it, so deleting it would have gone unnoticed; the resolution itself is
+ * covered where it can fail for a second reason, in `client/module.test.ts` and
+ * `@dunx/openapi`'s `module.test.ts`.
+ */
+@Module({})
+class Marker {}
+
+const CONFIGURED = [
+  [
+    'CompressionModule',
+    () =>
+      CompressionModule.forRootAsync({
+        imports: [Marker],
+        useFactory: () => ({ threshold: 1 }),
+      }),
+  ],
+  [
+    'HealthModule',
+    () =>
+      HealthModule.forRootAsync({
+        imports: [Marker],
+        useFactory: () => ({ timeoutMs: 1 }),
+      }),
+  ],
+  [
+    'StaticModule',
+    () =>
+      StaticModule.forRootAsync({
+        imports: [Marker],
+        useFactory: () => ({ root: '.' }),
+      }),
+  ],
+  [
+    'ThrottleModule',
+    () =>
+      ThrottleModule.forRootAsync({
+        imports: [Marker],
+        useFactory: () => ({ limit: 1, windowSeconds: 1, prefix: 't' }),
+      }),
+  ],
+] as const;
+
+describe('forRootAsync forwards the imports it was given', () => {
+  for (const [name, build] of CONFIGURED) {
+    it(`${name} puts them on the module it returns`, () => {
+      expect(build().imports).toContain(Marker);
+    });
+  }
+
+  it('leaves imports off entirely when the caller passed none', () => {
+    const module = CompressionModule.forRootAsync({
+      useFactory: () => ({ threshold: 1 }),
+    });
+
+    expect(module.imports ?? []).toEqual([]);
+  });
+});

--- a/packages/http/src/client/module.test.ts
+++ b/packages/http/src/client/module.test.ts
@@ -5,6 +5,8 @@ import {
   ConfigService,
   inject,
   Module,
+  provide,
+  token,
 } from '@dunx/core';
 import { HttpClientOptions } from './options.js';
 import { httpClient, HttpModule } from './module.js';
@@ -108,6 +110,80 @@ describe('HttpModule.forRootAsync', () => {
     expect(app.get(HttpClientOptions).timeoutMs).toBe(1234);
     expect(await app.get(HttpService).get<Path>('/from-config')).toEqual({
       path: '/from-config',
+    });
+    await app.shutdown();
+  });
+
+  /**
+   * The scoped-container case: this dynamic module is its own scope, so a factory
+   * cannot see a provider merely because the module calling `forRootAsync` imports
+   * it. `imports` here is what puts it in reach.
+   *
+   * A `token()` rather than a class: an unbound class self-binds into whichever
+   * scope asks first, so a class resolves whether or not `imports` reached the
+   * factory, and the test would pass against the bug it guards.
+   */
+  it('injects from a module named in its own imports', async () => {
+    const BASE = token<string>('UpstreamBase');
+
+    @Module({
+      providers: [provide(BASE, { useValue: base })],
+      exports: [BASE],
+    })
+    class UpstreamModule {}
+
+    @Module({
+      imports: [
+        HttpModule.forRootAsync({
+          imports: [UpstreamModule],
+          useFactory: (baseUrl: string) => ({ baseUrl, timeoutMs: 555 }),
+          inject: [BASE],
+        }),
+      ],
+    })
+    class AppModule {}
+
+    const app = await AppFactory.create(AppModule);
+
+    expect(app.get(HttpClientOptions).timeoutMs).toBe(555);
+    expect(await app.get(HttpService).get<Path>('/scoped')).toEqual({
+      path: '/scoped',
+    });
+    await app.shutdown();
+  });
+
+  it('forwards those imports to a named client too', async () => {
+    const BASE = token<string>('UpstreamBase');
+
+    @Module({
+      providers: [provide(BASE, { useValue: base })],
+      exports: [BASE],
+    })
+    class UpstreamModule {}
+
+    class Caller {
+      readonly billing = inject(httpClient('billing'));
+    }
+
+    @Module({
+      imports: [
+        HttpModule.forRootAsync(
+          {
+            imports: [UpstreamModule],
+            useFactory: (baseUrl: string) => ({ baseUrl, timeoutMs: 666 }),
+            inject: [BASE],
+          },
+          'billing',
+        ),
+      ],
+      providers: [Caller],
+    })
+    class AppModule {}
+
+    const app = await AppFactory.create(AppModule);
+
+    expect(await app.get(Caller).billing.get<Path>('/billing')).toEqual({
+      path: '/billing',
     });
     await app.shutdown();
   });

--- a/packages/http/src/client/module.ts
+++ b/packages/http/src/client/module.ts
@@ -4,7 +4,9 @@ import {
   RequestContext,
   token,
   type Deps,
+  type ModuleRef,
   type DynamicModule,
+  type AsyncModuleConfig,
   type FactoryProvider,
   type Token,
 } from '@dunx/core';
@@ -57,6 +59,7 @@ const serviceFrom = (
 const namedModule = (
   name: string,
   options: HttpClientOptions | FactoryProvider<HttpClientOptions, Deps>,
+  imports: readonly ModuleRef[] = [],
 ): DynamicModule => {
   const optionsToken = token<HttpClientOptions>(`HttpClientOptions(${name})`);
   const optionsProvider =
@@ -66,6 +69,7 @@ const namedModule = (
 
   return {
     module: HttpModule,
+    imports,
     exports: [optionsToken, httpClient(name)],
     providers: [optionsProvider, serviceFrom(httpClient(name), optionsToken)],
   };
@@ -127,30 +131,36 @@ export class HttpModule {
     name?: string,
   ): DynamicModule;
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<HttpClientOptionsInit, D>,
+    config: AsyncModuleConfig<HttpClientOptionsInit, D>,
     name?: string,
   ): DynamicModule;
   static forRootAsync(
     source:
       | (() => HttpClientOptionsInit | Promise<HttpClientOptionsInit>)
-      | FactoryProvider<HttpClientOptionsInit, Deps>,
+      | AsyncModuleConfig<HttpClientOptionsInit, Deps>,
     name?: string,
   ): DynamicModule {
     const load = typeof source === 'function' ? source : source.useFactory;
     const inject = typeof source === 'function' ? [] : (source.inject ?? []);
+    // The container is scoped: this dynamic module is its own scope, so a factory
+    // injecting a provider needs the module that exports it in *these* imports.
+    // Importing it into whatever module calls forRootAsync does not reach here.
+    const imports = typeof source === 'function' ? [] : (source.imports ?? []);
     const useFactory = async (
       ...deps: readonly unknown[]
     ): Promise<HttpClientOptions> => new HttpClientOptions(await load(...deps));
 
     if (name !== undefined) {
-      return namedModule(name, { useFactory, inject } as FactoryProvider<
-        HttpClientOptions,
-        Deps
-      >);
+      return namedModule(
+        name,
+        { useFactory, inject } as FactoryProvider<HttpClientOptions, Deps>,
+        imports,
+      );
     }
 
     return {
       module: HttpModule,
+      imports,
       exports: [HttpClientOptions, HttpService],
       providers: [
         provide(HttpClientOptions, { useFactory, inject } as FactoryProvider<

--- a/packages/http/src/compression/module.ts
+++ b/packages/http/src/compression/module.ts
@@ -3,7 +3,7 @@ import {
   provide,
   type Deps,
   type DynamicModule,
-  type FactoryProvider,
+  type AsyncModuleConfig,
   type Registration,
 } from '@dunx/core';
 import { Compression } from './compression.js';
@@ -41,9 +41,7 @@ export class CompressionModule {
 
   /** `forRoot` with the options read off the container - a config value, usually. */
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<CompressionOptionsInit, D> & {
-      readonly imports?: DynamicModule['imports'];
-    },
+    config: AsyncModuleConfig<CompressionOptionsInit, D>,
   ): DynamicModule {
     return {
       module: CompressionModule,

--- a/packages/http/src/health/module.ts
+++ b/packages/http/src/health/module.ts
@@ -3,7 +3,7 @@ import {
   provide,
   type Deps,
   type DynamicModule,
-  type FactoryProvider,
+  type AsyncModuleConfig,
   type ProviderEntry,
 } from '@dunx/core';
 import { HealthController, HiddenHealthController } from './controller.js';
@@ -86,8 +86,7 @@ export class HealthModule {
    * wait on a factory. Pass `routes: false` and mount your own if that matters.
    */
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<HealthOptionsInit, D> & {
-      readonly imports?: DynamicModule['imports'];
+    config: AsyncModuleConfig<HealthOptionsInit, D> & {
       readonly routes?: boolean;
       readonly documented?: boolean;
     },

--- a/packages/http/src/static/module.ts
+++ b/packages/http/src/static/module.ts
@@ -3,7 +3,7 @@ import {
   provide,
   type Deps,
   type DynamicModule,
-  type FactoryProvider,
+  type AsyncModuleConfig,
   type Registration,
 } from '@dunx/core';
 import { StaticFiles } from './files.js';
@@ -73,9 +73,7 @@ export class StaticModule {
 
   /** `forRoot` with the root read off the container - a config value, usually. */
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<StaticOptionsInit, D> & {
-      readonly imports?: DynamicModule['imports'];
-    },
+    config: AsyncModuleConfig<StaticOptionsInit, D>,
   ): DynamicModule {
     return {
       module: StaticModule,

--- a/packages/http/src/throttle/module.ts
+++ b/packages/http/src/throttle/module.ts
@@ -4,7 +4,7 @@ import {
   provide,
   type Deps,
   type DynamicModule,
-  type FactoryProvider,
+  type AsyncModuleConfig,
   type Registration,
 } from '@dunx/core';
 import { ClientAddress } from '../server/client-address.js';
@@ -84,9 +84,7 @@ export class ThrottleModule {
 
   /** `forRoot` with the limit read off the container - a config value, usually. */
   static forRootAsync<const D extends Deps>(
-    config: FactoryProvider<ThrottleOptionsInit, D> & {
-      readonly imports?: DynamicModule['imports'];
-    },
+    config: AsyncModuleConfig<ThrottleOptionsInit, D>,
   ): DynamicModule {
     return {
       module: ThrottleModule,

--- a/packages/openapi/src/module.test.ts
+++ b/packages/openapi/src/module.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { Module } from '@dunx/core';
+import { Module, provide, token } from '@dunx/core';
 import {
   Controller,
   Get,
@@ -236,6 +236,48 @@ describe('forRootAsync', () => {
         inject: [DocsConfig] as const,
       }),
     });
+
+  /**
+   * `imports: [options.root]` covers a provider the root exports, which is what the
+   * test below uses. It does not cover one the root never sees: this module is its
+   * own scope, so the caller's own `imports` are what put that in reach.
+   *
+   * A `token()` rather than a class: an unbound class self-binds into whichever
+   * scope asks first, so a class resolves whether or not `imports` reached the
+   * factory, and the test would pass against the bug it guards.
+   */
+  it('injects from a module named in its own imports, not only from the root', async () => {
+    const TITLE = token<string>('DocTitle');
+
+    @Module({
+      providers: [provide(TITLE, { useValue: 'From Imports' })],
+      exports: [TITLE],
+    })
+    class TitleModule {}
+
+    @Module({ imports: [ThingsModule] })
+    class PlainRoot {}
+
+    const server = await createTestServer({
+      modules: OpenApiModule.forRootAsync({
+        root: PlainRoot,
+        imports: [TitleModule],
+        useFactory: (title: string) => ({ title, version: '2.0.0' }),
+        inject: [TITLE],
+      }),
+    });
+
+    try {
+      const { status, body: document } =
+        await server.json<OpenApiDocument>('openapi.json');
+
+      expect(status).toBe(200);
+      expect(document.info.title).toBe('From Imports');
+      expect(document.info.version).toBe('2.0.0');
+    } finally {
+      await server.close();
+    }
+  });
 
   it('takes info off a provider, and mounts where that provider says', async () => {
     const server = await startAsync();

--- a/packages/openapi/src/module.ts
+++ b/packages/openapi/src/module.ts
@@ -3,7 +3,7 @@ import {
   provide,
   type Deps,
   type DynamicModule,
-  type FactoryProvider,
+  type AsyncModuleConfig,
   type ModuleRef,
 } from '@dunx/core';
 import {
@@ -60,7 +60,7 @@ export interface OpenApiOptions extends OpenApiInfo {
  * module reference - the graph has to exist before the container that would run
  * the factory does.
  */
-export interface OpenApiAsyncOptions<D extends Deps> extends FactoryProvider<
+export interface OpenApiAsyncOptions<D extends Deps> extends AsyncModuleConfig<
   OpenApiInfo,
   D
 > {
@@ -314,7 +314,10 @@ export class OpenApiModule {
 
     const configured: DynamicModule = {
       module: OpenApiModule,
-      imports: [options.root],
+      // The root this module wraps, plus whatever the caller's factory needs:
+      // this module is its own scope, so a provider the root merely imports is
+      // not in reach of the factory unless the root exports it.
+      imports: [options.root, ...(options.imports ?? [])],
       // The generated document, so an app can read `warnings` or serve the JSON
       // itself. This module wraps the app's root rather than being imported by it,
       // so the export is what makes `app.get(OpenApiExplorer)` resolve.


### PR DESCRIPTION
The rest of the `forRootAsync` inconsistency flagged in #6. After this, every
configured module in the repo takes an `AsyncModuleConfig` and forwards `imports`.

## Two real bugs

`HttpModule`'s client and `@dunx/openapi` had the same bug as `ScheduleModule` and
`RedisModule`: a bare `FactoryProvider` and no `imports` forwarded, so a factory
injecting a provider from a **non-global** module was a boot error while the
equivalent worked in seven other modules. The documented cases survived only because
`ConfigModule.forRoot` is `global: true`.

The client forwards them to a named client too, the way `RedisModule` does for a
named connection.

`@dunx/openapi` is the interesting one. It already had `imports: [options.root]`,
because that module **wraps** the app root rather than being imported by it. That
covers a provider the root *exports* and nothing else, so the caller's own imports
go alongside: `[options.root, ...(options.imports ?? [])]`.

Both new tests use a `token()` rather than a class, and each was checked to fail
with the forwarding removed:

```
AppError: Cannot resolve DocTitle in module "OpenApiModule". Nothing in the module
graph declares it.
```

A class would have caught nothing. An unbound class self-binds into whichever scope
asks first, so it resolves whether or not `imports` reached the factory — which is
exactly how the first version of the `ScheduleModule` test in #6 passed against the
bug it was written for.

## Four restatements of a type that already existed

`compression`, `health`, `static` and `throttle` each declared

```ts
FactoryProvider<T, D> & { imports?: DynamicModule['imports'] }
```

which is `AsyncModuleConfig<T, D>` spelled out four times. Same type:
`AsyncModuleConfig`'s `imports` is `readonly ModuleRef[]`, and
`DynamicModule['imports']` resolves to the same through `ModuleOptions`. `health`
keeps an intersection for the two fields that genuinely are its own, `routes` and
`documented`.

**No behaviour change** — all four already forwarded what they were given. But
nothing asserted it and it is one line each, so
`packages/http/src/async-imports.test.ts` now checks the returned module carries
them. Verified by deleting the forwarding from `throttle` and watching it fail.

That leaves `FactoryProvider` meaning one thing again: the shape `provide()` takes,
not the shape a module factory takes. Reaching for it in a `forRootAsync` signature
is the mistake, and CLAUDE.md now says so.

## Review notes

- Coverage unchanged at 96.1% lines / 94.6% functions; `bun run ci` 12/12 locally.
- **No `examples/full` update**, same reasoning as #6 under Rule 4's "or say in the
  review why it is not worth a line": the capability is an option becoming available
  where it was not, and nothing in that app is a non-global provider one of these
  factories would naturally want. Demonstrating it would mean adding a module that
  exists only to be imported. Covered end to end against a real container instead.
- `packages/http/src/async-imports.test.ts` is deliberately structural. The
  resolution path is covered where it can fail for a second reason, in
  `client/module.test.ts` and `@dunx/openapi`'s `module.test.ts`; this file guards
  the one line those four modules each have.
