### PR TITLE
feat(docs): motion for the documentation site, and drop the screenshot artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,23 +80,11 @@ jobs:
       # No browser download step: `Bun.WebView` drives the Chrome the runner image
       # already ships. If that ever stops being true the constructor throws naming
       # what it looked for, rather than failing silently.
+      # The suite still writes its 28 PNGs, because `bun run shots` is the same
+      # traversal and that is where they are looked at. They are not uploaded: a
+      # 7.8 MB artifact per run that nobody opened.
       - name: Browser suite
         run: bun run ci browser
-
-      # `if: always()` because the failing run is the one worth looking at: each
-      # test writes its frame before it asserts, so an overflow or a route that
-      # loaded the wrong page leaves the picture behind. 28 PNGs, 7.8 MB.
-      - name: Upload the screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshots
-          path: internal/docs/.shots
-          # `.shots` is dot-prefixed, and the default is to skip hidden paths, so
-          # the upload found nothing and failed a job whose suite had passed.
-          include-hidden-files: true
-          if-no-files-found: error
-          retention-days: 14
 
   coverage:
     name: Coverage

--- a/internal/docs/browser/site.browser.test.ts
+++ b/internal/docs/browser/site.browser.test.ts
@@ -15,10 +15,9 @@ import {
  * scroll sideways, and that nothing logs an error along the way.
  *
  * One test per route per viewport per colour scheme, and each writes its PNG into
- * `.shots/`. The screenshots are not a side errand: a failure saying `landing`
- * overflows at mobile is worth having the frame for, and this traversal already
- * visits every combination. `bun run shots` is this suite plus a build, so the
- * pictures and the assertions cannot drift apart.
+ * `.shots/`. That is for looking at locally - `bun run shots` is this suite plus a
+ * build, so the pictures and the assertions cannot drift apart. CI does not keep
+ * them.
  *
  * Outside `src/`, and with its own `bunfig.toml`, so `bun run test` does not
  * collect it and the happy-dom preload does not replace the global `Response` -
@@ -65,7 +64,7 @@ for (const scheme of SCHEMES) {
           await preview.view(width, height, 2);
           await preview.open(hash);
 
-          // Written before the assertions, so a failure leaves the frame behind.
+          // Before the assertions, so a local failure leaves the frame behind.
           await Bun.write(
             `${shots}${name}-${viewport}-${scheme}.png`,
             await preview.screenshot(),

--- a/internal/docs/src/App.tsx
+++ b/internal/docs/src/App.tsx
@@ -345,7 +345,13 @@ export const App = (): React.JSX.Element => {
       </AppShell.Navbar>
 
       <AppShell.Main>
-        <Page route={route} />
+        {/* Keyed on the page, not the whole route, so the entrance replays on
+            navigation while a `?h=symbol-...` on the page already open does not
+            remount it - `PackagePage` opens its API tab from that anchor and has
+            to survive the hash change. */}
+        <div className="page-enter" key={`${route.kind}:${route.slug ?? ''}`}>
+          <Page route={route} />
+        </div>
         <DocsFooter />
         <Search />
       </AppShell.Main>

--- a/internal/docs/src/styles.css
+++ b/internal/docs/src/styles.css
@@ -398,3 +398,133 @@ body {
   border: 0;
   border-radius: 0;
 }
+
+/* Motion. Every rule below animates `opacity` and `transform` only, so it runs on
+   the compositor and never triggers layout; nothing moves horizontally, because the
+   browser suite asserts that no route scrolls sideways. Durations are 140-220ms:
+   long enough to read as motion, short enough that a reader clicking through the
+   sidebar is never waiting for one. Easing matches `bench-grow` above.
+
+   Colours resolve through Mantine variables, so both schemes follow the theme
+   rather than needing a second palette. The whole block is switched off under
+   `prefers-reduced-motion` at the end of this file. */
+
+@keyframes page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+/* Keyed on the route in `App.tsx`, so React remounts it and the animation replays
+   per navigation. The key deliberately omits the anchor: a `?h=symbol-...` on the
+   page already open must not remount it, or `PackagePage` loses the API tab it
+   opened for that anchor. */
+.page-enter {
+  animation: page-enter 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  /* This div is now the flex item that `.mantine-AppShell-main > *` was clamping,
+     so it has to pass the clamp on to the page inside it. Without this the widest
+     code block's min-content width wins again and the document scrolls sideways on
+     a phone, which is the exact bug those rules above were written for. */
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.page-enter > * {
+  width: 100%;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+/* The one place a reader has to find something: the card a `?h=symbol-...` link
+   named. The ring is already there from `.symbol-card-linked`; this draws the eye
+   to it once and then stops. */
+@keyframes symbol-found {
+  0% {
+    box-shadow: 0 0 0 0 var(--mantine-primary-color-light);
+  }
+  40% {
+    box-shadow: 0 0 0 6px var(--mantine-primary-color-light);
+  }
+  100% {
+    box-shadow: 0 0 0 2px var(--mantine-primary-color-light);
+  }
+}
+
+.symbol-card-linked {
+  animation: symbol-found 620ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+/* Cards lift on hover the way `.feature` does on the landing page, so the two
+   pages behave the same way under the cursor. */
+.symbol-card {
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease;
+}
+
+.symbol-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(
+    in srgb,
+    var(--mantine-primary-color-filled) 45%,
+    var(--mantine-color-default-border)
+  );
+}
+
+.search-trigger {
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease;
+}
+
+.search-trigger:hover {
+  border-color: color-mix(
+    in srgb,
+    var(--mantine-primary-color-filled) 45%,
+    var(--mantine-color-default-border)
+  );
+}
+
+/* The dot and the rule already mark position in the page; this makes moving
+   between them feel continuous rather than stepped. */
+.toc a::before {
+  transition:
+    background-color 140ms ease,
+    scale 140ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.toc a:hover::before,
+.toc a[aria-current='true']::before {
+  scale: 1.35;
+}
+
+/* Mantine paints the active state itself. This is only the fade between states, so
+   clicking down the sidebar does not flash. */
+.mantine-NavLink-root {
+  transition: background-color 140ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-enter,
+  .symbol-card-linked {
+    animation: none;
+  }
+
+  .symbol-card,
+  .search-trigger,
+  .toc a::before,
+  .mantine-NavLink-root {
+    transition: none;
+  }
+
+  .symbol-card:hover {
+    transform: none;
+  }
+
+  .toc a:hover::before,
+  .toc a[aria-current='true']::before {
+    scale: 1;
+  }
+}


### PR DESCRIPTION
Two unrelated asks: drop the screenshot artifact, and give the documentation site
some motion.

## The screenshot artifact is gone

7.8 MB per run that nobody opened. The suite still writes its 28 PNGs, because
`bun run shots` is the same traversal and locally is where they get looked at. CI
discards them.

The test's docstring justified writing-before-asserting with "a CI failure is worth
having the frame for", which was the artifact's rationale. It now says what the
frames are actually for.

## Motion

The landing page already had entrance and hover motion. Every other route had none,
so this extends that system rather than adding a second one: the easing is
`bench-grow`'s, every colour resolves through a Mantine variable so both schemes
follow the theme, and the whole block is switched off under
`prefers-reduced-motion`.

- **Page entrance** - 220ms fade and a 6px rise, keyed on the route so it replays
  per navigation.
- **The anchored symbol** - the card a `?h=symbol-...` names widens its existing
  ring once and settles. The ring was already there; this draws the eye to it.
- **Hover** - symbol cards lift the way `.feature` does on the landing page, so the
  two behave the same under the cursor. Search trigger and table-of-contents dots
  get the same 140ms treatment.

Deliberately subtle. At 90ms of the 220ms the page is already almost settled, which
is the point: it should register as the page arriving, not as something to wait for.

### Not laggy, by construction

Only `opacity`, `transform`, `scale`, `box-shadow` and `background-color` - nothing
that triggers layout. Nothing moves horizontally, because the browser suite asserts
no route scrolls sideways.

Verified with `Bun.WebView` rather than assumed:

```
page-enter animation-name : page-enter        reduced: none
page-enter duration       : 0.22s
navlink transition        : background-color  reduced: none
linked card animation     : symbol-found      reduced: none
symbol-card transition    : transform, border-color
```

The browser suite is 15.5s against 15.4s before, so no measurable cost.

### The one thing that needed care

The entrance needs a wrapper element, and `.mantine-AppShell-main > *` plus
`> :first-child` were clamping the page's width. That clamp is not cosmetic: its own
comment records that without it a long code block's min-content width wins and the
whole document scrolls sideways on a phone. The wrapper absorbed those rules and now
passes them through explicitly.

Checked at three widths on the widest-content routes rather than trusting it:

```
320  #/guide/controllers  scrollWidth=305  overflow=no
393  #/guide/controllers  scrollWidth=378  overflow=no
768  #/guide/controllers  scrollWidth=753  overflow=no
```

The route key also omits the anchor on purpose. Keying on the whole route would
remount the page on a `?h=symbol-...` navigation, and `PackagePage` opens its API
tab from that anchor and has to survive the hash change - `symbol-anchor.test.tsx`
asserts exactly that.

`bun run ci` 12/12, docs suite 91/91, browser suite 29/29.
