### PR TITLE
fix(create-app): exit after the prompt, and setup instructions an agent can fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,11 @@ tmp
 internal/docs/src/generated/
 internal/docs/public/badges/
 
+# The agent-facing pair the docs build copies into the site root, from
+# `docs/setup.md` and the generated guide list.
+internal/docs/public/setup.md
+internal/docs/public/llms.txt
+
 # Session resume point written by /whats-next - regenerated per session, not a
 # repo artifact
 HANDOFF.md

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ specifier is a compile error rather than a runtime surprise.
 - **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** - what was measured, what was
   rejected, and why
 - **[ROADMAP.md](docs/ROADMAP.md)** - what is built and what is next
+- **[setup.md](https://petarzarkov.github.io/dunx/setup.md)** - the same setup for
+  an agent to fetch and follow: "set up my project using
+  https://petarzarkov.github.io/dunx/setup.md". Every scaffolded app also gets an
+  `AGENTS.md` and a `CLAUDE.md`
+- **[llms.txt](https://petarzarkov.github.io/dunx/llms.txt)** - every document
+  above, linked as raw markdown
 
 ## Performance
 

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -671,6 +671,33 @@ was not going to end anyway" without a race or a fixed delay. A ref'd timer woul
 add its own delay to every clean exit, and polling would need a loop that is itself
 a handle.
 
+### One line of stdin keeps the process alive
+
+`console` is async-iterable over stdin's lines. Taking one line off the iterator
+with `.next()` and stopping there leaves the handle referenced for the life of the
+process. Probed on Bun 1.4.0, one line written into a stdin the parent holds open:
+
+```
+console[Symbol.asyncIterator]().next()         still running after 6s     <- HANG
+for await (const line of console) { break }    exited after 0.02s
+for await (const line of console) { return }   exited after 0.02s
+process.stdin.unref() after .next()            exited after 0.02s
+process.stdin.pause() after .next()            exited after 0.02s
+Bun.stdin.stream() reader, then cancel()       exited after 0.02s
+```
+
+Ending the iteration is what releases it: `break` and `return` both run the
+iterator's `return()`, and the three explicit calls do the same job by hand.
+
+**A piped test never sees this.** `printf 'notes\n' | bun cli.ts` closes stdin
+straight away, the iteration ends on EOF, and the process exits. The hang needs
+something holding the other end open, which is every real terminal. That is how it
+reached a release: `bunx @dunx/create-app my-api` wrote the app, printed its next
+steps and then sat there until the user pressed Ctrl+C, reported from a real run
+after the piped CLI suite had been green for weeks. `tools/create-app/src/stdin.ts`
+is the one-line read, and its test spawns the reader with a pipe it deliberately
+does not close.
+
 ### Decorators - a compound assignment to a private field is a `SyntaxError`
 
 **Bun 1.4.0 refuses to parse a class that has both a decorated member and a

--- a/docs/guide/02-first-steps.md
+++ b/docs/guide/02-first-steps.md
@@ -11,7 +11,7 @@ bunx @dunx/create-app my-api
 
 ```
 Created my-api in my-api/
-  10 files from the minimal template
+  12 files from the minimal template
 
 Next:
   cd my-api
@@ -58,7 +58,7 @@ bunx @dunx/create-app my-api --with users,openapi,http
 
 ```
 Created my-api in my-api/
-  28 files, 4 features: openapi, http, database, users
+  33 files, 4 features: openapi, http, database, users
   database came along as requirements
 ```
 
@@ -113,6 +113,8 @@ my-api/
   package.json
   tsconfig.json
   README.md
+  AGENTS.md
+  CLAUDE.md
   .gitignore
   src/
     main.ts
@@ -491,6 +493,21 @@ you ask for it, because a suite printing one JSON line per assertion helps nobod
 `server.json(path)` returns `{ status, headers, body }` in one await. `server.request()`
 gives you the raw `Response` for bytes, HTML or a header assertion. `server.close()`
 is `app.shutdown()`: it stops the server, then tears the container down.
+
+### `AGENTS.md` and `CLAUDE.md`
+
+`AGENTS.md` states this app's layout, its commands, and the rules dunx fails at boot
+over: no `@Injectable()` to add, `.js` on relative imports, a `import type` at an
+injection site being an error rather than an `undefined`. A composed app also lists
+the features it carries and the services they want running.
+
+`CLAUDE.md` is four lines pointing at it, so both filenames find the same
+instructions and there is one file to edit.
+
+Neither restates the framework. They link
+[setup.md](https://petarzarkov.github.io/dunx/setup.md) and
+[llms.txt](https://petarzarkov.github.io/dunx/llms.txt), which are served from the
+documentation site and move with each release.
 
 ## Run it
 

--- a/docs/guide/21-agent-tooling.md
+++ b/docs/guide/21-agent-tooling.md
@@ -117,6 +117,25 @@ properly, so `dunx_openapi` is where it lives - and that split is what keeps the
 other five tools working in an app with no OpenAPI setup. `@dunx/openapi` is an
 optional peer, loaded only when `dunx_openapi` is called.
 
+## Starting a project with an agent
+
+Two files are served for an agent to fetch rather than render:
+
+| URL                                           | Holds                                                                   |
+| --------------------------------------------- | ----------------------------------------------------------------------- |
+| <https://petarzarkov.github.io/dunx/setup.md> | Install, wire and verify an app, plus the rules dunx fails at boot over |
+| <https://petarzarkov.github.io/dunx/llms.txt> | Every dunx document, linked as raw markdown                             |
+
+Hand the first one to an agent as an instruction: "set up my project using
+<https://petarzarkov.github.io/dunx/setup.md>". It is the same content the
+repository's guards check, copied to that URL by each build, so it states the
+version being served.
+
+`bunx @dunx/create-app my-api --yes` writes an `AGENTS.md` and a `CLAUDE.md` into
+the app: its layout, its commands, the features it carries and the services those
+want running. **Pass `--yes` or `--with` when an agent runs it**, since a bare run
+in a terminal asks which features to include and waits for an answer.
+
 ## It reads the app. It never boots it.
 
 This is the decision the package is built around.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,278 @@
+# Setting up dunx
+
+Instructions for an agent setting up a dunx application. Served raw at
+<https://petarzarkov.github.io/dunx/setup.md>, so it can be fetched and followed
+without cloning anything.
+
+dunx is a Bun-native dependency injection framework: modules, controllers,
+providers and lifecycle hooks, on `Bun.serve`. Constructor injection needs no
+annotation. Requires **Bun 1.4 or newer** and no other runtime.
+
+## Scaffold, or wire it by hand
+
+`bunx @dunx/create-app` writes a working app. **Pass `--yes` or `--with`**: with
+neither, and a TTY attached, it asks which features to include and waits for an
+answer.
+
+```bash
+bunx @dunx/create-app my-api --yes                      # minimal: 12 files, one route
+bunx @dunx/create-app my-api --with notes,openapi       # composed from features
+bunx @dunx/create-app my-api --all                      # every feature
+bunx @dunx/create-app --list                            # the feature names, then exit
+cd my-api && bun install && bun run start
+```
+
+Composed apps carry a feature directory each, copied from dunx's own
+`examples/full`. Every scaffolded app gets an `AGENTS.md` naming its layout and the
+rules below; read it before editing the app.
+
+The rest of this page is the manual path, for adding dunx to a project that already
+exists.
+
+## Install
+
+```bash
+bun add @dunx/core @dunx/http @dunx/transform
+bun add -d @dunx/testing @types/bun typescript
+```
+
+Add packages per feature as you need them, from the table further down. All
+`@dunx/*` packages version in lockstep: install the same version of each.
+
+## `bunfig.toml`
+
+```toml
+# The one line that makes constructor injection work. The compiler plugin records
+# each class's constructor parameter types so the container can resolve them.
+# Without it, providers are built with no arguments and boot fails saying so.
+preload = ["@dunx/transform/preload"]
+
+[test]
+preload = ["@dunx/transform/preload"]
+```
+
+Both sections are needed: `bun test` reads its own `preload`, and a suite without
+it fails the same way the app does.
+
+## `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["bun"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}
+```
+
+Do not add `experimentalDecorators` or `emitDecoratorMetadata`. dunx uses TC39
+standard decorators, which both flags change the meaning of.
+
+## The four files of a working app
+
+`src/greetings.service.ts` - a provider is a plain class:
+
+```ts
+import { Logger, type OnInit } from '@dunx/core';
+
+/** A provider is a plain class. Listing it in a module's `providers` is what
+ * makes it injectable; the container reads `Logger` off the constructor. */
+export class GreetingsService implements OnInit {
+  #greeted = 0;
+
+  constructor(private readonly logger: Logger) {}
+
+  onInit(): void {
+    this.logger.info('greetings ready');
+  }
+
+  greet(name: string): { greeting: string; served: number } {
+    this.#greeted++;
+    return { greeting: `hello, ${name}`, served: this.#greeted };
+  }
+}
+```
+
+`src/greetings.controller.ts` - a controller returns plain objects:
+
+```ts
+import { Controller, Get, type Input, type RouteSchemas } from '@dunx/http';
+import { GreetingsService } from './greetings.service.js';
+
+@Controller('greetings')
+export class GreetingsController {
+  constructor(private readonly greetings: GreetingsService) {}
+
+  @Get('/')
+  index(): { routes: readonly string[] } {
+    return { routes: ['GET /greetings', 'GET /greetings/:name'] };
+  }
+
+  // With no `params` schema declared, a path param stays a string.
+  // `examples/full` shows the typed, coerced version.
+  @Get('/:name')
+  one(input: Input<RouteSchemas>): { greeting: string; served: number } {
+    return this.greetings.greet(input.req.params['name'] ?? 'world');
+  }
+}
+```
+
+`src/app.module.ts` - `controllers` get routes, `providers` do not:
+
+```ts
+import { Module } from '@dunx/core';
+import { GreetingsController } from './greetings.controller.js';
+import { GreetingsService } from './greetings.service.js';
+
+@Module({
+  controllers: [GreetingsController],
+  providers: [GreetingsService],
+})
+export class AppModule {}
+```
+
+`src/main.ts` - the entry point:
+
+```ts
+import { HttpFactory } from '@dunx/http';
+import { AppModule } from './app.module.js';
+
+const app = await HttpFactory.create(AppModule);
+app.enableShutdownHooks();
+
+const url = await app.listen(3000);
+console.log(`listening on ${url}greetings`);
+
+await app.closed;
+```
+
+## Verify
+
+```bash
+bun src/main.ts &
+curl -s localhost:3000/greetings/ada     # {"greeting":"hello, ada","served":1}
+```
+
+A test needs no running server of its own:
+
+```ts
+import { describe, expect, test } from 'bun:test';
+import { createTestServer } from '@dunx/testing';
+import { AppModule } from './app.module.js';
+
+describe('minimal', () => {
+  test('serves the greeting', async () => {
+    const server = await createTestServer({ modules: [AppModule] });
+
+    const { status, body } = await server.json<{ greeting: string }>(
+      'greetings/ada',
+    );
+
+    expect(status).toBe(200);
+    expect(body.greeting).toBe('hello, ada');
+    await server.close();
+  });
+});
+```
+
+`createTestServer` binds a real `Bun.serve` on port 0. `createTestApp` builds the
+container without a server, and both take `overrides` to replace a provider in
+place.
+
+## Rules that produce a boot error when broken
+
+- **No `@Injectable()`, no `@Inject()`.** Being listed in a module's `providers` is
+  what makes a class injectable. TC39 standard decorators have no parameter
+  decorators, so `@Inject()` cannot exist. For a value with no constructor
+  parameter to hang off, use `inject(Token)` in a field initializer.
+- **No `reflect-metadata`, no `tsyringe`.** Nothing imports either.
+- **A constructor parameter whose type is erased fails at boot, naming the
+  parameter.** An interface, a primitive, a union, a class type parameter or a
+  `import type` at an injection site all record as `unresolved`. Inject a class, and
+  drop `type` from the import.
+- **Relative imports carry `.js`**, matching the emitted specifier under
+  `nodenext`: `'./greetings.service.js'`, never `'./greetings.service'`.
+- **A module's `exports` is its public surface.** The container is scoped per
+  module, so a provider another module injects has to be exported by the module that
+  declares it. Absent `exports` means nothing is exported; `global: true` publishes
+  a module's exports app-wide.
+- **`bun` only.** No `npm`, `npx`, `yarn` or `pnpm`; run tools with `bunx`.
+
+## Configuration
+
+One validation function, raw env in and a shaped object out. Whatever it throws is
+what boot fails with.
+
+```ts
+import { ConfigModule, ConfigService } from '@dunx/core';
+import { z } from 'zod';
+
+const schema = z.object({ PORT: z.coerce.number().default(3000) });
+export type AppConfig = z.infer<typeof schema>;
+export class AppConfigService extends ConfigService<AppConfig> {}
+
+ConfigModule.forRoot({
+  validate: (env) => schema.parse(env),
+  as: AppConfigService,
+});
+```
+
+Declare the subclass and pass it as `as`: without it, a factory annotating
+`ConfigService<AppConfig>` is rejected, since the bare token carries no type
+argument. Bun loads `.env` and `.env.local` on its own, so there is no loader and no
+`dotenv`.
+
+## Which package for what
+
+| Need                             | Import                                                    |
+| -------------------------------- | --------------------------------------------------------- |
+| DI, modules, lifecycle, config   | `@dunx/core`                                              |
+| Routes, middleware, guards, CORS | `@dunx/http`                                              |
+| Websockets                       | `@dunx/http` - `@Gateway`, `@OnMessage`                   |
+| Outbound HTTP with retries       | `@dunx/http/client`                                       |
+| Database and migrations          | `@dunx/infra/db` - drizzle over `bun:sqlite` or `Bun.SQL` |
+| Redis or Valkey                  | `@dunx/infra/redis` - `Bun.RedisClient`                   |
+| Queues and workers               | `@dunx/infra/queue` - bullmq                              |
+| Cron and intervals               | `@dunx/infra/schedule`                                    |
+| Uploads, downloads, images       | `@dunx/infra/files`, `@dunx/infra/images`                 |
+| Structured logging               | `@dunx/infra/logger`                                      |
+| OpenAPI 3.1 and Swagger UI       | `@dunx/openapi`                                           |
+| Sessions and sign-in             | `@dunx/auth` - better-auth                                |
+| Tests                            | `@dunx/testing`                                           |
+| An ops page                      | `@dunx/dashboard`                                         |
+
+Validation is Standard Schema, so zod, Valibot and ArkType all work with no adapter.
+drizzle, better-auth, bullmq and zod are peer dependencies: install the ones the
+features you use need.
+
+## Reading an app you did not write
+
+```bash
+bunx @dunx/mcp ./src/app.module.ts
+```
+
+An MCP server over stdio answering what routes, providers, modules and gateways
+exist, and which constructor parameters would fail to resolve. It reads the module
+graph and never boots the app.
+
+## More
+
+- <https://petarzarkov.github.io/dunx/llms.txt> - every document, as raw markdown
+- <https://petarzarkov.github.io/dunx/> - the guide, the API reference, benchmarks
+- <https://github.com/petarzarkov/dunx/blob/main/docs/MIGRATION-FROM-NEST.md> -
+  coming from NestJS
+- <https://github.com/petarzarkov/dunx/tree/main/examples> - `minimal`,
+  `databases`, `testing`, `full`

--- a/internal/docs/scripts/agent-docs.test.ts
+++ b/internal/docs/scripts/agent-docs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { join, resolve } from 'node:path';
+import type { SiteIndex } from './extract/model';
+
+/**
+ * The two files an agent fetches. Both are build output, written by
+ * `scripts/generate.ts` into `public/` for Vite to copy to the site root, so this
+ * asserts the artifacts rather than the generator.
+ */
+const TOOL_ROOT = resolve(import.meta.dir, '..');
+const REPO_ROOT = resolve(TOOL_ROOT, '../..');
+const PUBLIC_DIR = join(TOOL_ROOT, 'public');
+
+// Read rather than imported: the docs tsconfig has no `resolveJsonModule`, and the
+// `?raw` form `src/data.ts` uses is Vite's.
+const index = (await Bun.file(
+  join(TOOL_ROOT, 'src', 'generated', 'index.json'),
+).json()) as SiteIndex;
+
+describe('the agent-facing assets', () => {
+  test('setup.md is served verbatim from docs/', async () => {
+    const served = Bun.file(join(PUBLIC_DIR, 'setup.md'));
+
+    expect(await served.exists()).toBe(true);
+    expect(await served.text()).toBe(
+      await Bun.file(join(REPO_ROOT, 'docs', 'setup.md')).text(),
+    );
+  });
+
+  test('llms.txt lists every guide the site publishes', async () => {
+    const llms = await Bun.file(join(PUBLIC_DIR, 'llms.txt')).text();
+
+    expect(llms.startsWith('# dunx\n')).toBe(true);
+    expect(llms).toContain('https://petarzarkov.github.io/dunx/setup.md');
+
+    for (const guide of index.guides) {
+      expect(llms, `${guide.slug} is missing from llms.txt`).toContain(
+        `/main/${guide.source}`,
+      );
+    }
+  });
+
+  test('every link in it is absolute, a .txt having no base', async () => {
+    const llms = await Bun.file(join(PUBLIC_DIR, 'llms.txt')).text();
+
+    for (const [, href] of llms.matchAll(/\]\(([^)]+)\)/g)) {
+      expect(href, `${href} is not fetchable on its own`).toMatch(
+        /^https:\/\//,
+      );
+    }
+  });
+});

--- a/internal/docs/scripts/agent-docs.ts
+++ b/internal/docs/scripts/agent-docs.ts
@@ -1,0 +1,98 @@
+import { copyFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { GuideMeta } from './extract/model';
+
+/**
+ * The two files an agent fetches instead of reading the site.
+ *
+ * `setup.md` is `docs/setup.md`, copied verbatim so the URL an agent is handed
+ * serves the file the repository's own guards check. `llms.txt` is the index
+ * described by <https://llmstxt.org>, generated from the same guide list the nav
+ * is built from, with each entry pointing at raw markdown rather than at a
+ * hash-routed page a fetch cannot render.
+ *
+ * Both land in `public/`, which Vite copies to the output root, so they are served
+ * from https://petarzarkov.github.io/dunx/ alongside the coverage badges.
+ */
+export const SITE_URL = 'https://petarzarkov.github.io/dunx/';
+
+const RAW_URL = 'https://raw.githubusercontent.com/petarzarkov/dunx/main/';
+
+/** The first paragraph under the title, flattened to one line. */
+const summaryOf = (markdown: string): string => {
+  const body = markdown.replace(/^#[^\n]*\n+/, '');
+  const paragraph = (body.split(/\n\s*\n/)[0] ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\*\*/g, '')
+    .trim();
+  if (paragraph === '' || paragraph.startsWith('```')) return '';
+  const sentence = (
+    /^(.+?\.)(?:\s|$)/.exec(paragraph)?.[1] ?? paragraph
+  ).replace(/[:\-\s]+$/, '');
+  return sentence.length > 200 ? `${sentence.slice(0, 197)}...` : sentence;
+};
+
+const entry = (title: string, url: string, summary: string): string =>
+  summary === '' ? `- [${title}](${url})` : `- [${title}](${url}): ${summary}`;
+
+interface AgentDocsOptions {
+  readonly publicDir: string;
+  readonly docsDir: string;
+  readonly setupDoc: string;
+  readonly blurb: string;
+  /** The site's guides, in nav order, each with the source path it was read from. */
+  readonly guides: readonly GuideMeta[];
+  /** Reads a repository-relative file, returning '' when it is absent. */
+  readonly read: (file: string) => string;
+}
+
+export const writeAgentDocs = (options: AgentDocsOptions): void => {
+  const { publicDir, docsDir, setupDoc, blurb, guides, read } = options;
+
+  copyFileSync(setupDoc, join(publicDir, 'setup.md'));
+
+  // Grouped before sorting, so the tour keeps its own numbering: the reference
+  // pages start at 0 too, and one flat sort put "Migrating from NestJS" above
+  // "Introduction".
+  const sections = (['guide', 'reference'] as const).map((category) => {
+    const lines = guides
+      .filter((guide) => guide.category === category)
+      .sort((a, b) => a.order - b.order)
+      .map((guide) => {
+        const source = guide.source.replace(/^docs\//, '');
+        return entry(
+          guide.title,
+          `${RAW_URL}docs/${source}`,
+          summaryOf(read(join(docsDir, source))),
+        );
+      });
+    const heading = category === 'guide' ? 'Guide' : 'Reference';
+    return `## ${heading}\n\n${lines.join('\n')}`;
+  });
+
+  writeFileSync(
+    join(publicDir, 'llms.txt'),
+    `# dunx\n\n> ${blurb}\n\n` +
+      'Every link under Setup, Guide and Reference is raw markdown, fetchable\n' +
+      'as-is.\n\n' +
+      `## Setup\n\n${entry(
+        'Setting up dunx',
+        `${SITE_URL}setup.md`,
+        summaryOf(read(setupDoc)),
+      )}\n\n${sections.join('\n\n')}\n\n` +
+      '## Optional\n\n' +
+      entry(
+        'The documentation site',
+        SITE_URL,
+        'The same guides rendered, plus the API reference and the benchmarks.',
+      ) +
+      '\n' +
+      entry(
+        'The repository',
+        'https://github.com/petarzarkov/dunx',
+        'Source, examples and the architecture notes the site does not publish.',
+      ) +
+      '\n',
+  );
+};

--- a/internal/docs/scripts/generate.ts
+++ b/internal/docs/scripts/generate.ts
@@ -13,6 +13,7 @@ import {
   slugify,
   type LinkTargets,
 } from './content';
+import { writeAgentDocs } from './agent-docs';
 import { readBench } from './extract/bench';
 import { highlight, paletteCss, startHighlighter } from './highlight';
 import { ALL_SAMPLES, langOf } from '../src/samples';
@@ -43,6 +44,7 @@ const DOCS_DIR = join(REPO_ROOT, 'docs');
 const OUT_DIR = join(TOOL_ROOT, 'src', 'generated');
 const GUIDES_OUT = join(OUT_DIR, 'guides');
 const PACKAGES_OUT = join(OUT_DIR, 'packages');
+const PUBLIC_DIR = join(TOOL_ROOT, 'public');
 /**
  * `--if-missing` generates only when there is nothing there, and is what
  * `typecheck` passes.
@@ -403,6 +405,19 @@ writeFileSync(join(OUT_DIR, 'releases.json'), JSON.stringify(releases));
 const bench = readBench(BENCH_RESULTS);
 
 writeFileSync(join(OUT_DIR, 'index.json'), JSON.stringify(site));
+
+// The pair an agent fetches rather than rendering the site: `/setup.md` and
+// `/llms.txt`, written into `public/` for Vite to copy to the output root. Built
+// from the same guide list as the nav, so a page added to the site is a line added
+// to the index.
+writeAgentDocs({
+  publicDir: PUBLIC_DIR,
+  docsDir: DOCS_DIR,
+  setupDoc: join(DOCS_DIR, 'setup.md'),
+  blurb: BLURB,
+  guides: site.guides,
+  read,
+});
 writeFileSync(join(OUT_DIR, 'bench.json'), JSON.stringify(bench));
 // Last: every highlight() call above has interned its colours by now.
 writeFileSync(join(OUT_DIR, 'shiki.css'), `${paletteCss()}\n`);

--- a/internal/docs/src/published-voice.test.ts
+++ b/internal/docs/src/published-voice.test.ts
@@ -16,8 +16,15 @@ const FORBIDDEN: readonly (readonly [string, RegExp])[] = [
   // Private workspaces. A reader cannot open these, and a page that cites one is
   // explaining the repository rather than the framework.
   ['private workspace', /internal\/(?:bench|docs|ui|openapi-ui|dashboard-ui)/g],
-  // Planning records and the agent instructions.
-  ['planning record', /docs\/roadmap|CLAUDE\.md|docs\/ROADMAP\.md/g],
+  // Planning records, and this repository's own agent instructions. A published
+  // page may name the `AGENTS.md` and `CLAUDE.md` that `bunx @dunx/create-app`
+  // writes into a reader's app: those are the reader's files, and the name is the
+  // useful part. What stays banned is a link to dunx's own, which `rewriteHref`
+  // turns into a `blob/main/` URL.
+  [
+    'planning record',
+    /docs\/roadmap|docs\/ROADMAP\.md|blob\/main\/CLAUDE\.md/g,
+  ],
   // Source layout. `@dunx/http`'s lifecycle suite is the reader-facing spelling
   // of `packages/http/src/server/lifecycle.test.ts`.
   ['source path', /packages\/[a-z-]+\/src\//g],

--- a/scripts/no-slop.test.ts
+++ b/scripts/no-slop.test.ts
@@ -68,6 +68,9 @@ const MODES: readonly (readonly [RegExp, Mode])[] = [
   // Private workspaces. `internal/bench/README.md` is a long argument about
   // methodology and is meant to be.
   [/^internal\//, Mode.Exempt],
+  // Fetched by an agent rather than read on the site, and served raw at
+  // /dunx/setup.md. Instructions to a machine still have a reader.
+  [/^docs\/setup\.md$/, Mode.Reference],
   [/^docs\/guide\/01-introduction\.md$/, Mode.Explanation],
   [/^docs\/guide\/02-first-steps\.md$/, Mode.Tutorial],
   [/^docs\/guide\//, Mode.Reference],

--- a/scripts/setup-doc.test.ts
+++ b/scripts/setup-doc.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'bun:test';
+import { Glob } from 'bun';
+import { join } from 'node:path';
+
+/**
+ * `docs/setup.md` is fetched by an agent and followed literally, so every file it
+ * quotes has to be the file `bunx @dunx/create-app` writes.
+ *
+ * The parity is checked rather than avoided, the way `features.test.ts` checks the
+ * vendored feature folders against `examples/full`: a condensed page for a machine
+ * is worth having, and a copy nothing compares is what goes stale.
+ */
+const SETUP = 'docs/setup.md';
+const TEMPLATE = 'tools/create-app/templates/minimal';
+
+/** Quoted path in the page -> the template file it must equal. */
+const QUOTED: Readonly<Record<string, string>> = Object.freeze({
+  'bunfig.toml': '_bunfig.toml',
+  'tsconfig.json': 'tsconfig.json',
+  'src/greetings.service.ts': 'src/greetings.service.ts',
+  'src/greetings.controller.ts': 'src/greetings.controller.ts',
+  'src/app.module.ts': 'src/app.module.ts',
+  'src/main.ts': 'src/main.ts',
+});
+
+const page = await Bun.file(SETUP).text();
+
+/** Every fenced block, with the last non-empty line before it as its label. */
+const blocks = (): { label: string; body: string }[] => {
+  const found: { label: string; body: string }[] = [];
+  const lines = page.split('\n');
+  let label = '';
+  for (let at = 0; at < lines.length; at++) {
+    const line = lines[at] ?? '';
+    if (!line.startsWith('```')) {
+      if (line.trim() !== '') label = line;
+      continue;
+    }
+    const body: string[] = [];
+    for (
+      at++;
+      at < lines.length && !(lines[at] ?? '').startsWith('```');
+      at++
+    ) {
+      body.push(lines[at] ?? '');
+    }
+    found.push({ label, body: `${body.join('\n')}\n` });
+  }
+  return found;
+};
+
+describe('docs/setup.md', () => {
+  it('quotes the minimal template byte for byte', async () => {
+    const found = blocks();
+
+    for (const [quoted, template] of Object.entries(QUOTED)) {
+      const block = found.find(({ label }) => label.includes(`\`${quoted}\``));
+      expect(block, `no fenced block labelled \`${quoted}\``).toBeDefined();
+      expect(block?.body, `${quoted} has drifted from ${template}`).toBe(
+        await Bun.file(join(TEMPLATE, template)).text(),
+      );
+    }
+  });
+
+  it('names only packages and subpaths that exist', async () => {
+    const exports = new Map<string, readonly string[]>();
+    for await (const entry of new Glob('{packages,tools}/*/package.json').scan(
+      '.',
+    )) {
+      const manifest = (await Bun.file(entry).json()) as {
+        name?: string;
+        exports?: Record<string, unknown>;
+      };
+      if (manifest.name === undefined) continue;
+      exports.set(manifest.name, Object.keys(manifest.exports ?? { '.': {} }));
+    }
+
+    const named = new Set(
+      [...page.matchAll(/@dunx\/[a-z][a-z-]*(?:\/[a-z][a-z-]*)?/g)].map(
+        (match) => match[0],
+      ),
+    );
+    expect(named.size).toBeGreaterThan(8);
+
+    for (const name of named) {
+      const parts = name.split('/');
+      const pkg = `${parts[0]}/${parts[1]}`;
+      const subpath = parts[2] === undefined ? '.' : `./${parts[2]}`;
+      expect(exports.get(pkg), `${pkg} is not a workspace`).toBeDefined();
+      expect(exports.get(pkg), `${pkg} has no ${subpath} export`).toContain(
+        subpath,
+      );
+    }
+  });
+
+  it('tells the reader to run bun, and nothing else', () => {
+    const commands = blocks()
+      .filter(({ label }) => !label.includes('`'))
+      .map(({ body }) => body)
+      .join('\n');
+
+    expect(commands).not.toMatch(/\b(?:npm|npx|yarn|pnpm)\b/);
+    expect(page).toContain('bunx @dunx/create-app');
+  });
+});

--- a/tools/create-app/README.md
+++ b/tools/create-app/README.md
@@ -21,10 +21,17 @@ bun run start     # http://localhost:3000/greetings
 | Flag                | Default            | Meaning                                            |
 | ------------------- | ------------------ | -------------------------------------------------- |
 | `--name <name>`     | the directory name | Package name for the generated app                 |
+| `--with <a,b,c>`    |                    | Features to compose the app from                   |
+| `--all`             | off                | Every feature                                      |
+| `--list`            |                    | Print the features and exit                        |
 | `--template <name>` | `minimal`          | Which template to write                            |
 | `--force`           | off                | Write into a directory that already has files      |
-| `--yes`, `-y`       |                    | Accepted and ignored; nothing here ever prompts    |
+| `--yes`, `-y`       | off                | Take the minimal template without prompting        |
 | `--help`            |                    | Print usage                                        |
+
+With neither `--with` nor `--yes`, and a terminal attached, it lists the features
+and reads one line of stdin. Piped or in CI it never prompts, so **an agent or a
+script should pass `--yes` or `--with`**.
 
 The name is validated against npm's rules **before** anything is created, because
 an invalid one would otherwise surface as a confusing `bun install` failure inside
@@ -49,7 +56,12 @@ The `minimal` template, the same app as
 server, and the `bunfig.toml` preload line that makes constructor injection work.
 
 Its `src/` is a **byte-for-byte copy** of that example, and a test in this package
-fails if the two ever drift. The example is the one CI boots, so keeping them
+fails if the two ever drift.
+
+Every app also gets an `AGENTS.md` naming its layout, its commands and the rules
+dunx fails at boot over, plus a `CLAUDE.md` pointing at it. Both link
+<https://petarzarkov.github.io/dunx/setup.md>, which is served per release, rather
+than copying the framework's own instructions into your repository. The example is the one CI boots, so keeping them
 identical is what makes the template trustworthy rather than merely plausible.
 
 ## Two details

--- a/tools/create-app/src/agents.ts
+++ b/tools/create-app/src/agents.ts
@@ -1,0 +1,136 @@
+import type { Feature } from './features.js';
+
+/**
+ * `AGENTS.md` and `CLAUDE.md` for the scaffolded app.
+ *
+ * An agent starting on a fresh dunx app has to be told the things the framework
+ * fails at boot over: constructor injection needs the preload line, there is no
+ * `@Injectable()` to add, and a `import type` at an injection site is an error
+ * rather than an `undefined`. Everything here is app-scoped; the framework's own
+ * instructions stay at one URL so they are current rather than a copy frozen at
+ * scaffold time.
+ *
+ * `CLAUDE.md` is a pointer, not a second copy. Claude Code resolves an `@path`
+ * import, and the sentence above it says where to look for a tool that does not.
+ */
+const SETUP_URL = 'https://petarzarkov.github.io/dunx/setup.md';
+const LLMS_URL = 'https://petarzarkov.github.io/dunx/llms.txt';
+
+export const CLAUDE_POINTER = `# CLAUDE.md
+
+The instructions for this application live in \`AGENTS.md\`, imported below so every
+agent reads one file.
+
+@AGENTS.md
+`;
+
+const RULES = `## Rules that produce a boot error when broken
+
+- **No \`@Injectable()\`, no \`@Inject()\`.** Listing a class in a module's
+  \`providers\` is what makes it injectable. dunx uses TC39 standard decorators,
+  which have no parameter decorators. For a value with no constructor parameter to
+  hang off, use \`inject(Token)\` in a field initializer.
+- **Do not add \`reflect-metadata\`, \`experimentalDecorators\` or
+  \`emitDecoratorMetadata\`.** \`bunfig.toml\` preloads \`@dunx/transform\`, which
+  records each class's constructor parameter types. Removing that line makes every
+  provider fail at boot.
+- **A constructor parameter whose type is erased fails at boot, naming the
+  parameter.** An interface, a primitive, a union, a class type parameter, or a
+  \`import type\` at an injection site all record as \`unresolved\`. Inject a class,
+  and drop \`type\` from the import.
+- **Relative imports carry \`.js\`**: \`'./users.service.js'\`, never
+  \`'./users.service'\`.
+- **A module's \`exports\` is its public surface.** The container is scoped per
+  module, so a provider another module injects has to be exported by the module that
+  declares it.
+- **\`bun\` only.** No \`npm\`, \`npx\`, \`yarn\` or \`pnpm\`; run tools with \`bunx\`.
+`;
+
+const layout = (features: readonly Feature[]): string =>
+  features.length === 0
+    ? `- \`src/main.ts\` - the entry point
+- \`src/app.module.ts\` - the root module; \`controllers\` get routes, \`providers\` do not
+- \`src/greetings.controller.ts\`, \`src/greetings.service.ts\` - one route and its provider
+- \`src/app.test.ts\` - the whole app behind a real server on port 0
+- \`bunfig.toml\` - the preload line constructor injection needs
+`
+    : `- \`src/main.ts\` - the entry point
+- \`src/bootstrap.ts\` - builds the app; shared by \`start\` and the tests
+- \`src/app.module.ts\` - the root module, importing every feature
+- \`src/config.ts\` - one validation function, flat env in and a shaped object out
+${features.map((feature) => `- \`src/${feature.source}/\` - ${feature.name}`).join('\n')}
+- \`bunfig.toml\` - the preload line constructor injection needs
+
+\`main.ts\`, \`bootstrap.ts\`, \`app.module.ts\` and \`config.ts\` were generated for the
+features chosen at scaffold time. Everything else was copied from dunx's
+\`examples/full\`. The \`*.demo.ts\` files are that example's scripted walkthroughs;
+delete one and its \`providers\` entry to drop it.
+`;
+
+export const agents = (name: string, features: readonly Feature[]): string => {
+  const services = features.filter((feature) => feature.service !== undefined);
+  const hasJobs = features.some((feature) => feature.name === 'jobs');
+
+  return `# ${name}
+
+Notes for an agent working in this application. It is a
+[dunx](https://github.com/petarzarkov/dunx) app, scaffolded by
+\`bunx @dunx/create-app\`.
+
+## Commands
+
+\`\`\`bash
+bun install
+bun run start        # http://localhost:3000
+bun test
+bun run typecheck
+${hasJobs ? 'bun run worker      # drains the queues; the web process does not\n' : ''}\`\`\`
+
+## Layout
+
+${layout(features)}
+${
+  features.length === 0
+    ? ''
+    : `## What is wired up
+
+${features.map((feature) => `- **${feature.name}** - ${feature.summary}`).join('\n')}
+
+`
+}${
+    services.length === 0
+      ? ''
+      : `## Services
+
+Each of these reports itself degraded rather than failing the boot, so the app
+starts without them.
+
+${services.map((feature) => `- **${feature.name}** needs ${feature.service}`).join('\n')}
+
+`
+  }${RULES}
+## Reading this app instead of grepping it
+
+\`\`\`bash
+bunx @dunx/mcp ./src/app.module.ts
+\`\`\`
+
+An MCP server over stdio answering what routes, providers, modules and gateways
+exist, and which constructor parameters would fail to resolve. It reads the module
+graph and never boots the app.
+
+## The framework's own instructions
+
+- <${SETUP_URL}> - installing, wiring and verifying a dunx app
+- <${LLMS_URL}> - every dunx document, as raw markdown
+`;
+};
+
+/** Both files, written for a fixed template and a composed app alike. */
+export const agentFiles = (
+  name: string,
+  features: readonly Feature[],
+): Readonly<Record<string, string>> => ({
+  'AGENTS.md': agents(name, features),
+  'CLAUDE.md': CLAUDE_POINTER,
+});

--- a/tools/create-app/src/cli.ts
+++ b/tools/create-app/src/cli.ts
@@ -3,6 +3,7 @@ import { parseArgs } from 'node:util';
 import { relative } from 'node:path';
 import { FEATURES, featureNames, impliedBy } from './features.js';
 import { scaffold, ScaffoldError, TEMPLATES } from './scaffold.js';
+import { readLine } from './stdin.js';
 import type { TemplateName } from './scaffold.js';
 
 const USAGE = `Scaffold a new dunx application.
@@ -100,8 +101,7 @@ const ask = async (): Promise<readonly string[]> => {
   console.log('Names or numbers, comma separated. `all` for everything.');
   process.stdout.write('> ');
 
-  const line = (await console[Symbol.asyncIterator]().next()).value;
-  const answer = typeof line === 'string' ? line.trim() : '';
+  const answer = await readLine();
   if (answer === '') return [];
   if (answer === 'all') return featureNames;
 

--- a/tools/create-app/src/compose.test.ts
+++ b/tools/create-app/src/compose.test.ts
@@ -192,6 +192,20 @@ describe('a composed app', () => {
     expect(await read('bunfig.toml')).toContain('@dunx/transform/preload');
   });
 
+  test('lists the features and the services in AGENTS.md', async () => {
+    const { result, read } = await compose(['jobs']);
+    expect(result.files).toContain('AGENTS.md');
+
+    const agents = await read('AGENTS.md');
+    expect(agents).toContain('**jobs**');
+    expect(agents).toContain('Redis or Valkey');
+    // A queue needs a second process, and the layout has to name the directories
+    // the selection actually carries.
+    expect(agents).toContain('bun run worker');
+    expect(agents).toContain('src/jobs/');
+    expect(agents).not.toContain('src/notes/');
+  });
+
   test('lists the features and the services they need in the README', async () => {
     const { read } = await compose(['jobs']);
     const readme = await read('README.md');

--- a/tools/create-app/src/scaffold.test.ts
+++ b/tools/create-app/src/scaffold.test.ts
@@ -80,6 +80,27 @@ describe('scaffold', () => {
     }
   });
 
+  test('writes agent instructions for the fixed template too', async () => {
+    const cwd = workspace();
+    const { directory, files } = await scaffold({ target: 'my-api', cwd });
+
+    expect(files).toContain('AGENTS.md');
+    expect(files).toContain('CLAUDE.md');
+
+    const agents = await read(directory, 'AGENTS.md');
+    expect(agents).toContain('# my-api');
+    // The rules an agent breaks first, and where the framework's own instructions
+    // live rather than a copy of them frozen at scaffold time.
+    expect(agents).toContain('@Injectable()');
+    expect(agents).toContain('https://petarzarkov.github.io/dunx/setup.md');
+    expect(agents).toContain('bunx @dunx/mcp');
+
+    // A pointer, so Claude Code and everything else read one file.
+    const claude = await read(directory, 'CLAUDE.md');
+    expect(claude).toContain('@AGENTS.md');
+    expect(claude.length).toBeLessThan(agents.length);
+  });
+
   test('refuses a non-empty directory unless forced', async () => {
     const cwd = workspace();
     await Bun.write(join(cwd, 'taken', 'keep.txt'), 'mine');

--- a/tools/create-app/src/scaffold.ts
+++ b/tools/create-app/src/scaffold.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Glob } from 'bun';
+import { agentFiles } from './agents.js';
 import { resolveFeatures, type Feature } from './features.js';
 import {
   appModule,
@@ -225,6 +226,16 @@ export const scaffold = async (
     }
   };
 
+  /** Generated content, with the same placeholder substitution a copy gets. */
+  const writeAll = async (
+    files: Readonly<Record<string, string>>,
+  ): Promise<void> => {
+    for (const [target, contents] of Object.entries(files)) {
+      await Bun.write(join(directory, target), fill(contents, name, version));
+      written.push(target);
+    }
+  };
+
   if (!composing) {
     const source = join(templatesRoot(), template);
     if (!existsSync(source)) {
@@ -233,6 +244,9 @@ export const scaffold = async (
       );
     }
     await copyTree(source, '.');
+    // Written for the fixed template too, so both paths leave the app with one set
+    // of agent instructions rather than the template carrying a second copy.
+    await writeAll(agentFiles(name, []));
     return {
       directory,
       name,
@@ -263,10 +277,10 @@ export const scaffold = async (
     await copyTree(from, join('src', feature.source));
   }
 
-  for (const [target, contents] of Object.entries(generated(name, features))) {
-    await Bun.write(join(directory, target), fill(contents, name, version));
-    written.push(target);
-  }
+  await writeAll({
+    ...generated(name, features),
+    ...agentFiles(name, features),
+  });
 
   return {
     directory,

--- a/tools/create-app/src/stdin.test.ts
+++ b/tools/create-app/src/stdin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * The prompt read, spawned rather than imported, and with stdin left **open** after
+ * the answer - which is what a terminal does and what a pipe closed by `printf`
+ * does not.
+ *
+ * Reported from a real run: `bunx @dunx/create-app my-api`, answer the prompt, and
+ * the app is written, the next steps print, and the process never exits. The read
+ * that did it left the stdin handle referenced, so anything holding the other end
+ * of stdin - a terminal, or this test - kept the event loop alive forever.
+ *
+ * `bun -e` rather than a fixture file: importing the module here would put it in
+ * the coverage denominator as a function no in-process test can reach, since
+ * `bun test` owns the runner's stdin.
+ */
+const MODULE = new URL('./stdin.ts', import.meta.url).pathname;
+
+const readThrough = async (
+  input: string,
+): Promise<{ exited: boolean; stdout: string }> => {
+  const proc = Bun.spawn(
+    [
+      'bun',
+      '-e',
+      `const { readLine } = await import(${JSON.stringify(MODULE)});\n` +
+        `console.log(await readLine());`,
+    ],
+    { stdin: 'pipe', stdout: 'pipe', stderr: 'inherit' },
+  );
+
+  void proc.stdin.write(input);
+  await proc.stdin.flush();
+  // Deliberately not `proc.stdin.end()`: an EOF ends the iteration on its own, so
+  // closing it here would pass against the bug this guards.
+
+  const finished = await Promise.race([
+    proc.exited.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), 5000)),
+  ]);
+  if (!finished) {
+    proc.kill();
+    return { exited: false, stdout: '' };
+  }
+  return {
+    exited: true,
+    stdout: (await new Response(proc.stdout).text()).trim(),
+  };
+};
+
+describe('readLine', () => {
+  test('exits once the line is read, with stdin still open', async () => {
+    const { exited, stdout } = await readThrough('notes,openapi\n');
+
+    expect(exited).toBe(true);
+    expect(stdout).toBe('notes,openapi');
+  }, 10000);
+
+  test('trims the line rather than returning the newline', async () => {
+    const { exited, stdout } = await readThrough('  all  \n');
+
+    expect(exited).toBe(true);
+    expect(stdout).toBe('all');
+  }, 10000);
+});

--- a/tools/create-app/src/stdin.ts
+++ b/tools/create-app/src/stdin.ts
@@ -1,0 +1,21 @@
+/**
+ * One line of stdin, with the iteration ended before the value comes back.
+ *
+ * `console[Symbol.asyncIterator]().next()` on its own leaves stdin referenced for
+ * the life of the process: the scaffold wrote its files, printed the next steps and
+ * then sat there until the user pressed Ctrl+C. Ending the iteration runs the
+ * iterator's `return()`, which releases the handle, so the process exits on its own.
+ * Measured on Bun 1.4.0 - docs/bun-apis.md, "One line of stdin keeps the process
+ * alive".
+ *
+ * A function rather than a class because it is the whole module: no state, no
+ * configuration, and nothing to hold between calls.
+ */
+export const readLine = async (): Promise<string> => {
+  for await (const line of console) {
+    return typeof line === 'string' ? line.trim() : '';
+  }
+  // Reached only on a stdin that closed with nothing buffered, which is not an
+  // answer either.
+  return '';
+};


### PR DESCRIPTION
## What changed

Two things reported on [r/bun](https://www.reddit.com/r/bun/): the scaffolder no
longer hangs after its prompt, and there is now a setup document an agent can fetch
at <https://petarzarkov.github.io/dunx/setup.md>, plus an `AGENTS.md` and
`CLAUDE.md` in every scaffolded app.

## Why

**The hang.** `bunx @dunx/create-app my-api`, answer the prompt, and the app is
written, the next steps print, and the process never exits. Ctrl+C was the only way
back to the terminal.

`console[Symbol.asyncIterator]().next()` reads the line but never ends the
iteration, so the stdin handle stays referenced for the life of the process. A
piped run always exited, because `printf` closes stdin and EOF ends the iteration
on its own, which is why the CLI suite stayed green for weeks. The new test spawns
the reader with a pipe it deliberately does not close, and fails against the old
implementation.

**The agent document.** Starting a project with an agent had nothing to point at:
no fetchable setup instructions, and a scaffolded app carried none of its own.

- `docs/setup.md`, copied to `/dunx/setup.md` by the docs build, so "set up my
  project using <url>" is a usable instruction. Install, the bunfig preload, the
  tsconfig, the four files of a working app, verification, the rules that produce a
  boot error when broken, and a package-per-need table. It tells an agent to pass
  `--yes` or `--with`, since a bare run prompts.
- `/dunx/llms.txt`, generated from the same guide list the nav is built from, every
  entry a fetchable raw markdown link.
- `AGENTS.md` per scaffolded app, feature-aware: layout, commands, the services a
  selection wants running, the boot-error rules. `CLAUDE.md` is a four-line pointer
  at it rather than a second copy. Neither restates the framework; both link
  setup.md, which moves with each release instead of freezing at scaffold time.

Guarded rather than left to drift: `scripts/setup-doc.test.ts` asserts every file
setup.md quotes is byte identical to the minimal template, that every `@dunx/*`
name and subpath it mentions exists, and that it never tells a reader to run npm.
`internal/docs/scripts/agent-docs.test.ts` asserts the served copy matches
`docs/setup.md` and that llms.txt covers every published guide with absolute links.

Two edits that came with it: the minimal scaffold is 12 files now, updated in the
first-steps guide along with a section on the new files; and
`tools/create-app/README.md` claimed `--yes` was "accepted and ignored; nothing
here ever prompts" and listed neither `--with` nor `--all`.

## Measurements

Probed six ways on Bun 1.4.0, one line written into a stdin the parent holds open
(`docs/bun-apis.md`, "One line of stdin keeps the process alive"):

```
console[Symbol.asyncIterator]().next()         still running after 6s     <- HANG
for await (const line of console) { break }    exited after 0.02s
for await (const line of console) { return }   exited after 0.02s
process.stdin.unref() after .next()            exited after 0.02s
process.stdin.pause() after .next()            exited after 0.02s
Bun.stdin.stream() reader, then cancel()       exited after 0.02s
```

The real CLI under a pty, after the fix: empty answer, a named feature, numbered
answers and the unknown-feature error path all exit in 0.02s to 0.03s.

## Checks

- [x] `bun run build`
- [x] `bun run lint:check`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test:cov` (`create-app` 98.8% lines / 97.3% functions; 95.9% / 94.1% overall)
- [x] Tests cover the change. A bug fix has a test that fails without the fix.
- [x] Conventional commit messages (`feat:`, `fix:`, `docs:`, ...).
- [x] No em or en dashes. No `enum`, no `any`, no `Dunx`-prefixed identifiers.
- [x] New runtime dependency? None.
- [x] Docs updated if the public surface changed (`docs/guide/`, package README).

`bun run ci` is green, 12 of 12 steps, plus the on-request `unit` phase. No
`packages/*` change, so Rule 4 pulled in no `examples/full` edit; the scaffold
paths are covered by `check:scaffolds` and the new tests.


