### PR TITLE
feat(docs): run a request through the landing page's onion diagram

### DIFF
--- a/internal/docs/src/components/RequestFlow.tsx
+++ b/internal/docs/src/components/RequestFlow.tsx
@@ -68,7 +68,7 @@ const HANDLER = {
  * next()" as a claim in prose rather than a shape you can see.
  */
 export const RequestFlow = (): React.JSX.Element => {
-  const { ref, revealed } = useReveal<HTMLDivElement>();
+  const { ref, revealed, inView } = useReveal<HTMLDivElement>();
 
   return (
     <Container size="lg" component="section">
@@ -78,20 +78,30 @@ export const RequestFlow = (): React.JSX.Element => {
             What happens to a request
           </Title>
           <Text c="dimmed" maw={660}>
-            Each layer wraps the one inside it. The ones that call{' '}
-            <code>next()</code> see the response coming back out, so a single
+            Each layer wraps the one inside it, and the pulse below is one
+            request descending them and unwinding back out. The layers that call{' '}
+            <code>next()</code> see the response on the way, so a single
             middleware can log both halves. Two of these layers are the runtime
             rather than the framework.
           </Text>
         </Stack>
 
-        <div className="onion" ref={ref} data-revealed={revealed}>
+        {/* `data-running` rather than a CSS-only loop: the pulse repeats for as
+            long as the page is open, and an infinite animation off screen costs
+            what one on screen costs. */}
+        <div
+          className="onion"
+          ref={ref}
+          data-revealed={revealed}
+          data-running={inView}
+        >
           {LAYERS.reduceRight(
             (inner, layer, index) => (
               <div
                 className="onion-layer"
                 key={layer.who}
                 data-native={layer.native === true}
+                data-wraps={layer.wraps !== undefined}
                 style={{ '--depth': index } as React.CSSProperties}
               >
                 <div className="onion-head">

--- a/internal/docs/src/landing.css
+++ b/internal/docs/src/landing.css
@@ -290,19 +290,6 @@
   .feature:hover {
     transform: none;
   }
-
-  /* The reveal attribute still lands, so everything must be at its final
-     opacity here rather than merely transitioning to it instantly. */
-  .onion-layer,
-  .onion-core {
-    transition: none;
-  }
-
-  .onion:not([data-revealed='true']) .onion-layer,
-  .onion:not([data-revealed='true']) .onion-core {
-    opacity: 1;
-    translate: none;
-  }
 }
 
 /* Vertical tablist for the code tour. */
@@ -364,6 +351,11 @@
    instead of only asserted in the prose beside it. */
 .onion {
   --onion-inset: clamp(0.55rem, 1.6vw, 1.15rem);
+  /* One beat per boundary crossed, and one cycle for the whole trip. Every
+     animated part below shares the cycle and differs only in its delay, so the
+     five layers, the handler and the three return legs stay in step. */
+  --beat: 0.34s;
+  --cycle: 4.2s;
   display: flow-root;
 }
 
@@ -429,6 +421,7 @@
 }
 
 .onion-core {
+  position: relative;
   margin-left: var(--onion-inset);
   padding: 0.85rem;
   border-radius: 0.7rem;
@@ -451,6 +444,171 @@
 .onion:not([data-revealed='true']) .onion-core {
   opacity: 0;
   translate: 0 0.6rem;
+}
+
+/* One request, on a loop. The entrance above traces the path once as the section
+   arrives; this keeps tracing it, so "each layer wraps the one inside it" is
+   something a reader watches rather than a sentence beside a static diagram.
+
+   Direction is the colour: indigo going in, cyan coming back out, which is the
+   pairing the arrows and the return rows already use.
+
+   The delay is the whole schedule. Inbound, a layer lights at `depth * beat`, so
+   the flash descends. The handler lights one beat past the innermost layer. The
+   response then unwinds through the layers that call `next()`, `(8 - depth) * beat`
+   putting the global middleware first and the socket write last. Nothing here
+   animates a property that reflows: three pseudo-element rings and two arrows, on
+   opacity and translate.
+
+   Applied only under `[data-running='true']`, so leaving the section removes the
+   animation rather than pausing it mid-flash. */
+@keyframes onion-cross {
+  0%,
+  100% {
+    opacity: 0;
+  }
+  2% {
+    opacity: 1;
+  }
+  12% {
+    opacity: 0.35;
+  }
+  22% {
+    opacity: 0;
+  }
+}
+
+@keyframes onion-arrow-in {
+  0%,
+  100% {
+    opacity: 0.75;
+    translate: 0 0;
+  }
+  2% {
+    opacity: 1;
+    translate: 0 0.18rem;
+  }
+  14% {
+    opacity: 0.75;
+    translate: 0 0;
+  }
+}
+
+@keyframes onion-arrow-out {
+  0%,
+  100% {
+    opacity: 0.75;
+    translate: 0 0;
+  }
+  2% {
+    opacity: 1;
+    translate: 0 -0.18rem;
+  }
+  14% {
+    opacity: 0.75;
+    translate: 0 0;
+  }
+}
+
+@keyframes onion-land {
+  0%,
+  100% {
+    opacity: 0;
+    scale: 0.985;
+  }
+  3% {
+    opacity: 1;
+    scale: 1;
+  }
+  26% {
+    opacity: 0;
+    scale: 1.015;
+  }
+}
+
+/* The boundary itself, drawn just outside the layer's own border so a flash reads
+   as that edge being crossed. No fill: a tint would wash over every layer nested
+   inside this one. */
+.onion-layer::after,
+.onion-layer[data-wraps='true']::before,
+.onion-core::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  border: 2px solid color-mix(in srgb, var(--accent-a) 80%, transparent);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--accent-a) 22%, transparent);
+}
+
+/* Only the layers that see the response get an outbound ring, which is the same
+   three that carry a return row. */
+.onion-layer[data-wraps='true']::before {
+  border-color: color-mix(in srgb, var(--accent-c) 80%, transparent);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--accent-c) 22%, transparent);
+}
+
+.onion-core::after {
+  inset: -3px;
+  border-radius: 0.85rem;
+  box-shadow: 0 0 24px color-mix(in srgb, var(--accent-a) 40%, transparent);
+}
+
+.onion[data-running='true'] .onion-layer::after {
+  animation: onion-cross var(--cycle) linear infinite;
+  animation-delay: calc(var(--depth, 0) * var(--beat));
+}
+
+.onion[data-running='true'] .onion-head .onion-arrow {
+  animation: onion-arrow-in var(--cycle) linear infinite;
+  animation-delay: calc(var(--depth, 0) * var(--beat));
+}
+
+.onion[data-running='true'] .onion-core::after {
+  animation: onion-land var(--cycle) linear infinite;
+  animation-delay: calc(5 * var(--beat));
+}
+
+.onion[data-running='true'] .onion-layer[data-wraps='true']::before {
+  animation: onion-cross var(--cycle) linear infinite;
+  animation-delay: calc((8 - var(--depth, 0)) * var(--beat));
+}
+
+.onion[data-running='true'] .onion-return .onion-arrow {
+  animation: onion-arrow-out var(--cycle) linear infinite;
+  animation-delay: calc((8 - var(--depth, 0)) * var(--beat));
+}
+
+/* After the rules above rather than in the block up by `.feature`, and that is
+   the whole reason this second block exists. These selectors carry the same
+   specificity as the ones they turn off, so source order decides, and every
+   `.onion` rule in this file is declared below that block: the entrance
+   transitions had been overriding their own reduced-motion override since they
+   were written. */
+@media (prefers-reduced-motion: reduce) {
+  /* The reveal attribute still lands, so everything must be at its final opacity
+     here rather than merely transitioning to it instantly. */
+  .onion-layer,
+  .onion-core {
+    transition: none;
+  }
+
+  .onion:not([data-revealed='true']) .onion-layer,
+  .onion:not([data-revealed='true']) .onion-core {
+    opacity: 1;
+    translate: none;
+  }
+
+  /* The pulse is the one piece here that repeats, so it stops outright rather
+     than landing instantly. */
+  .onion[data-running='true'] .onion-layer::after,
+  .onion[data-running='true'] .onion-layer[data-wraps='true']::before,
+  .onion[data-running='true'] .onion-core::after,
+  .onion[data-running='true'] .onion-head .onion-arrow,
+  .onion[data-running='true'] .onion-return .onion-arrow {
+    animation: none;
+  }
 }
 
 /* Block, not flex. Mantine's Container centres with `margin-inline: auto`, and

--- a/internal/docs/src/request-flow.test.tsx
+++ b/internal/docs/src/request-flow.test.tsx
@@ -1,5 +1,5 @@
 import { test, expect } from 'bun:test';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import { RequestFlow } from './components/RequestFlow';
 
@@ -29,6 +29,27 @@ test('only the layers that see the response carry a return row', () => {
   expect(flow().querySelectorAll('.onion-return').length).toBe(3);
 });
 
+/* The outbound half of the pulse is drawn on the layer rather than on the return
+   row, and CSS cannot ask whether an element has a particular child. So the flag
+   the ring keys off has to agree with the rows: a layer marked as wrapping and
+   carrying no return row would light on the way out having claimed it does not see
+   the response. */
+test('the outbound flag marks exactly the layers with a return row', () => {
+  const container = flow();
+  const wrapping = [...container.querySelectorAll('.onion-layer')].filter(
+    (layer) => (layer as HTMLElement).dataset['wraps'] === 'true',
+  );
+
+  expect(wrapping.length).toBe(3);
+  for (const layer of wrapping) {
+    // Its own return row, not one belonging to a layer nested inside it.
+    const own = [...layer.querySelectorAll('.onion-return')].filter(
+      (row) => row.closest('.onion-layer') === layer,
+    );
+    expect(own.length).toBe(1);
+  }
+});
+
 test('depth ascends inwards, which is what the accent and stagger read', () => {
   const depths = [...flow().querySelectorAll('.onion-layer')].map((layer) =>
     (layer as HTMLElement).style.getPropertyValue('--depth'),
@@ -40,4 +61,75 @@ test('the runtime layer is marked native', () => {
   const native = flow().querySelectorAll('.onion-layer[data-native="true"]');
   expect(native.length).toBe(1);
   expect(native[0]?.textContent).toContain('Bun.serve');
+});
+
+/** Swaps the global observer for one body, restoring whatever was there. */
+const withObserver = <T,>(stub: unknown, body: () => T): T => {
+  const real = globalThis.IntersectionObserver;
+  globalThis.IntersectionObserver = stub as typeof IntersectionObserver;
+  try {
+    return body();
+  } finally {
+    globalThis.IntersectionObserver = real;
+  }
+};
+
+const onionOf = (): HTMLElement => {
+  const onion = flow().querySelector('.onion');
+  if (!(onion instanceof HTMLElement)) throw new Error('no .onion rendered');
+  return onion;
+};
+
+test('runs the pulse when there is no observer to ask', () => {
+  // A browser missing the API has nothing to wait for, so the section has to
+  // arrive revealed and animating rather than invisible and still. happy-dom does
+  // ship an IntersectionObserver, so this case needs the global taken away.
+  const onion = withObserver(undefined, onionOf);
+
+  expect(onion.dataset['revealed']).toBe('true');
+  expect(onion.dataset['running']).toBe('true');
+});
+
+/* The pulse loops for as long as the page is open, so it has to stop when the
+   section is off screen. The entrance stays one-shot: scrolling away and back
+   must not replay it. */
+test('the pulse follows the viewport while the entrance latches', () => {
+  const callbacks: IntersectionObserverCallback[] = [];
+  const watched: Element[] = [];
+  class Fake {
+    constructor(callback: IntersectionObserverCallback) {
+      callbacks.push(callback);
+    }
+    observe(node: Element): void {
+      watched.push(node);
+    }
+    disconnect(): void {
+      watched.length = 0;
+    }
+  }
+
+  const fire = (isIntersecting: boolean): void => {
+    const callback = callbacks[0];
+    if (!callback) throw new Error('the hook subscribed no observer');
+    act(() =>
+      callback(
+        [{ isIntersecting }] as unknown as IntersectionObserverEntry[],
+        {} as IntersectionObserver,
+      ),
+    );
+  };
+
+  withObserver(Fake, () => {
+    const onion = onionOf();
+    expect(watched).toEqual([onion]);
+    expect(onion.dataset['running']).toBe('false');
+
+    fire(true);
+    expect(onion.dataset['running']).toBe('true');
+    expect(onion.dataset['revealed']).toBe('true');
+
+    fire(false);
+    expect(onion.dataset['running']).toBe('false');
+    expect(onion.dataset['revealed']).toBe('true');
+  });
 });

--- a/internal/docs/src/reveal.ts
+++ b/internal/docs/src/reveal.ts
@@ -1,24 +1,31 @@
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * Marks an element once it has scrolled into view, so CSS can transition it in.
+ * Tracks an element against the viewport, for CSS to key motion off.
  *
- * The observer is dropped after the first intersection: these are one-shot
- * entrances, and leaving observers attached to every section on a long page
- * costs more than the effect is worth. `prefers-reduced-motion` is honoured in
- * CSS rather than here, so the attribute lands either way and only the
- * transition is dropped.
+ * `revealed` latches on the first intersection and drives the one-shot entrance
+ * transitions. `inView` keeps following, which is what lets a looping animation
+ * stop when nobody is looking at it: an infinite keyframe animation off screen
+ * costs what one on screen costs, and the request pulse in `RequestFlow` runs
+ * for as long as the page is open.
+ *
+ * One observer answers both, so the live half adds no second subscription. It is
+ * no longer disconnected after the first hit for that reason.
+ * `prefers-reduced-motion` is honoured in CSS rather than here, so both flags land
+ * either way and only the motion is dropped.
  */
 export const useReveal = <T extends HTMLElement>(): {
   ref: React.RefObject<T | null>;
   revealed: boolean;
+  inView: boolean;
 } => {
   const ref = useRef<T>(null);
   // Initialized from the capability check rather than set from the effect: with no
-  // observer there is nothing to wait for, so the first paint is the revealed one.
-  const [revealed, setRevealed] = useState(
-    () => typeof IntersectionObserver === 'undefined',
-  );
+  // observer there is nothing to wait for, so the first paint is the revealed one
+  // and the animation runs.
+  const blind = typeof IntersectionObserver === 'undefined';
+  const [revealed, setRevealed] = useState(blind);
+  const [inView, setInView] = useState(blind);
 
   useEffect(() => {
     const node = ref.current;
@@ -28,9 +35,8 @@ export const useReveal = <T extends HTMLElement>(): {
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
-          if (!entry.isIntersecting) continue;
-          setRevealed(true);
-          observer.disconnect();
+          setInView(entry.isIntersecting);
+          if (entry.isIntersecting) setRevealed(true);
         }
       },
       { rootMargin: '0px 0px -12% 0px', threshold: 0.12 },
@@ -40,5 +46,5 @@ export const useReveal = <T extends HTMLElement>(): {
     return () => observer.disconnect();
   }, []);
 
-  return { ref, revealed };
+  return { ref, revealed, inView };
 };


### PR DESCRIPTION
## What changed

The landing page's request-lifecycle diagram now runs a request through itself on a
loop: a ring lights each layer boundary descending inwards, the handler glows when
it lands, and the response unwinds back out through the three layers that call
`next()`. Indigo going in, cyan coming back out.

## Why

The section drew the lifecycle as nesting and staggered the layers inwards once as
it scrolled into view, then stopped. "Each layer wraps the one inside it" was a
sentence next to a picture that never did it.

Three notes on the shape of it:

- The outbound ring is drawn on the layer, not on the return row, because CSS
  cannot ask whether an element has a particular child. So the layer carries a
  `data-wraps` flag, and a test asserts that flag marks exactly the layers that
  have a return row. A layer marked wrapping with no return row would light on the
  way out having said it does not see the response.
- `useReveal` now also reports `inView` from the observer it already created, so
  the loop stops when the section is off screen. The observer stays connected for
  that, which is the one thing it previously went out of its way to avoid, and the
  comment says so.
- No new dependency, no JS per frame. Three pseudo-element rings and two arrows,
  animated on `opacity` and `translate` only.

**A pre-existing bug came out of it.** `landing.css` declared its
`prefers-reduced-motion` block above every `.onion` rule in the file. Those
selectors carry the same specificity as the ones they turn off, so source order
decided and the override lost: the entrance transitions have been running for
reduced-motion readers since they were written. The onion's overrides now sit below
the rules they disable, with a comment explaining the ordering.

## Measurements

Sampled in a real browser (`Bun.WebView` against the built site), reading the
computed opacity of every ring and arrow through one cycle. `--beat` is 0.34s,
`--cycle` 4.2s:

```
t(ms)   in L0..L4    core   out L2 L1 L0
  101    ▂ ▆ · · ·    ·      ·  ·  ·
  403    · ▃ ▇ · ·    ·      ·  ·  ·
  704    · ▁ ▃ ▇ ·    ·      ·  ·  ·
 1006    · · ▁ ▄ █    ·      ·  ·  ·
 1307    · · · ▁ ▄    ▄      ·  ·  ·
 1458    · · · · ▂    ▇      ·  ·  ·
 1759    · · · · ·    ▅      ▇  ·  ·
 2061    · · · · ·    ▂      ▃  ▇  ·
 2362    · · · · ·    ·      ▁  ▄  █
 2816    · · · · ·    ·      ▂  ·  ·
 3117    · · · · ·    ·      ·  ·  ·   <- quiet until the next cycle
```

The descent takes 5 beats, the handler lands one beat later, the unwind takes 3,
and about a second of the cycle is still.

Under `prefers-reduced-motion: reduce`, 24 samples over 1.5s return **one** distinct
frame: every ring at 0, every arrow at its static 0.75, every layer at full
opacity. Before this change the same probe showed the entrance transitions
animating.

The observer was checked in the browser too: `data-running` is `false` on load and
flips to `true` when the section is scrolled into view.

## Checks

- [x] `bun run build`
- [x] `bun run lint:check`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test:cov`
- [x] Tests cover the change. `request-flow.test.tsx` covers the no-observer
      fallback, the viewport toggle with the entrance latching, and the
      `data-wraps` agreement.
- [x] Conventional commit messages (`feat:`, `fix:`, `docs:`, ...).
- [x] No em or en dashes. No `enum`, no `any`, no `Dunx`-prefixed identifiers.
- [x] New runtime dependency? None. `internal/docs` gains nothing.
- [x] Docs updated if the public surface changed. No public surface changed; the
      section's own paragraph now mentions the pulse.

`bun run ci` is green, 12 of 12 steps. The `browser` phase screenshots the landing
page and those shots are artifacts rather than comparisons, so a frame landing
mid-pulse cannot flake it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an animated request-flow visualization showing requests moving through nested layers and returning responses.
  - Animations now run while the diagram is visible and reveal content as it enters the viewport.
  - Added reduced-motion support that displays the visualization without animations when preferred.

- **Bug Fixes**
  - Improved animation behavior when viewport observation is unavailable.
  - Ensured visibility tracking and animation cleanup work reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->