### PR TITLE
feat(docs): a spark that laps the hero headline

### DIFF
--- a/internal/docs/src/components/Hero.tsx
+++ b/internal/docs/src/components/Hero.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from '@mantine/core';
 import { decimal, scenarioHeadlines, startupHeadline } from '../bench';
+import { useReveal } from '../reveal';
 import { bench, site } from '../data';
 import { href, RouteKind } from '../router';
 import { HERO_FILES } from '../samples';
@@ -73,79 +74,88 @@ const MeasuredLine = (): React.JSX.Element | null => {
   );
 };
 
-export const Hero = (): React.JSX.Element => (
-  <Box component="section" className="hero">
-    <div className="hero-glow" aria-hidden="true" />
-    <Container size="lg">
-      <Grid gutter={{ base: 'xl', md: 48 }} align="center">
-        <Grid.Col span={{ base: 12, md: 6 }}>
-          <Stack gap="lg">
-            <Group gap={6}>
-              {site.positioning.chips.map((chip, index) => (
-                <Badge
-                  key={chip}
-                  variant={index === 0 ? 'light' : 'default'}
-                  size="sm"
-                  tt="none"
-                  radius="sm"
-                >
-                  {chip}
-                </Badge>
-              ))}
-            </Group>
+export const Hero = (): React.JSX.Element => {
+  // The lap repeats for as long as the page is open, so it stops once the headline
+  // has scrolled away rather than running behind the rest of the page.
+  const { ref, inView } = useReveal<HTMLHeadingElement>();
 
-            <Stack gap="sm">
-              {/* Both lines and the paragraph come from `scripts/positioning.ts`,
+  return (
+    <Box component="section" className="hero">
+      <div className="hero-glow" aria-hidden="true" />
+      <Container size="lg">
+        <Grid gutter={{ base: 'xl', md: 48 }} align="center">
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <Stack gap="lg">
+              <Group gap={6}>
+                {site.positioning.chips.map((chip, index) => (
+                  <Badge
+                    key={chip}
+                    variant={index === 0 ? 'light' : 'default'}
+                    size="sm"
+                    tt="none"
+                    radius="sm"
+                  >
+                    {chip}
+                  </Badge>
+                ))}
+              </Group>
+
+              <Stack gap="sm">
+                {/* Both lines and the paragraph come from `scripts/positioning.ts`,
                   which the README is generated from too. */}
-              <h1 className="hero-title">
-                {site.positioning.headline[0]}
-                <br />
-                <span className="gradient-text">
-                  {site.positioning.headline[1]}
-                </span>
-              </h1>
-              <Text size="lg" c="dimmed" maw="46ch">
-                {site.positioning.blurb}
-              </Text>
+                <h1 className="hero-title" ref={ref} data-spark={inView}>
+                  {site.positioning.headline[0]}
+                  <br />
+                  <span className="gradient-text">
+                    {site.positioning.headline[1]}
+                  </span>
+                  {/* Empty and hidden: the heading's text is asserted against
+                    `scripts/positioning.ts`, so the spark must add none. */}
+                  <span className="hero-spark" aria-hidden="true" />
+                </h1>
+                <Text size="lg" c="dimmed" maw="46ch">
+                  {site.positioning.blurb}
+                </Text>
+              </Stack>
+
+              <InstallLine />
+
+              <Group gap="sm">
+                <Button
+                  component="a"
+                  href={href(RouteKind.Guide, 'introduction')}
+                  size="md"
+                >
+                  Get started
+                </Button>
+                <Button
+                  component="a"
+                  href={href(RouteKind.Bench)}
+                  size="md"
+                  variant="default"
+                >
+                  See the benchmarks
+                </Button>
+                <Button
+                  component="a"
+                  href={site.repoUrl}
+                  target="_blank"
+                  size="md"
+                  variant="subtle"
+                >
+                  GitHub
+                </Button>
+              </Group>
+
+              <MeasuredLine />
             </Stack>
+          </Grid.Col>
 
-            <InstallLine />
-
-            <Group gap="sm">
-              <Button
-                component="a"
-                href={href(RouteKind.Guide, 'introduction')}
-                size="md"
-              >
-                Get started
-              </Button>
-              <Button
-                component="a"
-                href={href(RouteKind.Bench)}
-                size="md"
-                variant="default"
-              >
-                See the benchmarks
-              </Button>
-              <Button
-                component="a"
-                href={site.repoUrl}
-                target="_blank"
-                size="md"
-                variant="subtle"
-              >
-                GitHub
-              </Button>
-            </Group>
-
-            <MeasuredLine />
-          </Stack>
-        </Grid.Col>
-
-        <Grid.Col span={{ base: 12, md: 6 }}>
-          <EditorWindow files={FILES} label="A dunx application" />
-        </Grid.Col>
-      </Grid>
-    </Container>
-  </Box>
-);
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <EditorWindow files={FILES} label="A dunx application" />
+          </Grid.Col>
+        </Grid>
+      </Container>
+    </Box>
+  );
+};

--- a/internal/docs/src/harness.tsx
+++ b/internal/docs/src/harness.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from '@mantine/core';
-import { configure, render } from '@testing-library/react';
+import { act, configure, render } from '@testing-library/react';
 import { App } from './App';
 
 /**
@@ -28,3 +28,70 @@ export const mount = (hash: string) => {
  * failure takes longer to report.
  */
 configure({ asyncUtilTimeout: 5_000 });
+
+/** What a suite drives a stubbed observer with. */
+export interface Intersection {
+  /** Reports an intersection to every observer the render subscribed. A property
+      rather than a method, so a suite can destructure it. */
+  readonly fire: (isIntersecting: boolean) => void;
+  /** The elements handed to `observe`, in subscription order. */
+  readonly watched: readonly Element[];
+}
+
+const swap = <T,>(stub: unknown, body: () => T): T => {
+  const real = globalThis.IntersectionObserver;
+  globalThis.IntersectionObserver = stub as typeof IntersectionObserver;
+  try {
+    return body();
+  } finally {
+    globalThis.IntersectionObserver = real;
+  }
+};
+
+/**
+ * Renders with an IntersectionObserver a suite can drive.
+ *
+ * happy-dom ships one that never reports, so a component keyed off the viewport
+ * sits in its initial state forever and a test of what it does when a section
+ * arrives or leaves has to supply the events itself.
+ */
+export const withIntersection = <T,>(body: (io: Intersection) => T): T => {
+  const callbacks: IntersectionObserverCallback[] = [];
+  const watched: Element[] = [];
+
+  class Stub {
+    constructor(callback: IntersectionObserverCallback) {
+      callbacks.push(callback);
+    }
+    observe(node: Element): void {
+      watched.push(node);
+    }
+    disconnect(): void {
+      watched.length = 0;
+    }
+  }
+
+  const fire = (isIntersecting: boolean): void => {
+    if (callbacks.length === 0) {
+      throw new Error('nothing subscribed an IntersectionObserver');
+    }
+    act(() => {
+      for (const callback of callbacks) {
+        callback(
+          [{ isIntersecting }] as unknown as IntersectionObserverEntry[],
+          {} as IntersectionObserver,
+        );
+      }
+    });
+  };
+
+  return swap(Stub, () => body({ fire, watched }));
+};
+
+/**
+ * Renders with the API absent, which is a real browser that does not implement it.
+ * Anything gated on the viewport has to arrive in its final state there rather than
+ * waiting for an event that can never come.
+ */
+export const withoutIntersection = <T,>(body: () => T): T =>
+  swap(undefined, body);

--- a/internal/docs/src/harness.tsx
+++ b/internal/docs/src/harness.tsx
@@ -42,7 +42,19 @@ const swap = <T,>(stub: unknown, body: () => T): T => {
   const real = globalThis.IntersectionObserver;
   globalThis.IntersectionObserver = stub as typeof IntersectionObserver;
   try {
-    return body();
+    const result = body();
+    // The real observer goes back when this returns, so an async body would run
+    // its assertions against a stub that is no longer installed and fail somewhere
+    // unrelated. Checked here rather than in the signature: inference through an
+    // `Exclude<T, Promise<unknown>>` parameter collapses T to `unknown` and takes
+    // every caller's return type with it.
+    const thenable = result as unknown as { then?: unknown } | null;
+    if (typeof thenable?.then === 'function') {
+      throw new Error(
+        'the body must be synchronous: the real IntersectionObserver is restored when it returns',
+      );
+    }
+    return result;
   } finally {
     globalThis.IntersectionObserver = real;
   }
@@ -60,14 +72,23 @@ export const withIntersection = <T,>(body: (io: Intersection) => T): T => {
   const watched: Element[] = [];
 
   class Stub {
-    constructor(callback: IntersectionObserverCallback) {
+    constructor(private readonly callback: IntersectionObserverCallback) {
       callbacks.push(callback);
     }
+
     observe(node: Element): void {
       watched.push(node);
     }
+
+    /**
+     * Drops its own callback, and nothing else. `useReveal` disconnects on unmount,
+     * so a `fire` after that would push state into an unmounted tree: an `act`
+     * warning at best, a pass that means nothing at worst. `watched` is left alone,
+     * being the record of what was observed rather than what is still live.
+     */
     disconnect(): void {
-      watched.length = 0;
+      const at = callbacks.indexOf(this.callback);
+      if (at !== -1) callbacks.splice(at, 1);
     }
   }
 

--- a/internal/docs/src/hero-spark.test.tsx
+++ b/internal/docs/src/hero-spark.test.tsx
@@ -48,6 +48,22 @@ describe('the hero spark', () => {
     });
   });
 
+  test('stops being observed when the hero unmounts', () => {
+    withIntersection(({ fire }) => {
+      const view = render(
+        <MantineProvider>
+          <Hero />
+        </MantineProvider>,
+      );
+      fire(true);
+      view.unmount();
+
+      // `useReveal` disconnects on unmount and the stub drops that callback with
+      // it, so a later event has nothing to push state into.
+      expect(() => fire(true)).toThrow(/nothing subscribed/);
+    });
+  });
+
   test('laps anyway where there is no observer to ask', () => {
     expect(withoutIntersection(titleOf).dataset['spark']).toBe('true');
   });

--- a/internal/docs/src/hero-spark.test.tsx
+++ b/internal/docs/src/hero-spark.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import { render } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { Hero } from './components/Hero';
+import { withIntersection, withoutIntersection } from './harness';
+import { HEADLINE } from '../../../scripts/positioning.js';
+
+const hero = (): HTMLElement =>
+  render(
+    <MantineProvider>
+      <Hero />
+    </MantineProvider>,
+  ).container;
+
+const titleOf = (): HTMLElement => {
+  const title = hero().querySelector('.hero-title');
+  if (!(title instanceof HTMLElement)) throw new Error('no .hero-title');
+  return title;
+};
+
+describe('the hero spark', () => {
+  /* `positioning.test.tsx` asserts the heading's text is exactly the shared
+     headline, so an element added inside it has to carry none. That test would
+     catch this from the other side; this one says why the span is empty. */
+  test('is decorative and adds no text to the heading', () => {
+    const title = withoutIntersection(titleOf);
+    const spark = title.querySelector('.hero-spark');
+
+    expect(spark).not.toBeNull();
+    expect(spark?.textContent).toBe('');
+    expect(spark?.getAttribute('aria-hidden')).toBe('true');
+    expect(title.textContent).toBe(HEADLINE.join(''));
+  });
+
+  test('laps while the headline is on screen, and stops when it is not', () => {
+    withIntersection(({ fire, watched }) => {
+      const title = titleOf();
+      expect(watched).toEqual([title]);
+      expect(title.dataset['spark']).toBe('false');
+
+      fire(true);
+      expect(title.dataset['spark']).toBe('true');
+
+      // The lap repeats for as long as the page is open, so scrolling past the
+      // headline has to end it rather than leave it running behind the page.
+      fire(false);
+      expect(title.dataset['spark']).toBe('false');
+    });
+  });
+
+  test('laps anyway where there is no observer to ask', () => {
+    expect(withoutIntersection(titleOf).dataset['spark']).toBe('true');
+  });
+});

--- a/internal/docs/src/landing.css
+++ b/internal/docs/src/landing.css
@@ -11,6 +11,16 @@
   --accent-a: var(--mantine-color-indigo-5);
   --accent-b: var(--mantine-color-violet-5);
   --accent-c: var(--mantine-color-cyan-5);
+  /* The spark's own two colours, because a glow is read against the page rather
+     than against the accents: on near-black a white core is the spark, and on
+     white the same core is a hole. */
+  --spark-core: var(--mantine-color-white);
+  --spark-sheen: color-mix(
+    in srgb,
+    var(--mantine-color-white) 88%,
+    transparent
+  );
+  --spark-cycle: 9s;
 }
 
 .hero {
@@ -64,23 +74,130 @@
     );
 }
 
+/* Two layers: the sheen the spark drags through the letters, over the gradient
+   itself. The sheen is wider than the text and parked off its right edge, so with
+   no animation running the line looks exactly as it did before. */
 .gradient-text {
-  background: linear-gradient(
-    100deg,
-    var(--mantine-color-indigo-4),
-    var(--mantine-color-violet-4) 42%,
-    var(--mantine-color-cyan-4)
-  );
+  background-image:
+    linear-gradient(
+      96deg,
+      transparent 42%,
+      var(--spark-sheen) 50%,
+      transparent 58%
+    ),
+    linear-gradient(
+      100deg,
+      var(--mantine-color-indigo-4),
+      var(--mantine-color-violet-4) 42%,
+      var(--mantine-color-cyan-4)
+    );
+  background-repeat: no-repeat;
+  background-size:
+    260% 100%,
+    100% 100%;
+  background-position:
+    200% 0,
+    0 0;
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }
 
 .hero-title {
+  position: relative;
   font-size: clamp(2.35rem, 4.6vw, 3.4rem);
   font-weight: 800;
   letter-spacing: -0.035em;
   line-height: 1.02;
+}
+
+/* A spark that runs the headline: one lap of the heading's own box, a sheen
+   dragged through the gradient line as it passes underneath, then a pause before
+   it comes round again.
+
+   `offset-path: border-box` is what makes the lap responsive. It traces the box of
+   the containing block, so the headline wrapping to three lines on a phone needs no
+   breakpoint and no measurement in JavaScript. Where that is unsupported the spark
+   is not rendered at all, because the fallback for an unresolved path is a dot
+   parked in the top-left corner.
+
+   `offset-distance` is the only property the lap animates, and the browser
+   composites it. */
+.hero-spark {
+  display: none;
+}
+
+@supports (offset-path: border-box) {
+  .hero-title[data-spark='true'] .hero-spark {
+    --size: clamp(2.4rem, 4.5vw, 3.4rem);
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: -1;
+    width: var(--size);
+    height: var(--size);
+    border-radius: 50%;
+    pointer-events: none;
+    offset-path: border-box;
+    offset-rotate: 0deg;
+    background: radial-gradient(
+      circle at 50% 50%,
+      var(--spark-core) 0%,
+      color-mix(in srgb, var(--accent-b) 70%, transparent) 22%,
+      color-mix(in srgb, var(--accent-a) 30%, transparent) 46%,
+      transparent 70%
+    );
+    filter: blur(1px);
+    animation: hero-spark var(--spark-cycle) linear infinite;
+  }
+
+  .hero-title[data-spark='true'] .gradient-text {
+    animation: hero-sheen var(--spark-cycle) linear infinite;
+  }
+}
+
+@keyframes hero-spark {
+  0% {
+    offset-distance: 0%;
+    opacity: 0;
+  }
+  4% {
+    opacity: 1;
+  }
+  72% {
+    offset-distance: 100%;
+    opacity: 1;
+  }
+  80%,
+  100% {
+    offset-distance: 100%;
+    opacity: 0;
+  }
+}
+
+/* Timed off the lap, measured rather than guessed. `offset-distance` runs 0 to 100%
+   of the border box over 0% to 72% of the cycle, and a rectangle is not walked in
+   even quarters: the headline's box is far wider than it is tall, so at the desktop
+   size the bottom edge is distance 50% to 88%, which is cycle 36% to 63%. That edge
+   runs right to left along the gradient line, and this is the sheen following it.
+
+   The split shifts with the box's aspect ratio, so on a phone, where the headline
+   wraps to three lines, the sheen leads the spark slightly. Both still cross the
+   same line in the same direction, which is what the eye is following. */
+@keyframes hero-sheen {
+  0%,
+  36% {
+    background-position:
+      200% 0,
+      0 0;
+  }
+  63%,
+  100% {
+    background-position:
+      -110% 0,
+      0 0;
+  }
 }
 
 .install {
@@ -509,12 +626,32 @@
   filter: blur(84px);
 }
 
+/* Both layers restated, because `background-image` is one property: setting the
+   gradient alone here would drop the sheen layer in light mode. */
 [data-mantine-color-scheme='light'] .gradient-text {
-  background-image: linear-gradient(
-    100deg,
-    var(--mantine-color-indigo-7),
-    var(--mantine-color-violet-7) 42%,
-    var(--mantine-color-cyan-8)
+  background-image:
+    linear-gradient(
+      96deg,
+      transparent 42%,
+      var(--spark-sheen) 50%,
+      transparent 58%
+    ),
+    linear-gradient(
+      100deg,
+      var(--mantine-color-indigo-7),
+      var(--mantine-color-violet-7) 42%,
+      var(--mantine-color-cyan-8)
+    );
+}
+
+[data-mantine-color-scheme='light'] .landing {
+  /* A white core disappears into the page, and a white sheen reads as the letters
+     dropping out. Both go up the scale instead. */
+  --spark-core: var(--mantine-color-violet-5);
+  --spark-sheen: color-mix(
+    in srgb,
+    var(--mantine-color-violet-3) 92%,
+    transparent
   );
 }
 
@@ -633,4 +770,16 @@
    vertical rhythm rather than inheriting the section stack's. */
 .speed-lead {
   padding-block: clamp(2rem, 5vw, 3.5rem);
+}
+
+/* Last in the file, and that placement is the point: these selectors carry the
+   same specificity as the ones they turn off, so source order decides. */
+@media (prefers-reduced-motion: reduce) {
+  .hero-title[data-spark='true'] .hero-spark {
+    display: none;
+  }
+
+  .hero-title[data-spark='true'] .gradient-text {
+    animation: none;
+  }
 }

--- a/internal/docs/src/landing.css
+++ b/internal/docs/src/landing.css
@@ -82,7 +82,7 @@
     linear-gradient(
       96deg,
       transparent 42%,
-      var(--spark-sheen) 50%,
+      var(--spark-sheen, transparent) 50%,
       transparent 58%
     ),
     linear-gradient(
@@ -633,7 +633,7 @@
     linear-gradient(
       96deg,
       transparent 42%,
-      var(--spark-sheen) 50%,
+      var(--spark-sheen, transparent) 50%,
       transparent 58%
     ),
     linear-gradient(

--- a/internal/docs/src/reveal.ts
+++ b/internal/docs/src/reveal.ts
@@ -1,24 +1,31 @@
 import { useEffect, useRef, useState } from 'react';
 
 /**
- * Marks an element once it has scrolled into view, so CSS can transition it in.
+ * Tracks an element against the viewport, for CSS to key motion off.
  *
- * The observer is dropped after the first intersection: these are one-shot
- * entrances, and leaving observers attached to every section on a long page
- * costs more than the effect is worth. `prefers-reduced-motion` is honoured in
- * CSS rather than here, so the attribute lands either way and only the
- * transition is dropped.
+ * `revealed` latches on the first intersection and drives the one-shot entrance
+ * transitions. `inView` keeps following, which is what lets a looping animation
+ * stop when nobody is looking at it: an infinite keyframe animation off screen
+ * costs what one on screen costs, and the request pulse in `RequestFlow` runs
+ * for as long as the page is open.
+ *
+ * One observer answers both, so the live half adds no second subscription. It is
+ * no longer disconnected after the first hit for that reason.
+ * `prefers-reduced-motion` is honoured in CSS rather than here, so both flags land
+ * either way and only the motion is dropped.
  */
 export const useReveal = <T extends HTMLElement>(): {
   ref: React.RefObject<T | null>;
   revealed: boolean;
+  inView: boolean;
 } => {
   const ref = useRef<T>(null);
   // Initialized from the capability check rather than set from the effect: with no
-  // observer there is nothing to wait for, so the first paint is the revealed one.
-  const [revealed, setRevealed] = useState(
-    () => typeof IntersectionObserver === 'undefined',
-  );
+  // observer there is nothing to wait for, so the first paint is the revealed one
+  // and the animation runs.
+  const blind = typeof IntersectionObserver === 'undefined';
+  const [revealed, setRevealed] = useState(blind);
+  const [inView, setInView] = useState(blind);
 
   useEffect(() => {
     const node = ref.current;
@@ -28,9 +35,8 @@ export const useReveal = <T extends HTMLElement>(): {
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
-          if (!entry.isIntersecting) continue;
-          setRevealed(true);
-          observer.disconnect();
+          setInView(entry.isIntersecting);
+          if (entry.isIntersecting) setRevealed(true);
         }
       },
       { rootMargin: '0px 0px -12% 0px', threshold: 0.12 },
@@ -40,5 +46,5 @@ export const useReveal = <T extends HTMLElement>(): {
     return () => observer.disconnect();
   }, []);
 
-  return { ref, revealed };
+  return { ref, revealed, inView };
 };


### PR DESCRIPTION
## What changed

A glowing spark runs one lap of the hero headline's own box, dragging a sheen
through the gradient line as it passes underneath, then pauses and comes round
again. Nothing in the hero moved before this.

## Why

Asked for directly: the landing page's first screen was a grid, a fixed glow and
static type.

Three notes on the build:

- **`offset-path: border-box` is what makes the lap responsive.** It traces the box
  of the containing block, so the headline wrapping to three lines on a phone needs
  no breakpoint and no measurement in JavaScript, and `offset-distance` is the only
  property the lap animates. Where it is unsupported the spark is not rendered at
  all, behind `@supports (offset-path: border-box)`, because the fallback for an
  unresolved path is a dot parked in the top-left corner.
- **The heading's text is asserted against `scripts/positioning.ts`**, so the spark
  is an empty `aria-hidden` span, and `hero-spark.test.tsx` holds it that way from
  this side as well.
- **The lap stops when the headline scrolls off.** `useReveal` now also reports
  `inView` from the observer it already created.

## Measurements

**Where the lap actually goes.** A rectangle is not walked in even quarters, so
this was measured rather than assumed. Setting `offset-distance` directly and
reading the spark's centre against the heading's box, at the desktop size
(530x166):

```
  0%  -> x0   y0      top edge, left to right
 12.5% -> x33 y0
 25%  -> x66  y0
 37.5% -> x99 y0      corner
 50%  -> x100 y100    right edge, short
 62.5% -> x67 y100    bottom edge, right to left
 75%  -> x34 y100
 87.5% -> x1  y100
100%  -> x0   y0      left edge back up

gradient line: y 65% to 102% of the box
```

The gradient line sits in the box's lower third, so the bottom edge is the leg that
runs along it. That leg is distance 50 to 88%, which maps to cycle 36% to 63%, and
that is the sheen's window. Verified in flight, phases set through the Web
Animations API rather than a negative `animation-delay` (which shifts the start
time of a running animation instead of setting its phase):

```
cycle 15%  distance 20.8%  sheen  200% (parked)
cycle 33%  distance 45.8%  sheen  200% (parked)
cycle 40%  distance 55.6%  sheen  154%   <- entering the line
cycle 50%  distance 69.4%  sheen   39%
cycle 60%  distance 83.3%  sheen  -76%   <- leaving it
cycle 68%  distance 94.4%  sheen -110% (parked)
```

**`prefers-reduced-motion: reduce`**: zero animations on both elements,
`.hero-spark` at `display: none`, and 20 samples over 1.2s return one distinct
frame with the sheen parked off the right edge, so the line renders exactly as it
did before. Without the query: two animations, `offset-distance` advancing
smoothly.

**Per scheme.** A white core is the spark on near-black and a hole on white, so
light mode takes violet-5 for the core and a violet-3 sheen. Checked at 1200px and
390px in both schemes. One trap worth flagging in review: the light-mode
`.gradient-text` override had to restate **both** background layers, since
`background-image` is one property and setting the gradient alone silently dropped
the sheen.

## Checks

- [x] `bun run build`
- [x] `bun run lint:check`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test:cov`
- [x] Tests cover the change: the spark contributes no text to the heading, the lap
      follows the viewport, and it runs anyway where there is no observer.
- [x] Conventional commit messages (`feat:`, `fix:`, `docs:`, ...).
- [x] No em or en dashes. No `enum`, no `any`, no `Dunx`-prefixed identifiers.
- [x] New runtime dependency? None.
- [x] Docs updated if the public surface changed. No public surface changed.

`bun run ci` is green, 12 of 12 steps.

## Overlap with #14

Both branches add `inView` to `internal/docs/src/reveal.ts`, and the change is
byte-identical, so whichever merges second merges cleanly. #14 animates the request
diagram further down the page; this is the hero. They are independent, and if the
hero is the only one you want, closing #14 costs nothing here.

One tidy-up left for whenever both land: #14's `request-flow.test.tsx` carries its
own IntersectionObserver stub, and this PR puts the shared one in `harness.tsx`.
That suite should move onto the shared helper so there is one copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a decorative animated spark effect around the hero heading.
  - Added animated gradient and spark styling, including light-mode support.
  - Added reduced-motion support to disable decorative animations.

- **Accessibility**
  - Decorative spark content is excluded from accessible heading text.
  - Animations are disabled for users who prefer reduced motion.
  - Added graceful fallback behavior when animation observation is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->