### PR TITLE
feat(infra): @arkv/logger 0.12, and drain the logger on the way out

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -228,7 +228,7 @@
       "name": "@dunx/infra",
       "version": "3.0.3",
       "dependencies": {
-        "@arkv/logger": "^0.10.2",
+        "@arkv/logger": "^0.12.0",
         "@arkv/timezones": "^0.0.2",
       },
       "devDependencies": {
@@ -347,7 +347,7 @@
 
     "@arkv/colors": ["@arkv/colors@0.8.0", "", {}, "sha512-r4xt9tTUpeEgfOnKfVfdvP1QMgX4aMQtK1z12sGbB85hEqH6ijBiugZbKAo7HqfCaHtIXycX3diptQL+OfcimA=="],
 
-    "@arkv/logger": ["@arkv/logger@0.10.2", "", { "dependencies": { "@arkv/colors": "^0.8.0", "@arkv/shared": "^0.8.0" } }, "sha512-VMkH1Bb1VhyHhMIyIpgsqfcEhQpqy/tvirFfiCuwPH2xfRom83WSGFCTvUdZE4OlJLGK3usmV81pKXObMnzDXg=="],
+    "@arkv/logger": ["@arkv/logger@0.12.0", "", { "dependencies": { "@arkv/colors": "^0.8.0", "@arkv/shared": "^0.8.0" } }, "sha512-+T8Guxk9iH5mLwiytfGcbJ8ozeELbyRm89ZCPuwT829w+nu3Uvd6+kaT0OT6/PMsiGcW4FH573T7sZC50ywTQw=="],
 
     "@arkv/shared": ["@arkv/shared@0.8.0", "", {}, "sha512-c9YTix/b35KTEmIl+qlyjm74SzqWEXXcvwr4rqhYPWr7ihirdSaydOFFNFQSyQYgefVOc4JEKdpb4gOhSsKcrA=="],
 

--- a/docs/guide/13-logging.md
+++ b/docs/guide/13-logging.md
@@ -284,10 +284,57 @@ const fileAndConsole = (path: string): Transport[] => [
 ```
 
 `FileTransport` buffers, which is safe here because `LoggerModule` registers a
-lifecycle provider that flushes and closes it from `onShutdown`. That hook runs
-late: `App.shutdown` walks instances in reverse resolution order and the logger
-resolves before anything that depends on it, so services can still log while they
-close.
+lifecycle provider that drains it from `onShutdown`. That hook runs late:
+`App.shutdown` walks instances in reverse resolution order and the logger resolves
+before anything that depends on it, so services can still log while they close.
+
+It drains with `closeAsync`, and the await matters for anything reached over a
+network. A file is written synchronously and either form finishes it; a collector
+cannot answer synchronously at all, so a plain `close()` discards whatever it was
+holding and every deploy loses its last batch.
+
+### Shipping somewhere other than a file
+
+`HttpTransport` covers the collectors that differ only in the shape of the body:
+
+```ts
+import { HttpTransport, SamplingTransport } from '@dunx/infra/logger';
+
+new HttpTransport({
+  url: 'https://logs.example.com/ingest',
+  headers: { authorization: `Bearer ${token}` },
+  batchSize: 200,
+  flushIntervalMs: 2000,
+});
+```
+
+`encode` is the seam: Datadog wants a JSON array, Splunk HEC concatenated objects,
+Loki streams and values. `SyslogTransport` speaks RFC 5424 over UDP or TCP, and
+anything else that batches is a subclass of `BatchTransport`, which owns the
+bounded queue, the retry and the drop accounting.
+
+`SamplingTransport` wraps another transport to thin what reaches it. Warnings and
+worse are never sampled, and every discard is announced in the stream rather than
+being silent.
+
+`logger.stats()` on the `BackingLogger` token reports what each transport is
+holding and what it has dropped, which is what an alert on "we are losing logs"
+reads.
+
+### Output formats
+
+`format` on any transport takes one of four:
+
+| Formatter      | Emits                                            |
+| -------------- | ------------------------------------------------ |
+| `jsonFormat`   | `{"level":"info","message":"order placed",…}`    |
+| `prettyFormat` | the same JSON, ANSI-coloured for a terminal      |
+| `textFormat`   | `09:00:15.123 INFO  order placed  requestId=r-1` |
+| `logfmtFormat` | `level=info msg="order placed" order.id=ord_1`   |
+
+`examples/full` reads `LOG_FORMAT` and wires whichever you name. A file always
+takes a machine format even when the console does not, since nothing reads a log
+file with its eyes first.
 
 ### `captureGlobalErrors`
 

--- a/examples/full/src/app.module.ts
+++ b/examples/full/src/app.module.ts
@@ -3,7 +3,11 @@ import { ConfigModule, Module } from '@dunx/core';
 import {
   ConsoleTransport,
   FileTransport,
+  jsonFormat,
+  logfmtFormat,
+  type LogFormatter,
   LoggerModule,
+  textFormat,
   type Transport,
 } from '@dunx/infra/logger';
 import { AccountsModule } from './auth/auth.module.js';
@@ -28,14 +32,31 @@ import { Tour } from './tour/tour.service.js';
 import { UsersModule } from './users/users.module.js';
 import { WiringModule } from './wiring/wiring.module.js';
 
+/**
+ * JSON is what a log shipper reads; the other two are for a person and for a
+ * `key=value` reader. `undefined` leaves `ConsoleTransport` on its own default,
+ * which is coloured JSON at a terminal and plain JSON anywhere else.
+ */
+const formatters: Record<string, LogFormatter | undefined> = {
+  json: undefined,
+  text: textFormat,
+  logfmt: logfmtFormat,
+};
+
 /** `transports` replaces the console sink, so keeping stdout means naming it. */
-const fileAndConsole = (path: string): Transport[] => [
-  new ConsoleTransport(),
+const fileAndConsole = (
+  path: string,
+  format: LogFormatter | undefined,
+): Transport[] => [
+  new ConsoleTransport(format === undefined ? {} : { format }),
   new FileTransport({
     path,
     interval: 'daily',
     maxFiles: 7,
     bufferBytes: 16 * 1024,
+    // A file is read by a machine even when the console is not, so it never
+    // takes the terminal formatter.
+    format: format === logfmtFormat ? logfmtFormat : jsonFormat,
   }),
 ];
 
@@ -50,12 +71,15 @@ const fileAndConsole = (path: string): Transport[] => [
       {
         useFactory: (config: AppConfigService) => {
           const log = config.get('log');
+          const format = formatters[log.format];
           return {
             name: config.get('appName'),
             level: log.level,
             ...(log.file === undefined
-              ? {}
-              : { transports: fileAndConsole(log.file) }),
+              ? format === undefined
+                ? {}
+                : { transports: [new ConsoleTransport({ format })] }
+              : { transports: fileAndConsole(log.file, format) }),
           };
         },
         inject: [AppConfigService] as const,

--- a/examples/full/src/config.ts
+++ b/examples/full/src/config.ts
@@ -16,6 +16,12 @@ const envSchema = z.object({
    * `req.clone().text()`, and the pair costs about two thirds of the throughput
    * on `internal/bench`'s `validate` scenario.
    */
+  /**
+   * How an entry is rendered. `json` is what a shipper reads, `text` is the
+   * human line for a terminal, `logfmt` is the `key=value` shape Loki and Splunk
+   * parse without a schema.
+   */
+  LOG_FORMAT: z.enum(['json', 'text', 'logfmt']).default('json'),
   LOG_REQUEST_BODY: z.stringbool().default(true),
   LOG_RESPONSE_BODY: z.stringbool().default(true),
   CORS_ORIGIN: z.string().default('https://example.com'),
@@ -49,6 +55,7 @@ export interface AppConfig {
   readonly log: {
     readonly level: LogLevel;
     readonly file: string | undefined;
+    readonly format: 'json' | 'text' | 'logfmt';
     readonly requestBody: boolean;
     readonly responseBody: boolean;
   };
@@ -86,6 +93,7 @@ export const validate = (env: ConfigSource): AppConfig => {
     log: {
       level: value.LOG_LEVEL,
       file: value.LOG_FILE,
+      format: value.LOG_FORMAT,
       requestBody: value.LOG_REQUEST_BODY,
       responseBody: value.LOG_RESPONSE_BODY,
     },

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -100,7 +100,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@arkv/logger": "^0.10.2",
+    "@arkv/logger": "^0.12.0",
     "@arkv/timezones": "^0.0.2"
   },
   "devDependencies": {

--- a/packages/infra/src/logger/index.ts
+++ b/packages/infra/src/logger/index.ts
@@ -10,8 +10,14 @@ export {
   type LogMessage,
   type SerializedError,
 } from '@dunx/core';
-// The implementation's own surface. dunx restates none of it.
+// The implementation's own surface. dunx restates none of it, which is what keeps
+// a new transport upstream reachable here by adding a name rather than a wrapper.
+// `StreamTransport` was missing from this list and unreachable through the subpath
+// despite shipping, which is the failure mode a hand-written re-export has.
 export {
+  BatchTransport,
+  type BatchedEntry,
+  type BatchTransportOptions,
   type CaptureGlobalErrorsOptions,
   captureGlobalErrors,
   ConsoleTransport,
@@ -20,7 +26,11 @@ export {
   DEFAULT_MASK_FIELDS,
   FileTransport,
   type FileTransportOptions,
+  HttpDeliveryError,
+  HttpTransport,
+  type HttpTransportOptions,
   jsonFormat,
+  logfmtFormat,
   type LogFormatter,
   type LoggerConfig,
   prettyFormat,
@@ -28,7 +38,16 @@ export {
   RESERVED_ENTRY_KEYS,
   type RotationInterval,
   type RunWithContextOptions,
+  SamplingTransport,
+  type SamplingOptions,
+  StreamTransport,
+  type StreamTransportOptions,
+  type SyslogProtocol,
+  SyslogTransport,
+  type SyslogTransportOptions,
+  textFormat,
   type Transport,
+  type TransportStats,
 } from '@arkv/logger';
 export {
   BackingLogger,

--- a/packages/infra/src/logger/module.test.ts
+++ b/packages/infra/src/logger/module.test.ts
@@ -383,3 +383,103 @@ describe('LoggerModule', () => {
     expect(process.listenerCount('unhandledRejection')).toBe(unhandled);
   });
 });
+
+/**
+ * A sink that can only answer asynchronously, which is every collector reached
+ * over a network. `close()` on one discards what it is holding; `closeAsync()` is
+ * the half that drains.
+ */
+class AsyncSink implements Transport {
+  readonly sent: string[] = [];
+  #queued: string[] = [];
+  closedSync = false;
+
+  write(entry: { message?: unknown }): void {
+    this.#queued.push(String(entry['message']));
+  }
+
+  close(): void {
+    // What a sync shutdown does to a batch: it is simply gone.
+    this.closedSync = true;
+    this.#queued = [];
+  }
+
+  async closeAsync(): Promise<void> {
+    await Bun.sleep(1);
+    this.sent.push(...this.#queued);
+    this.#queued = [];
+  }
+}
+
+describe('shutting the logger down', () => {
+  it('drains a transport that can only answer asynchronously', async () => {
+    const sink = new AsyncSink();
+
+    @Module({ imports: [LoggerModule.forRoot({ transports: [sink] })] })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    app.get(Logger).info('the last thing before the pod goes away');
+    await app.shutdown();
+
+    // Without the await this entry was discarded on every deploy.
+    expect(sink.sent).toEqual(['the last thing before the pod goes away']);
+    expect(sink.closedSync).toBe(false);
+  });
+
+  it('still closes a transport that only answers synchronously', async () => {
+    let closed = false;
+    const sink: Transport = {
+      write: () => undefined,
+      close: () => {
+        closed = true;
+      },
+    };
+
+    @Module({ imports: [LoggerModule.forRoot({ transports: [sink] })] })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    await app.shutdown();
+
+    expect(closed).toBe(true);
+  });
+});
+
+describe('the backing logger', () => {
+  it('can be turned to debug on a running app, children included', async () => {
+    const sink = new MemoryTransport();
+
+    @Module({
+      imports: [
+        LoggerModule.forRoot({ level: LogLevel.INFO, transports: [sink] }),
+      ],
+    })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    const backing = app.get(BackingLogger);
+    const child = backing.child({ module: 'orders' });
+
+    child.debug('before');
+    backing.setLevel(BackingLogLevel.DEBUG);
+    child.debug('after');
+    await app.shutdown();
+
+    expect(sink.entries.map((each) => each['message'])).toEqual(['after']);
+  });
+
+  it('reports what its transports are holding', async () => {
+    const sink = new MemoryTransport();
+
+    @Module({ imports: [LoggerModule.forRoot({ transports: [sink] })] })
+    class Root {}
+
+    const app = await AppFactory.create(Root);
+    const stats = app.get(BackingLogger).stats();
+    await app.shutdown();
+
+    // MemoryTransport keeps no counters, so it reports none rather than zeroes.
+    expect(stats).toEqual([]);
+  });
+});

--- a/packages/infra/src/logger/module.ts
+++ b/packages/infra/src/logger/module.ts
@@ -29,9 +29,14 @@ export const LoggerSettings = token<LoggerConfig>('LoggerConfig');
  * The same instance `Logger` resolves to, typed as the implementation.
  *
  * Core's contract covers the six levels and nothing else, on purpose. The
- * implementation carries three things beyond it - `child(bindings)`,
- * `flush()` and `close()` - and this token is how an app reaches them without
- * a cast or an adapter class widening the contract for everyone.
+ * implementation carries more than that - `child(bindings)`, `setLevel(level)`,
+ * `stats()`, `flush()`/`close()` and their awaited counterparts - and this token
+ * is how an app reaches them without a cast or an adapter class widening the
+ * contract for everyone.
+ *
+ * `setLevel` is the one worth knowing about: it moves this logger and every child
+ * it made, so a `SIGUSR2` handler resolving this token can turn a running process
+ * to debug without a restart.
  */
 export const BackingLogger = token<ArkvLogger>('BackingLogger');
 
@@ -75,10 +80,17 @@ class LoggerLifecycle implements OnInit, OnShutdown {
    * Runs late: `App.shutdown` walks instances in reverse resolution order, and
    * the logger resolves before anything that depends on it, so those services
    * can still log while they close.
+   *
+   * **`closeAsync`, and the await is the point.** A `FileTransport` writes
+   * synchronously and either form drains it, but a transport whose sink is a
+   * network cannot answer synchronously at all: `close()` on one discards
+   * whatever it was holding, so every deploy lost the last batch of logs before
+   * the pod went away. `@dunx/core` declares `onShutdown(): void | Promise<void>`
+   * and `App.shutdown` awaits it, so this costs nothing to arrange.
    */
-  onShutdown(): void {
+  async onShutdown(): Promise<void> {
     this.#release?.();
-    this.logger.close();
+    await this.logger.closeAsync();
   }
 }
 


### PR DESCRIPTION
Moves `@arkv/logger` from 0.10.2 to 0.12.0 and wires up what that brings: the
network transports, `textFormat` and `logfmtFormat`, `setLevel`, `stats()` and the
async half of the transport contract.

## The bug this was waiting to hit

`LoggerLifecycle.onShutdown` called `close()`, which is synchronous. That was fine
while a file was the only sink: `FileTransport` writes with `writeSync` and either
form drains it. A transport whose sink is a network **cannot answer synchronously
at all**, so `close()` on one discards whatever it is holding, and an app shipping
to a collector would have lost its last batch on every deploy.

`@dunx/core` already declares `onShutdown(): void | Promise<void>` and
`App.shutdown` already awaits it, so the fix is one `await`:

```ts
async onShutdown(): Promise<void> {
  this.#release?.();
  await this.logger.closeAsync();
}
```

Covered by a test using a transport that can only answer asynchronously, and
**verified by mutation**: restoring the sync `close()` fails that test and nothing
else.

## Surface

The subpath re-exports the new names and restates none of them, which is what lets
a transport added upstream arrive here as a name rather than a wrapper:
`BatchTransport`, `HttpTransport`, `SyslogTransport`, `SamplingTransport`,
`textFormat`, `logfmtFormat`, `TransportStats`.

That list is also where **`StreamTransport` had been missing since it shipped** —
reachable from `@arkv/logger`, not from `@dunx/infra/logger`. Exactly the failure
mode a hand-written re-export has, and the reason the comment above it now says so.

Two more reachable through `BackingLogger` without widening core's contract:
`setLevel(level)`, which moves a logger and every child it made so a `SIGUSR2`
handler can turn a running process to debug, and `stats()`, which reports what each
transport is holding and has dropped.

## Rule 4

`examples/full` reads `LOG_FORMAT`, so `json`, `text` and `logfmt` are exercised by
an app CI boots rather than by a documented option nobody runs:

```
text    09:53:06.313 INFO    order placed  pid=278077 requestId=r-1 order={"id":"ord_1","total":4200}
logfmt  level=info time=2026-08-29T09:53:06.374Z msg="order placed" requestId=r-1 order.id=ord_1 order.total=4200
```

A file takes a machine format even when the console does not, since nothing reads a
log file with its eyes first.

## Checks

`bun run ci`: 12/12 green. Coverage unchanged at 96.1% lines / 94.1% functions,
`infra` at 93.6%/93.1%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable JSON, text, and logfmt output formats for console and file logging.
  * Expanded logging capabilities with HTTP, syslog, stream, batching, sampling, formatting, and transport statistics support.
  * Added runtime log-level updates and asynchronous log flushing during shutdown.
* **Bug Fixes**
  * Improved shutdown handling to ensure buffered network logs are delivered before exit.
* **Documentation**
  * Expanded the logging guide with transport, formatting, statistics, and asynchronous shutdown guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->