### PR TITLE
feat(core): an error carries the status it means, whoever raised it

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@ other.
 | `@dunx/testing`    | Bindings replaced in place, a real `Bun.serve` on port 0                                    |
 | `@dunx/auth`       | better-auth mounted, `SessionGuard`, `Bun.password` hashing                                 |
 | `@dunx/dashboard`  | Opt-in ops page, one middleware, bull-board mounted for queues                              |
-| `@dunx/create-app` | `bunx @dunx/create-app my-api` - base template plus feature folders                         |
+| `@dunx/create-app` | `bunx @dunx/create-app my-api` - an arrow-key feature list, base template plus folders      |
 | `@dunx/mcp`        | MCP server that reads an app's routes, providers and modules                                |
 
 Five of those are a library wired in rather than dunx code - never invent what a
@@ -29,7 +29,9 @@ drives `bun:sqlite`/`Bun.SQL` through its own Bun adapters; `bullmq` is one too 
 reaches Redis through `createBunRedisClient`; `swagger-ui-dist` is the `/docs` page
 and is optional too; `better-auth` is a required peer of `@dunx/auth`; `@arkv/logger`
 is a `dependency` and satisfies core's `Logger` contract structurally, with no
-adapter class in between.
+adapter class in between - and since 0.12 it brings the HTTP, syslog and sampling
+transports, `textFormat`/`logfmtFormat`, `setLevel` and `stats()`, all of which
+`@dunx/infra/logger` re-exports rather than restates.
 
 ## Priority: the core three, until someone who is not the owner files an issue
 
@@ -284,11 +286,11 @@ carrying both. The hang itself is still open and is upstream's; see the roadmap 
 delivered rather than marking it done, so the folder only ever holds open work.
 Feedback goes in as a new file rather than into conversation.
 
-| Item                                                                                            | Shape                                                                        |
-| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| [class-modules-and-opt-in-config](../internal/notes/roadmap/class-modules-and-opt-in-config.md) | **P1.** Requested. Partly shipped; W1, W1b, W2 and W6 remain.                |
-| [queue-shutdown-sigterm](../internal/notes/roadmap/queue-shutdown-sigterm.md)                   | One upstream defect left, in bullmq's Bun adapter. Bun 1.4 fixed the other.  |
-| [bun-1.4-adoption](../internal/notes/roadmap/bun-1.4-adoption.md)                               | Five adopt items, one rejected on measurement, four defects closed for free. |
+| Item                                                                                            | Shape                                                                       |
+| ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [class-modules-and-opt-in-config](../internal/notes/roadmap/class-modules-and-opt-in-config.md) | **P1.** Requested. Partly shipped; W1, W1b, W2 and W6 remain.               |
+| [queue-shutdown-sigterm](../internal/notes/roadmap/queue-shutdown-sigterm.md)                   | One upstream defect left, in bullmq's Bun adapter. Bun 1.4 fixed the other. |
+| [bun-1.4-adoption](../internal/notes/roadmap/bun-1.4-adoption.md)                               | A1 partly adopted: `--parallel` is in the `unit` phase. A2-A5 open.         |
 
 Delivered and moved out of this folder rather than left here marked done:
 
@@ -309,6 +311,16 @@ Delivered and moved out of this folder rather than left here marked done:
 - **the landing page** - the hero, the lifecycle drawing, the motion and the light
   palette are built; what remains is judgement about the benchmark panel rather than
   work.
+- **the scaffolder's interface** - `bunx @dunx/create-app` asks with an arrow-key
+  list instead of taking `--with`, `--all`, `--list` and `--template`. The list shows
+  what a selection pulls in and what needs a service running, which a flag cannot.
+  Built on `setRawMode` and tested through `Bun.spawn({ terminal })`, a real PTY;
+  both are recorded in [bun-apis.md](./bun-apis.md).
+- **`@arkv/logger` 0.12** - the upstream work landed there rather than here, which is
+  the "improvements go into the `@arkv` repo" rule doing its job. What dunx changed is
+  one line: `LoggerLifecycle.onShutdown` drains with `closeAsync`, because a transport
+  whose sink is a network discards its queue on a synchronous `close()` and an app
+  shipping to a collector lost its last batch on every deploy.
 
 ### From porting nestjs-template to dunx-template
 

--- a/docs/guide/08-middleware-and-guards.md
+++ b/docs/guide/08-middleware-and-guards.md
@@ -413,6 +413,14 @@ export const errorMapper =
         { status: error.status },
       );
     }
+    // Any `AppError` that named a status, whoever raised it.
+    if (error instanceof AppError && isStatus(error.status)) {
+      if (error.status >= 500) logger.error('Unhandled error', error);
+      return Response.json(
+        { error: error.message, status: error.status },
+        { status: error.status },
+      );
+    }
     logger.error('Unhandled error', error);
     return Response.json(
       {
@@ -452,6 +460,38 @@ const app = await HttpFactory.create(AppModule, {
 ```
 
 Falling through to `defaultErrorMapper` is the normal way to handle the rest.
+
+### An error is mapped by whoever raised it
+
+`AppError` carries an optional `status`, and that is how a package with no business
+importing the web layer still says what its failure means:
+
+```ts
+export class CursorError extends AppError {
+  override readonly name = 'CursorError';
+  override readonly status = 400;
+}
+```
+
+An integer is not a dependency. `@dunx/infra` must not import `@dunx/http`, so it
+cannot raise an `HttpError` or ship a filter that constructs one; it can set a
+number, and the default mapper reads it. `CursorError` and `PageOptionsError` in
+`@dunx/infra/pagination` already do, so a bad cursor is a 400 in an app that wrote
+no `catch` at all.
+
+Two details that follow from where the number is set:
+
+- **A 4xx is not logged as an incident.** It is the caller's mistake, and logging
+  one at error level is how a log fills with entries nobody can act on. A status of
+  500 or above still logs.
+- **The value is range-checked.** It is set by hand in a package that never sees a
+  `Response`, so a typo would otherwise reach `Response.json` as `status: 4000` and
+  throw a `RangeError` from the error path itself. Anything outside 200 to 599 falls
+  back to a 500.
+
+An `AppError` with no status is a 500 with its message withheld, which is the right
+answer for something like `CircularDependencyError`: a boot failure is not a
+response.
 
 ### `ErrorFilter`, when the mapper needs dependencies
 

--- a/docs/guide/14-database.md
+++ b/docs/guide/14-database.md
@@ -700,9 +700,10 @@ asynchronous `Bun.SQL` one.
   document.
 - **No total count.** `hasNextPage` comes from fetching one row more than asked and
   dropping it, so there is no second `COUNT(*)`.
-- **No HTTP error.** A bad cursor throws `CursorError`; bad options throw
-  `PageOptionsError`. `@dunx/infra` must not depend on the web layer, so mapping them
-  to a 400 is yours.
+- **A 400 without a filter.** A bad cursor throws `CursorError`; bad options throw
+  `PageOptionsError`. Both extend `AppError` and carry `status = 400`, which is an
+  integer rather than a dependency on the web layer, and `@dunx/http`'s default
+  mapper turns it into the response. You write no `catch`.
 
 `examples/full` serves it at `GET /api/ledger/page`.
 

--- a/examples/full/src/service.test.ts
+++ b/examples/full/src/service.test.ts
@@ -113,6 +113,37 @@ it('serves the ledger over drizzle, seeded at onInit', async () => {
   expect(typeof page.balance).toBe('number');
 });
 
+it('answers a bad cursor with a 400 that nothing in this app maps', async () => {
+  const { status, body } = await json<{ error: string; status: number }>(
+    'ledger/page?cursor=not-a-cursor',
+  );
+
+  // `CursorError` is raised by `@dunx/infra/pagination`, which must not depend on
+  // the web layer and so cannot raise an `HttpError`. It carries `status = 400`
+  // instead, and `@dunx/http`'s default mapper reads it. No controller here
+  // catches anything: that `catch` used to be the app's to write.
+  expect(status).toBe(400);
+  expect(body.status).toBe(400);
+});
+
+it('walks the ledger by cursor', async () => {
+  const first = await json<{
+    data: unknown[];
+    meta: { nextCursor: string | null };
+  }>('ledger/page?take=1');
+
+  expect(first.status).toBe(200);
+  expect(first.body.data).toHaveLength(1);
+
+  const cursor = first.body.meta.nextCursor;
+  if (cursor !== null) {
+    const second = await json<{ data: unknown[] }>(
+      `ledger/page?take=1&cursor=${encodeURIComponent(cursor)}`,
+    );
+    expect(second.status).toBe(200);
+  }
+});
+
 it('rolls a transfer back as one unit, observably', async () => {
   const entries = async (): Promise<number> =>
     (await json<{ entries: unknown[] }>('ledger')).body.entries.length;

--- a/internal/notes/roadmap/class-modules-and-opt-in-config.md
+++ b/internal/notes/roadmap/class-modules-and-opt-in-config.md
@@ -360,6 +360,18 @@ there, and even those are a candidate for a `logStartup` option.
 
 ### W2 - an error is mapped by whoever raised it
 
+**Half shipped.** `AppError` carries an optional `status`, `@dunx/http`'s default
+mapper honours any error that names one and range-checks it, a 4xx no longer logs as
+an incident, and `CursorError`/`PageOptionsError` declare 400 - so the `catch` that
+used to be in the `CursorError` doc comment is deleted rather than documented.
+
+**What remains is the `bun:sqlite` half, and it is blocked on a design decision
+rather than on effort.** The plan says `@dunx/infra/db` catches `SQLiteError`, reads
+the constraint code and rethrows `DatabaseError` with 409 or 400. There is nowhere to
+catch it: drizzle owns the call, `@dunx/infra/db` has no interception point, and
+adding one means wrapping every query or making the repository base class mandatory.
+Both are larger than the item and neither is obviously right. Pick the seam first.
+
 `error-mapper.ts` is 130 lines and only about 20 are the app's own errors. The rest is
 knowledge that belongs to the package that produced the error:
 

--- a/packages/core/src/di/errors.ts
+++ b/packages/core/src/di/errors.ts
@@ -1,5 +1,19 @@
 export class AppError extends Error {
   override name = 'AppError';
+  /**
+   * The HTTP status this error should become, if it should become one.
+   *
+   * **An integer is not the web layer**, which is the whole point: `@dunx/infra`
+   * must not depend on `@dunx/http`, so it cannot raise an `HttpError` or ship a
+   * filter that imports one. It can declare a number. `@dunx/http`'s default
+   * mapper honours any `AppError` carrying one and sends everything else to 500,
+   * so the package that raised an error owns what it means without the two
+   * packages knowing about each other.
+   *
+   * Undefined is not "no opinion, use 500" by accident: it is the honest answer
+   * for a `CircularDependencyError`, which is a boot failure and not a response.
+   */
+  readonly status?: number;
 }
 
 export class CircularDependencyError extends AppError {

--- a/packages/http/src/client/errors.ts
+++ b/packages/http/src/client/errors.ts
@@ -24,7 +24,7 @@ export class FetchError extends AppError {
   override readonly name = 'FetchError';
 
   constructor(
-    readonly status: number,
+    override readonly status: number,
     readonly statusText: string,
     /** The response body, parsed as JSON when it was, else text, else undefined. */
     readonly body: unknown,

--- a/packages/http/src/server/error-status.test.ts
+++ b/packages/http/src/server/error-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test';
+import { AppError, ConsoleLogger, type Logger } from '@dunx/core';
+import { errorMapper } from './errors.js';
+
+/** Records what the mapper logged, so a 4xx logged as an incident is visible. */
+class RecordingLogger extends ConsoleLogger {
+  readonly errors: string[] = [];
+  override error(message: unknown, ...rest: unknown[]): void {
+    this.errors.push(String(message));
+    void rest;
+  }
+}
+
+/**
+ * What a package with no business importing `@dunx/http` can declare: an integer.
+ * `CursorError` and `PageOptionsError` in `@dunx/infra/pagination` are this shape.
+ */
+class OutsideError extends AppError {
+  override readonly name = 'OutsideError';
+  constructor(
+    message: string,
+    override readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+const map = async (
+  error: unknown,
+  logger: Logger = new ConsoleLogger(),
+): Promise<{ status: number; body: Record<string, unknown> }> => {
+  const response = await errorMapper(logger)(error, new Request('http://x/'));
+  return {
+    status: response.status,
+    body: (await response.json()) as Record<string, unknown>,
+  };
+};
+
+describe('an AppError that named a status', () => {
+  it('becomes that status, without importing the web layer to say so', async () => {
+    const { status, body } = await map(new OutsideError('bad cursor', 400));
+
+    expect(status).toBe(400);
+    expect(body['status']).toBe(400);
+    expect(body['error']).toBe('bad cursor');
+  });
+
+  it('does not log a 4xx as an incident', async () => {
+    const logger = new RecordingLogger();
+    await map(new OutsideError('bad cursor', 400), logger);
+
+    // The caller's mistake, not the server's. Logging it at error level is how a
+    // log fills with entries nobody can act on.
+    expect(logger.errors).toEqual([]);
+  });
+
+  it('still logs a 5xx it was handed', async () => {
+    const logger = new RecordingLogger();
+    const { status } = await map(
+      new OutsideError('upstream gone', 502),
+      logger,
+    );
+
+    expect(status).toBe(502);
+    expect(logger.errors).toEqual(['Unhandled error']);
+  });
+
+  it('sends an AppError with no status to 500, message withheld', async () => {
+    const { status, body } = await map(new AppError('internal detail'));
+
+    expect(status).toBe(500);
+    // A boot failure is not a response, and its message is not the caller's.
+    expect(body['error']).toBe('Internal Server Error');
+  });
+
+  it('sends a plain Error to 500', async () => {
+    expect((await map(new Error('boom'))).status).toBe(500);
+  });
+});
+
+describe('a status that could not be a response', () => {
+  // The integer is set by hand in a package that never sees `Response`, so a typo
+  // reaching `Response.json` would be a RangeError thrown from the error path.
+  for (const bad of [0, 99, 600, 4000, -1, 1.5, Number.NaN]) {
+    it(`falls back to 500 rather than throwing on ${bad}`, async () => {
+      const { status } = await map(new OutsideError('typo', bad));
+
+      expect(status).toBe(500);
+    });
+  }
+
+  it('accepts the edges that are real', async () => {
+    expect((await map(new OutsideError('a', 200))).status).toBe(200);
+    expect((await map(new OutsideError('b', 599))).status).toBe(599);
+  });
+});

--- a/packages/http/src/server/errors.ts
+++ b/packages/http/src/server/errors.ts
@@ -15,7 +15,9 @@ export class HttpError extends AppError {
   readonly headers: Readonly<Record<string, string>> | undefined;
 
   constructor(
-    readonly status: number,
+    // Narrows `AppError`'s optional status to a required one: an `HttpError`
+    // exists to name a status, so there is no version of it without one.
+    override readonly status: number,
     message: string,
     options?: HttpErrorOptions,
   ) {
@@ -142,6 +144,24 @@ export const errorMapper =
         },
       );
     }
+    /**
+     * Any `AppError` that named a status, which is how a package with no business
+     * importing the web layer still says what its failure means. `@dunx/infra`
+     * cannot raise an `HttpError` without depending on `@dunx/http`; it can set an
+     * integer. Nothing is logged at error level here: a 4xx is the caller's
+     * mistake, not the server's, and logging one as an incident is how a log fills
+     * with noise nobody can act on.
+     */
+    if (error instanceof AppError && isStatus(error.status)) {
+      if (error.status >= HttpStatusCode.INTERNAL_SERVER_ERROR) {
+        logger.error('Unhandled error', error);
+      }
+      return Response.json(
+        { error: error.message, status: error.status },
+        { status: error.status },
+      );
+    }
+
     logger.error('Unhandled error', error);
     return Response.json(
       {
@@ -151,6 +171,17 @@ export const errorMapper =
       { status: HttpStatusCode.INTERNAL_SERVER_ERROR },
     );
   };
+
+/**
+ * A status a response can actually carry. A package outside `@dunx/http` sets this
+ * by hand, so a typo reaching `Response.json` as `status: 4000` would be a
+ * `RangeError` thrown from the error path itself.
+ */
+const isStatus = (value: number | undefined): value is number =>
+  value !== undefined &&
+  Number.isInteger(value) &&
+  value >= 200 &&
+  value <= 599;
 
 /**
  * The same mapper with no container behind it, for `buildRoutes` and

--- a/packages/infra/src/pagination/cursor.ts
+++ b/packages/infra/src/pagination/cursor.ts
@@ -19,19 +19,23 @@ export interface CursorPayload {
 }
 
 /**
- * Raised for a cursor that does not decode. Extends `AppError`, not an HTTP error:
- * `@dunx/infra` must not depend on the web layer, and a bad cursor is the caller's
- * to map - usually to a 400.
+ * Raised for a cursor that does not decode.
  *
- * ```ts
- * catch (error) {
- *   if (error instanceof CursorError) throw new HttpError(400, error.message);
- *   throw error;
- * }
- * ```
+ * Extends `AppError` and not an HTTP error, because `@dunx/infra` must not depend
+ * on the web layer. It carries `status = 400` instead, which is an integer rather
+ * than a dependency, and `@dunx/http`'s default mapper turns that into the
+ * response. Nothing in an application has to catch it to get a 400.
  */
 export class CursorError extends AppError {
   override readonly name = 'CursorError';
+  /**
+   * A cursor the caller sent and got wrong, so a 400 rather than a 500.
+   *
+   * An integer, not an `HttpError`: `@dunx/infra` must not depend on the web
+   * layer, and this is how it says what the failure means without doing so.
+   * `@dunx/http`'s default mapper honours it.
+   */
+  override readonly status = 400;
 }
 
 export const encodeCursor = (

--- a/packages/infra/src/pagination/options.ts
+++ b/packages/infra/src/pagination/options.ts
@@ -50,6 +50,8 @@ export interface PageOptions {
 
 export class PageOptionsError extends AppError {
   override readonly name = 'PageOptionsError';
+  /** Page parameters the caller sent and got wrong. See {@link CursorError}. */
+  override readonly status = 400;
 }
 
 const one = (value: unknown): string | undefined => {


### PR DESCRIPTION
Roadmap **W2**, the half that was not blocked, plus a roadmap refresh.

## The mechanism

`@dunx/infra` must not depend on the web layer, so it cannot raise an `HttpError`
or ship a filter that constructs one. The way through is not a dependency, it is a
number:

```ts
export class CursorError extends AppError {
  override readonly name = 'CursorError';
  override readonly status = 400;   // an integer is not the web layer
}
```

`@dunx/http`'s default mapper honours any `AppError` that names a status. A bad
cursor is now a 400 in an app that wrote no `catch` — and the
`if (error instanceof CursorError) throw new HttpError(400, ...)` line that
`CursorError`'s own doc comment carried as the recommended workaround is deleted
rather than documented.

Two things fall out of the number being set where no `Response` is ever seen:

- **Range-checked.** A typo would otherwise reach `Response.json` as `status: 4000`
  and throw a `RangeError` from the error path itself. Outside 200-599 falls back
  to 500.
- **A 4xx is not logged as an incident.** It is the caller's mistake; logging one
  at error level is how a log fills with entries nobody can act on. 500+ still logs.

An `AppError` with no status stays a 500 with its message withheld — right for a
`CircularDependencyError`, which is a boot failure and not a response.

`HttpError` and `FetchError` gained `override` on their own `status`, narrowing the
optional base to a required one, which they were already doing implicitly.

## Verification

Both halves **mutation-tested**: dropping the range guard fails 7 tests, removing
the feature fails 4. `examples/full` asserts the 400 end to end through the real
`createApp`, per Rule 4.

`bun run ci`: 13/13 green.

## Roadmap

Refreshed for what actually shipped: the scaffolder's arrow-key interface, the
`@arkv/logger` 0.12 integration and its `closeAsync` drain, and `--parallel` being
the adopted part of A1.

**W2 is recorded as half done, with the reason the rest waits.** The plan says
`@dunx/infra/db` should catch `SQLiteError`, read the constraint code and rethrow
with 409 or 400. There is nowhere to catch it: drizzle owns the call, the subpath
has no interception point, and adding one means wrapping every query or making a
repository base class mandatory. Both are larger than the item and neither is
obviously right, so the seam is the decision to make first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application errors can now provide valid HTTP status codes for automatic response mapping.
  * Invalid pagination cursors and options now return clear HTTP 400 responses without manual conversion.
  * Server error handling safely falls back to generic HTTP 500 responses for invalid or missing statuses.
  * Errors with status 500 or higher are logged automatically.

* **Documentation**
  * Updated guides and roadmap documentation to explain status-aware error handling, pagination behavior, and logger capabilities.

* **Tests**
  * Added coverage for error mapping, logging behavior, invalid cursors, and cursor-based pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->