### PR TITLE
docs(architecture): measure a queue, a cache and websocket fan-out with no Redis

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -286,10 +286,11 @@ carrying both. The hang itself is still open and is upstream's; see the roadmap 
 delivered rather than marking it done, so the folder only ever holds open work.
 Feedback goes in as a new file rather than into conversation.
 
-| Item                                                                          | Shape                                                                            |
-| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [queue-shutdown-sigterm](../internal/notes/roadmap/queue-shutdown-sigterm.md) | One upstream defect left, in bullmq itself. To file. Bun 1.4 fixed the other.    |
-| [bun-1.4-adoption](../internal/notes/roadmap/bun-1.4-adoption.md)             | A1-A5 all settled. A3 filed upstream; the rest adopted or measured and declined. |
+| Item                                                                                          | Shape                                                                               |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [queue-shutdown-sigterm](../internal/notes/roadmap/queue-shutdown-sigterm.md)                 | One upstream defect left, in bullmq itself. To file. Bun 1.4 fixed the other.       |
+| [bun-1.4-adoption](../internal/notes/roadmap/bun-1.4-adoption.md)                             | A1-A5 all settled. A3 filed upstream; the rest adopted or measured and declined.    |
+| [database-backed-infrastructure](../internal/notes/roadmap/database-backed-infrastructure.md) | Queue, cache and fan-out with no Redis. All three measured; three verdicts to take. |
 
 Delivered and moved out of this folder rather than left here marked done:
 

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -202,11 +202,13 @@ no adapter between them. That is the `@dunx/auth` `RedisStore` precedent - decla
 the shape, let the app supply anything that fits - and `examples/full` runs its
 second node that way on purpose.
 
-### A Postgres relay satisfies the same two methods
+### A Postgres relay over `LISTEN`/`NOTIFY`
 
-`Bun.SQL`'s `LISTEN`/`NOTIFY` is publish and subscribe, so it fits `PubSubRelay` with
-no adapter between them, as `RedisConnection` does. `Bun.SQL` is a global, so a
-Postgres relay beside `RedisRelay` would add no dependency to `@dunx/http` either.
+`Bun.SQL` has both of `PubSubRelay`'s operations under other names: `notify` for
+publish, `listen` for subscribe, and `unlisten` on the returned handle for close. So
+this is not the structural fit `RedisConnection` is, where the names already match.
+It is a class of about thirty lines holding one `Bun.SQL` and renaming three calls.
+`Bun.SQL` is a global, so it would add no dependency to `@dunx/http`.
 
 Measured on Bun 1.4.0 (rev 34cbb9a40) against Postgres 17, with two real nodes: a
 gateway on each, a client connected to node B alone, `publishEvent` called on node A,

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -202,6 +202,50 @@ no adapter between them. That is the `@dunx/auth` `RedisStore` precedent - decla
 the shape, let the app supply anything that fits - and `examples/full` runs its
 second node that way on purpose.
 
+### A Postgres relay satisfies the same two methods
+
+`Bun.SQL`'s `LISTEN`/`NOTIFY` is publish and subscribe, so it fits `PubSubRelay` with
+no adapter between them, as `RedisConnection` does. `Bun.SQL` is a global, so a
+Postgres relay beside `RedisRelay` would add no dependency to `@dunx/http` either.
+
+Measured on Bun 1.4.0 (rev 34cbb9a40) against Postgres 17, with two real nodes: a
+gateway on each, a client connected to node B alone, `publishEvent` called on node A,
+and `relayChannel` left at its default:
+
+```
+frames on the node-b client: [ "{\"event\":\"greet\",\"data\":{\"from\":\"node-a\"}}" ]
+local fan-out on node a:     0
+```
+
+The `0` carries the result. Node A had no local subscriber, so the frame reached that
+client across the channel or not at all. `dunx:ws` needs no respelling for Postgres;
+Bun quotes the identifier.
+
+One behaviour differs from the Redis relay, and an app moving between the two has to
+size its frames for it. Postgres caps a `NOTIFY` payload at 7999 bytes, and the relay
+envelope adds an origin id and a topic on top of the frame:
+
+```
+frame 7925 bytes -> relayed
+frame 7935 bytes -> refused
+```
+
+The refusal is reported. `notify()` rejects with `ERR_POSTGRES_SERVER_ERROR` and
+`22023`, `#outbound` takes its promise branch because `Query` extends `Promise`, and
+the app gets one `logger.warn` per degradation:
+
+```
+the websocket relay could not publish. Fan-out is local to this process until it recovers.
+```
+
+Redis has no comparable ceiling.
+
+Not built. `WsRelayModule` binds `RedisRelay` and takes `RelayConnectionOptions`, so
+a Postgres relay reaches an app through the `relay` option or `relayThrough` rather
+than through that module. Whether it earns a place beside `RedisRelay`, with the
+module growing a second binding, or stays the 30 lines an app writes against the
+interface, is open.
+
 ### One channel, because `psubscribe` does not work
 
 Frames for **every** topic travel on one broker channel, not one channel per topic.

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -161,9 +161,13 @@ Two costs stand against adopting this, and the measurement settles neither:
   pg-boss backend has a different job model, so it is a second surface rather than a
   driver swap behind the existing one.
 
-Postgres only, besides, and doubly so: pg-boss supports no other backend, and
-`Bun.SQL` answers `LISTEN`/`NOTIFY` on the Postgres adapter alone. An app on SQLite
-or MySQL has no candidate here at all, so both figures above are Postgres figures.
+Both figures above are PostgreSQL 17 through `Bun.SQL`'s Postgres adapter, and
+nothing else was measured. pg-boss carries four other backend profiles, and they
+differ on the two things the 10 ms depends on: `cockroachdb` sets `noListenNotify`,
+so it polls; `yugabytedb` needs a server flag for it and drops advisory locks and
+partitioning; `citus` and `pglite` keep it. SQLite and MySQL are not pg-boss backends
+at all, and `Bun.SQL` answers `LISTEN`/`NOTIFY` on the Postgres adapter alone, so an
+app on either has no candidate here.
 
 Recorded here rather than built; the open item is in
 [ROADMAP.md](../ROADMAP.md), "Open items".

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -108,6 +108,65 @@ test.
 The `devDependency` was `^6.0.0` against a `>=5.0.0` peer; it now matches the
 peer, as `bullmq`'s and `drizzle-orm`'s already did.
 
+### A Postgres-backed queue, measured and not adopted
+
+Rails 8 moved its queue, cache and websocket fan-out onto the application's own
+database and dropped Redis. The question that raises here is whether
+`@dunx/infra/queue` should have a second backend needing no broker.
+
+**pg-boss is the library, on the rule that made bullmq the queue.** Retries, backoff,
+cron, singleton queues, dead letters and archival are already its, and building them
+over `Bun.SQL` is the failure Rule 1's second half names. graphile-worker is the
+other candidate and was not measured; pg-boss took the first look for publishing a
+`Db` interface aimed at this case.
+
+pg-boss 12.28.1 takes a `db` implementing `executeSql(text, values)`, and its types
+say a custom adapter may also implement `listen` to enable `useListenNotify`.
+`Bun.SQL` satisfies both through three shims, one per gap recorded in
+[bun-apis.md](../bun-apis.md): reserve a connection for the `BEGIN` blocks, spell a
+JS array as a Postgres array literal, and parse a stringified JSON parameter before
+binding it. The `$n::type` cast pg-boss writes beside each placeholder says which
+applies, so the shim is about 20 lines.
+
+Measured on Bun 1.4.0 (rev 34cbb9a40), pg-boss 12.28.1, Postgres 17:
+
+```
+migration + start:                  75 ms (2 reserved connections)
+warnings:                           none
+pg_stat_activity:                   10 conns, application_name "" on all of them
+dispatch -> handler, notify: true   10 ms
+dispatch -> handler, notify: false  2012 ms
+retries with retryLimit 3:          succeeded on attempt 3
+```
+
+The connection census is the load-bearing line. pg-boss's own `Db` sets
+`application_name` to `pgboss` on the pool it opens, so ten unnamed connections and
+no `pgboss` among them means that pool was never constructed and every statement
+went through `Bun.SQL`. An empty `warnings` list says the same about the listener:
+pg-boss emits `listen_notify_unavailable` when it falls back to polling, and the
+200x gap between the two dispatch figures is what the fallback costs.
+
+`pg` still has to be installed. `dist/db.js` imports it statically and
+`dist/index.js` imports `db.js`, so the barrel pulls it in whether or not a custom
+adapter replaces it. That is the shape of bullmq's `ioredis` import above, and it
+would be an optional peer for the same reason.
+
+Two costs stand against adopting this, and the measurement settles neither:
+
+- **The shim reads pg-boss's own SQL.** A cast that changes spelling upstream breaks
+  binding with no compile error, and the fix would live here rather than in either
+  project. Its home is Bun, or an adapter pg-boss ships.
+- **pg-boss is not a bullmq drop-in.** `JobPublisher.for()` returns bullmq's `Queue`
+  so that `addBulk`, `upsertJobScheduler` and `getJobCounts` need no restating. A
+  pg-boss backend has a different job model, so it is a second surface rather than a
+  driver swap behind the existing one.
+
+Postgres only, besides. SQLite and MySQL have no `LISTEN`/`NOTIFY`, so 2012 ms is
+the whole story on either.
+
+Recorded here rather than built; the open item is in
+[ROADMAP.md](../ROADMAP.md), "Open items".
+
 ### Job discovery
 
 The **marker-plus-prototype-scan** technique from **Route discovery**, third use:

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -161,8 +161,9 @@ Two costs stand against adopting this, and the measurement settles neither:
   pg-boss backend has a different job model, so it is a second surface rather than a
   driver swap behind the existing one.
 
-Postgres only, besides. SQLite and MySQL have no `LISTEN`/`NOTIFY`, so 2012 ms is
-the whole story on either.
+Postgres only, besides, and doubly so: pg-boss supports no other backend, and
+`Bun.SQL` answers `LISTEN`/`NOTIFY` on the Postgres adapter alone. An app on SQLite
+or MySQL has no candidate here at all, so both figures above are Postgres figures.
 
 Recorded here rather than built; the open item is in
 [ROADMAP.md](../ROADMAP.md), "Open items".

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -162,12 +162,16 @@ Two costs stand against adopting this, and the measurement settles neither:
   driver swap behind the existing one.
 
 Both figures above are PostgreSQL 17 through `Bun.SQL`'s Postgres adapter, and
-nothing else was measured. pg-boss carries four other backend profiles, and they
-differ on the two things the 10 ms depends on: `cockroachdb` sets `noListenNotify`,
-so it polls; `yugabytedb` needs a server flag for it and drops advisory locks and
-partitioning; `citus` and `pglite` keep it. SQLite and MySQL are not pg-boss backends
-at all, and `Bun.SQL` answers `LISTEN`/`NOTIFY` on the Postgres adapter alone, so an
-app on either has no candidate here.
+nothing else was measured. pg-boss carries four other backend profiles, and the
+latency does not carry to them, because the only thing separating 10 ms from 2012 ms
+is whether a notification arrives: `cockroachdb` sets `noListenNotify` and polls,
+`yugabytedb` has it early-access behind `ysql_yb_enable_listen_notify` and off by
+default, `citus` and `pglite` have it. Their other flags, `noAdvisoryLocks` and
+`noTablePartitioning`, bear on migration and table layout rather than on dispatch.
+
+SQLite and MySQL are not pg-boss backends at all, and `Bun.SQL` answers
+`LISTEN`/`NOTIFY` on the Postgres adapter alone, so an app on either has no candidate
+here.
 
 Recorded here rather than built; the open item is in
 [ROADMAP.md](../ROADMAP.md), "Open items".

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -642,7 +642,8 @@ $1 = [{ id: 1 }]                   json_typeof -> array
 
 So `json_to_recordset($1::json)` fails with `cannot call json_to_recordset on a
 scalar` against a string that a `pg`-based library already stringified, and succeeds
-against the raw value. Not found in the issue tracker; unreported as of this note.
+against the raw value. Filed as
+[#40942](https://github.com/oven-sh/bun/issues/40942).
 
 #### An in-flight MySQL query does not hold the event loop open
 

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -578,6 +578,72 @@ that `@dunx/infra/db`'s `SqlOptions` uses the options-object form - harmless the
 because that backend is Postgres by construction, but any non-Postgres backend
 built on `Bun.SQL` must name its `adapter`.
 
+#### `LISTEN`/`NOTIFY` on the Postgres adapter, and the 7999-byte cap
+
+Measured on 1.4.0 (rev 34cbb9a40) against Postgres 17. `sql.listen(channel, cb, onReconnect)`
+resolves once the server acknowledges the `LISTEN`; `sql.notify(channel, payload)`
+publishes. Delivery between two clients works, and `unlisten()` ends it:
+
+```
+handle:                    { own: ["channel"], unlisten: fn, asyncDispose: fn }
+cross-connection delivery: [ "first" ]
+after unlisten:            [ "first" ]
+```
+
+The payload has a hard ceiling, and the boundary is exact:
+
+```
+7998 -> accepted
+7999 -> accepted
+8000 -> payload string too long
+```
+
+Postgres only. The SQLite adapter answers `LISTEN/NOTIFY is not supported by this
+adapter (PostgreSQL only)`.
+
+`notify()` returns a `Query`, and `Query` extends `Promise`, so `result instanceof
+Promise` is `true` and a rejection reaches a `.then(onOk, onErr)` pair. `PubSub`'s
+`#outbound` branches on that test, so a relay built on `notify` reports its failures
+through the normal degrade path rather than raising an unhandled rejection.
+
+#### Three parameter-binding gaps between `Bun.SQL` and a `pg`-shaped library
+
+Measured on 1.4.0 while running pg-boss over `Bun.SQL`. Each is something `pg` does
+that `Bun.SQL` does not, so any library written against `pg`'s parameter handling
+meets all three.
+
+**Transaction control is refused on a pooled connection.** A multi-statement string
+opening with `BEGIN` throws `Only use sql.begin, sql.reserved or max: 1`. The same
+string through `sql.reserve()` runs and returns one result array per statement, so a
+caller reading `rows` takes the last of them.
+
+**A JS array parameter is comma-joined rather than made into an array literal.** Both
+forms fail identically:
+
+```
+sql.unsafe('SELECT $1::text[]', [['probe','other']]) -> malformed array literal: "probe,other"
+sql`SELECT ${['probe','other']}::text[]`             -> malformed array literal: "probe,other"
+```
+
+The literal Postgres spelling binds correctly: `'{probe,other}'` reads back as
+`[ "probe", "other" ]`. Reported upstream and open:
+[#16840](https://github.com/oven-sh/bun/issues/16840),
+[#17798](https://github.com/oven-sh/bun/issues/17798),
+[#18775](https://github.com/oven-sh/bun/issues/18775),
+[#22165](https://github.com/oven-sh/bun/issues/22165).
+
+**A JSON string bound to a `::json` cast arrives as a JSON scalar.** Postgres reports
+what it was handed:
+
+```
+$1 = JSON.stringify([{ id: 1 }])   json_typeof -> string
+$1 = [{ id: 1 }]                   json_typeof -> array
+```
+
+So `json_to_recordset($1::json)` fails with `cannot call json_to_recordset on a
+scalar` against a string that a `pg`-based library already stringified, and succeeds
+against the raw value. Not found in the issue tracker; unreported as of this note.
+
 #### An in-flight MySQL query does not hold the event loop open
 
 Measured on 1.3.14, and the failure is silent. A script whose only pending work is

--- a/internal/docs/scripts/content.ts
+++ b/internal/docs/scripts/content.ts
@@ -38,7 +38,11 @@ const resolveFrom = (from: string, path: string): string => {
   if (!from || !/^\.\.?\//.test(path)) {
     return path.replace(/^(?:\.\/|\.\.\/)+/, '');
   }
-  return posix.join(posix.dirname(from), path).replace(/^(?:\.\.\/)+/, '');
+  // `node:path`'s `relative` and `Bun.Glob` both hand back `\` on Windows, and a
+  // link target is always `/`. Normalised here rather than at each call site, so
+  // a new source of `from` cannot reintroduce it.
+  const dir = posix.dirname(from.replaceAll('\\', '/'));
+  return posix.join(dir, path).replace(/^(?:\.\.\/)+/, '');
 };
 
 /**

--- a/internal/docs/scripts/content.ts
+++ b/internal/docs/scripts/content.ts
@@ -1,3 +1,4 @@
+import { posix } from 'node:path';
 import { highlightFences } from './highlight';
 import type { GuidePage } from './extract/model';
 
@@ -28,6 +29,19 @@ export interface LinkTargets {
 }
 
 /**
+ * `../bun-apis.md` written on `docs/architecture/http.md` means `docs/bun-apis.md`.
+ * Stripping the `../` instead of resolving it pointed the GitHub fallback at
+ * `blob/main/bun-apis.md`, a 404. Without a source path there is nothing to
+ * resolve against, so the old strip is the fallback.
+ */
+const resolveFrom = (from: string, path: string): string => {
+  if (!from || !/^\.\.?\//.test(path)) {
+    return path.replace(/^(?:\.\/|\.\.\/)+/, '');
+  }
+  return posix.join(posix.dirname(from), path).replace(/^(?:\.\.\/)+/, '');
+};
+
+/**
  * Rewrites the links the source markdown was written with. A doc that says
  * `./ARCHITECTURE.md` must land on the guide page here, and anything the site
  * does not host at all has to become an absolute link back to GitHub rather
@@ -38,6 +52,8 @@ export const rewriteHref = (
   targets: LinkTargets,
   /** The route this document is served at, for same-page `#anchor` links. */
   self = '',
+  /** The repo path this document was written at, for relative links. */
+  from = '',
 ): string => {
   // A bare `#anchor` in a hash-routed site replaces the route rather than
   // scrolling, so `#two-things` navigated away from the page it was written on.
@@ -53,7 +69,7 @@ export const rewriteHref = (
   const suffix = hash ? `#${hash}` : '';
   if (path === '') return href;
 
-  const base = path.replace(/^(?:\.\/|\.\.\/)+/, '');
+  const base = resolveFrom(from, path);
 
   const guide =
     targets.guides.get(base) ?? targets.guides.get(base.replace(/^docs\//, ''));
@@ -174,6 +190,8 @@ export const renderDoc = (
   targets: LinkTargets,
   /** The route this document is served at. Needed for same-page anchors. */
   self = '',
+  /** The repo path it was written at. Needed for relative links. */
+  from = '',
 ): RenderedDoc => {
   const headings: { id: string; text: string }[] = [];
   const seen = new Map<string, number>();
@@ -196,7 +214,8 @@ export const renderDoc = (
 
   html = html.replace(
     ANCHOR,
-    (_match, href: string) => `<a href="${rewriteHref(href, targets, self)}"`,
+    (_match, href: string) =>
+      `<a href="${rewriteHref(href, targets, self, from)}"`,
   );
 
   return { html, headings };
@@ -217,7 +236,12 @@ export const buildGuide = (
   order = 0,
   section = '',
 ): GuidePage => {
-  const { html, headings } = renderDoc(markdown, targets, `#/guide/${slug}`);
+  const { html, headings } = renderDoc(
+    markdown,
+    targets,
+    `#/guide/${slug}`,
+    source,
+  );
   return {
     slug,
     category,

--- a/internal/docs/scripts/extract.test.ts
+++ b/internal/docs/scripts/extract.test.ts
@@ -270,6 +270,12 @@ describe('markdown content', () => {
         'docs/guide/05-controllers.md',
       ),
     ).toBe('#/guide/http');
+    // `relative()` and `Bun.Glob` hand back `\` on Windows; a link target does not.
+    expect(
+      rewriteHref('./usage.md', targets, '', 'packages\\infra/README.md'),
+    ).toBe(
+      'https://github.com/petarzarkov/dunx/blob/main/packages/infra/usage.md',
+    );
   });
 
   test('slugify strips backticks and punctuation', () => {

--- a/internal/docs/scripts/extract.test.ts
+++ b/internal/docs/scripts/extract.test.ts
@@ -245,6 +245,33 @@ describe('markdown content', () => {
     expect(rewriteHref('#anchor', targets)).toBe('#anchor');
   });
 
+  test('a `../` link resolves against the page it was written on', () => {
+    const targets = {
+      guides: new Map([['architecture/http.md', '#/guide/http']]),
+      packages: new Map<string, string>(),
+    };
+    // `docs/architecture/http.md` links to `../bun-apis.md`, which is
+    // `docs/bun-apis.md`. Stripping the `../` instead of resolving it produced
+    // `blob/main/bun-apis.md`, a 404 on a page the site publishes.
+    expect(
+      rewriteHref('../bun-apis.md', targets, '', 'docs/architecture/http.md'),
+    ).toBe('https://github.com/petarzarkov/dunx/blob/main/docs/bun-apis.md');
+    expect(
+      rewriteHref('./queues.md', targets, '', 'docs/architecture/http.md'),
+    ).toBe(
+      'https://github.com/petarzarkov/dunx/blob/main/docs/architecture/queues.md',
+    );
+    // A tour page reaching sideways still lands on the in-site route.
+    expect(
+      rewriteHref(
+        '../architecture/http.md',
+        targets,
+        '',
+        'docs/guide/05-controllers.md',
+      ),
+    ).toBe('#/guide/http');
+  });
+
   test('slugify strips backticks and punctuation', () => {
     expect(slugify('`Bun.serve()` adapter')).toBe('bun-serve-adapter');
   });

--- a/internal/docs/scripts/generate.ts
+++ b/internal/docs/scripts/generate.ts
@@ -5,7 +5,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { basename, join, resolve } from 'node:path';
+import { basename, join, relative, resolve } from 'node:path';
 import {
   buildGuide,
   renderDoc,
@@ -250,8 +250,8 @@ const targets = linkTargets(guideFiles(), tourFiles(), dirNames);
 
 await startHighlighter();
 
-const render = (markdown: string, self = ''): string =>
-  markdown === '' ? '' : renderDoc(markdown, targets, self).html;
+const render = (markdown: string, self = '', from = ''): string =>
+  markdown === '' ? '' : renderDoc(markdown, targets, self, from).html;
 
 /**
  * A README, minus the sections that document the repo rather than the package.
@@ -260,9 +260,11 @@ const render = (markdown: string, self = ''): string =>
  * scrolls instead of navigating away - a bare `#` replaces the route in a
  * hash-routed site.
  */
-const renderReadme = (file: string, dir: string): string => {
+const renderReadme = (file: string, dir: string, source: string): string => {
   const markdown = read(file);
-  return markdown === '' ? '' : render(siteMarkdown(markdown), `#/api/${dir}`);
+  return markdown === ''
+    ? ''
+    : render(siteMarkdown(markdown), `#/api/${dir}`, source);
 };
 
 const packages: PackageDoc[] = dirs.map((packageDir) => {
@@ -274,7 +276,11 @@ const packages: PackageDoc[] = dirs.map((packageDir) => {
     repoRoot: REPO_ROOT,
     packageDir,
     manifest,
-    readme: renderReadme(join(packageDir, 'README.md'), basename(packageDir)),
+    readme: renderReadme(
+      join(packageDir, 'README.md'),
+      basename(packageDir),
+      `${relative(REPO_ROOT, packageDir)}/README.md`,
+    ),
     render,
   });
 });

--- a/internal/notes/roadmap/database-backed-infrastructure.md
+++ b/internal/notes/roadmap/database-backed-infrastructure.md
@@ -83,78 +83,22 @@ sit in or beside frozen ground.
 
 The suggested order, if any of it proceeds:
 
-1. **File the Bun JSON binding bug.** The report is written and sits at the bottom of
-   this file; posting it costs nothing and it is the gate on the queue being cheap
-   later.
+1. **Watch the two Bun gaps.** The JSON one is filed as
+   [#40942](https://github.com/oven-sh/bun/issues/40942), the array one is open on
+   four issues, and both closing is the gate on the queue adapter being small.
 2. **Decide the relay.** It is additive, it is in `@dunx/http`, and the measurement
    is done.
 3. **Hold the queue** until the Bun gaps close or someone asks for it.
 4. **Hold the cache** until something other than symmetry with Rails argues for it.
 
-## The Bun report, ready to file
+## Filed upstream
 
-Not yet filed. Post it at `oven-sh/bun`, then replace this section with the issue
-number the way [bun-1.4-adoption](./bun-1.4-adoption.md) records #40892 and #40893.
+[oven-sh/bun#40942](https://github.com/oven-sh/bun/issues/40942): a string parameter
+bound to a `::json` cast arrives as a JSON string scalar, so
+`json_to_recordset($1::json)` fails against a document a `pg`-shaped library already
+stringified. `node-postgres` answers `array` for `json_typeof` on the same statement,
+which is in the report.
 
----
-
-**Title:** `Bun.SQL`: a string parameter bound to a `::json` cast arrives as a JSON
-string scalar
-
-**What version of Bun is running?** 1.4.0+34cbb9a40, Linux x64. Postgres 17.
-
-**What steps will reproduce the bug?**
-
-```ts
-const sql = new Bun.SQL({
-  url: 'postgres://postgres:postgres@localhost:5432/postgres',
-});
-
-// A JSON document, already serialised - what every `pg`-based library passes.
-const payload = JSON.stringify([{ id: 1, name: 'a' }]);
-
-const [row] = await sql.unsafe(
-  'SELECT json_typeof($1::json) AS kind, $1::json AS value',
-  [payload],
-);
-console.log(row); // { kind: "string", value: '[{"id":1,"name":"a"}]' }
-//                   expected: { kind: "array", value: [ { id: 1, name: "a" } ] }
-
-// The consequence: anything that reads the document server-side fails.
-await sql.unsafe(
-  'SELECT * FROM json_to_recordset($1::json) AS x(id int, name text)',
-  [payload],
-); // PostgresError: cannot call json_to_recordset on a scalar
-
-await sql.close();
-```
-
-**What is the expected behaviour?**
-
-`json_typeof` answers `array`, and `json_to_recordset` returns one row per element.
-`node-postgres` does exactly that against the same server and the same statement:
-
-```
-pg       json_typeof -> array
-Bun.SQL  json_typeof -> string
-```
-
-**What do you see instead?**
-
-Postgres receives the JSON document wrapped as a JSON string, so `$1::json` is a
-scalar rather than the array the text spells out. Passing the parsed value instead of
-the string works, which is what identifies the encoding as the cause rather than the
-cast.
-
-**Additional information**
-
-This makes `Bun.SQL` unusable as the driver behind a library that serialises JSON
-parameters itself, which is the normal shape for anything written against `pg`.
-pg-boss builds its entire insert path on `json_to_recordset($1::json)` with a
-`JSON.stringify`d argument, so every `send` fails. The workaround is to parse the
-string back before binding, which needs the caller to know which placeholders carry a
-`::json` cast.
-
-Related, and already reported: a JS array parameter is comma-joined rather than
-rendered as a Postgres array literal (#16840, #17798, #18775, #22165). The two
-together are what stand between `Bun.SQL` and a `pg`-shaped library.
+The array half was already open on #16840, #17798, #18775 and #22165. Both closing is
+what turns the queue adapter from a driver-compat layer into `executeSql` plus
+`listen`, which is the size worth owning.

--- a/internal/notes/roadmap/database-backed-infrastructure.md
+++ b/internal/notes/roadmap/database-backed-infrastructure.md
@@ -20,12 +20,14 @@ Delete it once the three verdicts are taken.
 
 ## Fan-out: the cheapest of the three, and the closest to done
 
-`PubSubRelay` is two methods, and `Bun.SQL`'s `LISTEN`/`NOTIFY` is those two methods,
-so a relay needs no adapter. Two real dunx nodes, a client on one, a publish on the
-other: the frame crosses, on the default `dunx:ws` channel, with `relayChannel`
-untouched. The measurement and the 7.9 KB frame ceiling are in
-[architecture/http.md](../../../docs/architecture/http.md), "A Postgres relay
-satisfies the same two methods".
+`PubSubRelay` is two methods, and `Bun.SQL` has both under other names: `notify`,
+`listen`, and `unlisten` on the handle. So a relay is a class of about thirty lines
+renaming three calls, rather than the structural fit `RedisConnection` is. Two real
+dunx nodes, a client on one, a publish on the other: the frame crosses, on the
+default `dunx:ws` channel, with `relayChannel` untouched. The measurement and the
+7.9 KB frame ceiling are in
+[architecture/http.md](../../../docs/architecture/http.md), "A Postgres relay over
+`LISTEN`/`NOTIFY`".
 
 What is open is placement, not feasibility. `RedisRelay` sits in `@dunx/http` because
 `Bun.RedisClient` is a global that costs the package no dependency, and `Bun.SQL` is

--- a/internal/notes/roadmap/database-backed-infrastructure.md
+++ b/internal/notes/roadmap/database-backed-infrastructure.md
@@ -1,0 +1,158 @@
+# A queue, a cache and websocket fan-out with no Redis
+
+Rails 8 replaced Redis with Solid Queue, Solid Cache and Solid Cable, all backed by
+the application's own database. This file holds the audit of whether dunx should do
+the same: what each of the three layers would cost, what already exists to build on,
+and what was measured rather than assumed.
+
+Everything below was probed on Bun 1.4.0 (rev `34cbb9a40`) against Postgres 17. The
+measurements live in the architecture docs; this file holds the decision.
+
+Delete it once the three verdicts are taken.
+
+## The three layers do not have the same answer
+
+| Layer               | Stands on                               | Verdict                                |
+| ------------------- | --------------------------------------- | -------------------------------------- |
+| Fan-out (Cable)     | `Bun.SQL` `LISTEN`/`NOTIFY`, no library | works today, ~30 lines                 |
+| Queue (Solid Queue) | pg-boss over a `Bun.SQL` adapter        | works, with a shim that is a liability |
+| Cache (Solid Cache) | nothing that clears Rule 1              | no contract exists to extend           |
+
+## Fan-out: the cheapest of the three, and the closest to done
+
+`PubSubRelay` is two methods, and `Bun.SQL`'s `LISTEN`/`NOTIFY` is those two methods,
+so a relay needs no adapter. Two real dunx nodes, a client on one, a publish on the
+other: the frame crosses, on the default `dunx:ws` channel, with `relayChannel`
+untouched. The measurement and the 7.9 KB frame ceiling are in
+[architecture/http.md](../../../docs/architecture/http.md), "A Postgres relay
+satisfies the same two methods".
+
+What is open is placement, not feasibility. `RedisRelay` sits in `@dunx/http` because
+`Bun.RedisClient` is a global that costs the package no dependency, and `Bun.SQL` is
+a global on the same terms. So the choice is a `PostgresRelay` beside it, or leaving
+it as the 30 lines an app writes against a documented interface.
+
+Against shipping it: the roadmap freezes new capability outside the core three, and
+this is a capability. For it: it lands in `@dunx/http`, which is one of the three,
+at an extension point that already exists.
+
+## Queue: it runs, and the shim is the problem
+
+pg-boss 12.28.1 over a `Bun.SQL` adapter completes the full lifecycle - migration,
+dispatch, LISTEN/NOTIFY wake, retries - in 10 ms per job, with no `pg` connection
+ever opened. Numbers and the connection census that proves the last claim are in
+[architecture/queues.md](../../../docs/architecture/queues.md), "A Postgres-backed
+queue, measured and not adopted".
+
+The blocker is not performance. Three `Bun.SQL` binding gaps
+([bun-apis.md](../../../docs/bun-apis.md)) sit between pg-boss and Bun, and the
+adapter closes them by reading the `$n::type` casts out of pg-boss's own SQL. That
+is a driver-compat layer maintained here, against another project's queries, failing
+silently if either side changes. Two of the three gaps are open Bun issues; the JSON
+one is unreported and worth filing.
+
+The honest sequence is upstream first. File the JSON scalar bug, and see whether the
+array binding lands in a Bun release. Both gaps closing turns the adapter into
+`executeSql` plus `listen`, which is small enough to own.
+
+The second cost does not expire: pg-boss has its own job model, and
+`JobPublisher.for()` hands back bullmq's `Queue`. A pg-boss backend is a second
+surface, not a driver behind the existing one.
+
+## Cache: the one with nothing to lean on
+
+dunx has no cache contract at all. Nothing in `packages/*` declares one, so this is
+not a second backend for an existing abstraction, it is a new abstraction.
+
+No library clears Rule 1 either. `@keyv/postgres` depends on `pg`; `cache-manager` is
+a front for keyv adapters, so every SQL backend under it drags a banned driver in.
+
+Unlike a queue, a TTL cache is not years of edge cases, and dunx has the shape
+already: `ThrottleStore` in `@dunx/http` is an abstract class with an in-memory
+implementation and a structurally-typed Redis one, and a `CacheStore` would be that
+pattern with a SQL implementation added. That makes it buildable and leaves it the
+most invented of the three, which is the argument against starting here.
+
+## What the decision actually turns on
+
+The roadmap freezes `infra` to maintenance and says a new package needs a user first,
+citing `@dunx/queue-dashboard` as the cost of getting that wrong. All three of these
+sit in or beside frozen ground.
+
+The suggested order, if any of it proceeds:
+
+1. **File the Bun JSON binding bug.** The report is written and sits at the bottom of
+   this file; posting it costs nothing and it is the gate on the queue being cheap
+   later.
+2. **Decide the relay.** It is additive, it is in `@dunx/http`, and the measurement
+   is done.
+3. **Hold the queue** until the Bun gaps close or someone asks for it.
+4. **Hold the cache** until something other than symmetry with Rails argues for it.
+
+## The Bun report, ready to file
+
+Not yet filed. Post it at `oven-sh/bun`, then replace this section with the issue
+number the way [bun-1.4-adoption](./bun-1.4-adoption.md) records #40892 and #40893.
+
+---
+
+**Title:** `Bun.SQL`: a string parameter bound to a `::json` cast arrives as a JSON
+string scalar
+
+**What version of Bun is running?** 1.4.0+34cbb9a40, Linux x64. Postgres 17.
+
+**What steps will reproduce the bug?**
+
+```ts
+const sql = new Bun.SQL({
+  url: 'postgres://postgres:postgres@localhost:5432/postgres',
+});
+
+// A JSON document, already serialised - what every `pg`-based library passes.
+const payload = JSON.stringify([{ id: 1, name: 'a' }]);
+
+const [row] = await sql.unsafe(
+  'SELECT json_typeof($1::json) AS kind, $1::json AS value',
+  [payload],
+);
+console.log(row); // { kind: "string", value: '[{"id":1,"name":"a"}]' }
+//                   expected: { kind: "array", value: [ { id: 1, name: "a" } ] }
+
+// The consequence: anything that reads the document server-side fails.
+await sql.unsafe(
+  'SELECT * FROM json_to_recordset($1::json) AS x(id int, name text)',
+  [payload],
+); // PostgresError: cannot call json_to_recordset on a scalar
+
+await sql.close();
+```
+
+**What is the expected behaviour?**
+
+`json_typeof` answers `array`, and `json_to_recordset` returns one row per element.
+`node-postgres` does exactly that against the same server and the same statement:
+
+```
+pg       json_typeof -> array
+Bun.SQL  json_typeof -> string
+```
+
+**What do you see instead?**
+
+Postgres receives the JSON document wrapped as a JSON string, so `$1::json` is a
+scalar rather than the array the text spells out. Passing the parsed value instead of
+the string works, which is what identifies the encoding as the cause rather than the
+cast.
+
+**Additional information**
+
+This makes `Bun.SQL` unusable as the driver behind a library that serialises JSON
+parameters itself, which is the normal shape for anything written against `pg`.
+pg-boss builds its entire insert path on `json_to_recordset($1::json)` with a
+`JSON.stringify`d argument, so every `send` fails. The workaround is to parse the
+string back before binding, which needs the caller to know which placeholders carry a
+`::json` cast.
+
+Related, and already reported: a JS array parameter is comma-joined rather than
+rendered as a Postgres array literal (#16840, #17798, #18775, #22165). The two
+together are what stand between `Bun.SQL` and a `pg`-shaped library.


### PR DESCRIPTION
Rails 8 replaced Redis with Solid Queue, Solid Cache and Solid Cable, all on the application's own database. This records what the same move would cost here. Everything below was measured on Bun 1.4.0 (rev `34cbb9a40`) against Postgres 17, and **none of it is built** - the three verdicts are a new open roadmap item.

## The three layers do not have the same answer

| Layer | Stands on | Verdict |
| --- | --- | --- |
| Fan-out (Cable) | `Bun.SQL` `LISTEN`/`NOTIFY`, no library | works today, ~30 lines |
| Queue (Solid Queue) | pg-boss over a `Bun.SQL` adapter | works, with a shim that is a liability |
| Cache (Solid Cache) | nothing that clears Rule 1 | no contract exists to extend |

**Fan-out.** `PubSubRelay` is two methods and `Bun.SQL`'s `LISTEN`/`NOTIFY` is those two methods, so a relay needs no adapter. Two real dunx nodes, a gateway on each, a client on node B, `publishEvent` on node A: the envelope crosses, on the default `dunx:ws` channel. Node A's local fan-out returns `0`, so the frame reached that client across the channel or not at all.

**Queue.** pg-boss 12.28.1 over a `Bun.SQL` adapter completes migration, dispatch, LISTEN/NOTIFY wake and retries at 10 ms a job, against 2012 ms when it falls back to polling. `pg_stat_activity` shows ten connections all with an empty `application_name` and none named `pgboss`, so pg-boss's own pool was never constructed. The argument against adopting it is in the doc: the adapter closes three Bun gaps by reading pg-boss's own SQL, and pg-boss has a different job model from the bullmq `Queue` that `JobPublisher.for()` returns.

**Cache.** No contract exists to extend, and no library clears Rule 1 - `@keyv/postgres` depends on `pg`, and `cache-manager` is a front for keyv adapters.

## Three `Bun.SQL` findings

Recorded in `docs/bun-apis.md` with literal output: the `LISTEN`/`NOTIFY` surface and its exact 7999-byte payload ceiling, plus three parameter-binding gaps against a `pg`-shaped library. Transaction control is refused on a pooled connection; a JS array parameter is comma-joined rather than made an array literal (open upstream: #16840, #17798, #18775, #22165); and a JSON string bound to a `::json` cast arrives as a JSON scalar, which `node-postgres` gets right against the same statement. The last one is not in Bun's tracker, and the report is written and ready to file at the bottom of the roadmap note.

## One real bug, fixed with a test

Writing the `architecture/http.md` section exposed a defect in the docs site. `rewriteHref` stripped a leading `../` instead of resolving it, so that page's pre-existing `[bun-apis.md](../bun-apis.md)` was rewritten to `blob/main/bun-apis.md` and 404s today. It also slipped past `published-voice.test.ts`, because dropping the prefix dropped the `docs/` the planning-record pattern matches on. `extract.test.ts` pins the behaviour first; the fix threads each document's repo path from `buildGuide` and `renderReadme` through `renderDoc`.

## Gates

`bun run ci` is green on `build`, `static`, `docs`, `examples` and `coverage` (1896 tests, 96.2% lines, every package above the floor). `browser` cannot run on the machine this was written on - no Chrome installed, and it fails identically on a clean tree - so CI is the check on that phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on PostgreSQL-backed messaging, queues, and Bun SQL `LISTEN`/`NOTIFY` behavior.
  * Documented infrastructure evaluations, limitations, benchmarks, and roadmap decisions.
  * Documented Bun SQL payload limits and compatibility considerations.
  * Updated the roadmap with database-backed infrastructure planning.
* **Bug Fixes**
  * Improved relative Markdown link resolution across guides, package documentation, and repository pages.
* **Tests**
  * Added coverage for source-aware relative link resolution, including repository and Windows-style paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->