### PR TITLE
fix(testing): read the resolved middleware, not the argument, before warning

### DIFF
--- a/examples/testing/src/app.module.ts
+++ b/examples/testing/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@dunx/core';
+import { HttpModule } from './http/http.module.js';
 import { ReportsModule } from './reports/reports.module.js';
 import { WeatherModule } from './weather/weather.module.js';
 
-@Module({ imports: [WeatherModule, ReportsModule] })
+@Module({ imports: [HttpModule, WeatherModule, ReportsModule] })
 export class AppModule {}

--- a/examples/testing/src/http/http.module.ts
+++ b/examples/testing/src/http/http.module.ts
@@ -1,0 +1,22 @@
+import { Module, provide } from '@dunx/core';
+import { HttpOptionsProvider } from '@dunx/http';
+import { RequestId } from './request-id.middleware.js';
+
+/**
+ * Global middleware on a provider rather than an argument to `create()`. That is
+ * what makes it reach a fixture: `createTestServer` resolves the same
+ * `HttpOptionsProvider` the application does, so a suite gets the chain production
+ * gets without restating it.
+ */
+export class AppHttpOptions extends HttpOptionsProvider {
+  override readonly middleware = [RequestId];
+}
+
+@Module({
+  providers: [
+    RequestId,
+    provide(HttpOptionsProvider, { useClass: AppHttpOptions }),
+  ],
+  exports: [HttpOptionsProvider],
+})
+export class HttpModule {}

--- a/examples/testing/src/http/request-id.middleware.ts
+++ b/examples/testing/src/http/request-id.middleware.ts
@@ -1,0 +1,23 @@
+import type { BunRequest } from 'bun';
+import type { Middleware, Next, RouteContext } from '@dunx/http';
+
+/**
+ * Global middleware, so it runs for every route rather than the ones a decorator
+ * names. It stamps the id a client quotes back in a bug report.
+ *
+ * `next()` returns the handler's `Response`, and a `Response` built by a route is
+ * safe to copy but not always to mutate, so the header goes on a new one.
+ */
+export class RequestId implements Middleware {
+  async handle(
+    req: BunRequest,
+    _ctx: RouteContext,
+    next: Next,
+  ): Promise<Response> {
+    const id = req.headers.get('x-request-id') ?? Bun.randomUUIDv7();
+    const response = await next();
+    const headers = new Headers(response.headers);
+    headers.set('x-request-id', id);
+    return new Response(response.body, { status: response.status, headers });
+  }
+}

--- a/examples/testing/src/server.test.ts
+++ b/examples/testing/src/server.test.ts
@@ -109,11 +109,17 @@ describe('global middleware from an HttpOptionsProvider', () => {
       lines.push(args.map(String).join(' '));
     };
 
-    const server = await createTestServer({
-      modules: [HttpModule, WeatherModule],
-      overrides: [provide(ForecastClient, { useValue: new FixedForecast() })],
-    });
-    console.warn = warn;
+    let server: Awaited<ReturnType<typeof createTestServer>>;
+    try {
+      server = await createTestServer({
+        modules: [HttpModule, WeatherModule],
+        overrides: [provide(ForecastClient, { useValue: new FixedForecast() })],
+      });
+    } finally {
+      // Restored even if boot throws, or every later test in this file reports
+      // into a dead array.
+      console.warn = warn;
+    }
 
     try {
       const { headers } = await server.request('weather/oslo');

--- a/examples/testing/src/server.test.ts
+++ b/examples/testing/src/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { provide } from '@dunx/core';
 import { createTestServer } from '@dunx/testing';
+import { HttpModule } from './http/http.module.js';
 import { ApiKeys } from './reports/api-keys.js';
 import { ReportsModule } from './reports/reports.module.js';
 import { ForecastClient } from './weather/forecast.client.js';
@@ -92,5 +93,35 @@ describe('a guard, through the real request path', () => {
     expect((await server.json('reports/health')).status).toBe(200);
 
     await server.close();
+  });
+});
+
+/**
+ * Global middleware reaches a fixture only if the fixture includes the module that
+ * binds the `HttpOptionsProvider`. Include it and `createTestServer` runs the same
+ * chain production runs, with nothing restated here and no warning about globals.
+ */
+describe('global middleware from an HttpOptionsProvider', () => {
+  test('runs in the fixture, and the harness says nothing about it', async () => {
+    const lines: string[] = [];
+    const { warn } = console;
+    console.warn = (...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    };
+
+    const server = await createTestServer({
+      modules: [HttpModule, WeatherModule],
+      overrides: [provide(ForecastClient, { useValue: new FixedForecast() })],
+    });
+    console.warn = warn;
+
+    try {
+      const { headers } = await server.request('weather/oslo');
+      expect(headers.get('x-request-id')).toBeTruthy();
+      // Omitting `middleware` is correct here: the provider supplies it.
+      expect(lines).toEqual([]);
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/packages/testing/src/server.test.ts
+++ b/packages/testing/src/server.test.ts
@@ -4,8 +4,10 @@ import {
   Controller,
   Get,
   HttpError,
+  HttpOptionsProvider,
   Post,
   UseGuards,
+  type ErrorHandler,
   type Middleware,
   type RouteInput,
 } from '@dunx/http';
@@ -256,6 +258,36 @@ class ScopedController {
 })
 class ScopedGuardModule {}
 
+class ProvidedMiddleware extends HttpOptionsProvider {
+  override readonly middleware = [DenyGuard];
+}
+
+@Module({
+  controllers: [OpenController],
+  providers: [
+    DenyGuard,
+    provide(HttpOptionsProvider, { useClass: ProvidedMiddleware }),
+  ],
+  exports: [DenyGuard, HttpOptionsProvider],
+})
+class ProvidedMiddlewareModule {}
+
+class ProvidedErrorMapper extends HttpOptionsProvider {
+  override get onError(): ErrorHandler {
+    return () => new Response('mapped', { status: 418 });
+  }
+}
+
+@Module({
+  controllers: [OpenController],
+  providers: [
+    DenyGuard,
+    provide(HttpOptionsProvider, { useClass: ProvidedErrorMapper }),
+  ],
+  exports: [DenyGuard, HttpOptionsProvider],
+})
+class ProvidedErrorMapperModule {}
+
 const warnings = async (run: () => Promise<void>): Promise<string[]> => {
   const lines: string[] = [];
   const { warn } = console;
@@ -326,6 +358,47 @@ describe('createTestServer() global middleware', () => {
       expect(lines).toEqual([]);
       // Route-level guards are in the route table, so the fixture is the app.
       expect((await fixture!.request('scoped')).status).toBe(401);
+    } finally {
+      await fixture?.close();
+    }
+  });
+
+  /**
+   * Since 3.1.0 the argument is not the only source of global middleware, so a
+   * fixture whose module binds an `HttpOptionsProvider` is the application. The
+   * warning read the argument alone and fired anyway, telling an app that had
+   * taken the upgrading guide's advice to undo it.
+   */
+  it('says nothing when an HttpOptionsProvider supplied the middleware', async () => {
+    let fixture: TestServer | undefined;
+    const lines = await warnings(async () => {
+      fixture = await createTestServer({ modules: [ProvidedMiddlewareModule] });
+    });
+
+    try {
+      expect(lines).toEqual([]);
+      // The guard the warning would have claimed was not running.
+      expect((await fixture!.request('open')).status).toBe(401);
+    } finally {
+      await fixture?.close();
+    }
+  });
+
+  it('does not call the mapper default when a provider supplied one', async () => {
+    let fixture: TestServer | undefined;
+    const lines = await warnings(async () => {
+      fixture = await createTestServer({
+        modules: [ProvidedErrorMapperModule],
+      });
+    });
+
+    try {
+      // Middleware is still unsupplied, so the warning is right to fire.
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain('DenyGuard');
+      // ...but this app's errors do not reach the default mapper.
+      expect(lines[0]).not.toContain('`onError` is the default mapper');
+      expect(lines[0]).toContain('HttpOptionsProvider');
     } finally {
       await fixture?.close();
     }

--- a/packages/testing/src/server.ts
+++ b/packages/testing/src/server.ts
@@ -6,6 +6,7 @@ import {
 } from '@dunx/core';
 import {
   HttpFactory,
+  HttpOptionsProvider,
   type HttpApp,
   type HttpOptions,
   type Middleware,
@@ -79,17 +80,18 @@ const scopedGuards = (
  * The one silent way this harness can lie: `middleware` and `onError` default
  * away, so a suite that forgets them boots a server with no global guards and the
  * default error mapper, which still answers 200 where the application answers 401.
- * A first integration run of 12 pass / 10 fail is the reported cost of finding
- * that out by hand.
  *
- * So a `Middleware` implementation that is in the graph, is not attached by
- * `@UseGuards`, and was not passed here is worth one line on `console.warn` -
- * `console`, not the bound `Logger`, because a suite asserting on a
- * `RecordingLogger` should not see an entry the application never wrote.
+ * So a `Middleware` implementation in the graph, not attached by `@UseGuards`, and
+ * reaching the chain from neither the argument nor an `HttpOptionsProvider` is
+ * worth one line on `console.warn` - `console`, not the bound `Logger`, so a suite
+ * asserting on a `RecordingLogger` sees nothing the application never wrote.
+ *
+ * `mapperIsDefault` is passed because `onError` resolves from the same two places.
  */
 const warnAboutGlobals = (
   app: HttpApp,
   modules: readonly ResolvedModule[],
+  mapperIsDefault: boolean,
 ): void => {
   const declared = declaredMiddleware(modules);
   if (declared.length === 0) return;
@@ -102,9 +104,10 @@ const warnAboutGlobals = (
   console.warn(
     `createTestServer: ${orphaned.map((ctor) => ctor.name).join(', ')} ` +
       'implement Middleware and are in the graph under test, but no `middleware` ' +
-      'was supplied. If they are global in main.ts then this fixture is not the ' +
-      'application: no global guard runs and `onError` is the default mapper. ' +
-      'Export one httpOptions(config) and give it to both, or pass ' +
+      'was supplied and no HttpOptionsProvider bound any. If they are global in ' +
+      'main.ts then this fixture is not the application: no global guard runs' +
+      (mapperIsDefault ? ' and `onError` is the default mapper' : '') +
+      '. Bind the same HttpOptionsProvider the application binds, or pass ' +
       '`middleware: []` to say the omission is deliberate.',
   );
 };
@@ -144,8 +147,17 @@ export const createTestServer = async (
     bootLogging: bootLogging ?? false,
     port: 0,
   });
-  if (http.middleware === undefined)
-    warnAboutGlobals(app, collectModules(root));
+  // The argument is not the only source since 3.1.0: `resolveHttpOptions` runs
+  // inside `HttpFactory.create` and reconciles it with the bound
+  // `HttpOptionsProvider`, so reading the argument alone warned at applications
+  // that had done the better thing.
+  const settings = app.get(HttpOptionsProvider);
+  if (http.middleware === undefined && settings.middleware.length === 0)
+    warnAboutGlobals(
+      app,
+      collectModules(root),
+      (http.onError ?? settings.onError) === undefined,
+    );
   if (prefix !== undefined) app.setGlobalPrefix(prefix);
 
   return {

--- a/packages/testing/src/server.ts
+++ b/packages/testing/src/server.ts
@@ -156,7 +156,10 @@ export const createTestServer = async (
     warnAboutGlobals(
       app,
       collectModules(root),
-      (http.onError ?? settings.onError) === undefined,
+      // `in`, not `??`: `resolveHttpOptions` merges by `Object.keys(given)`, so an
+      // explicit `onError: undefined` is a caller saying "no filter" and the
+      // default mapper is what runs.
+      ('onError' in http ? http.onError : settings.onError) === undefined,
     );
   if (prefix !== undefined) app.setGlobalPrefix(prefix);
 


### PR DESCRIPTION
Closes the `createTestServer` false positive found migrating Firecracker to 3.1.1: 13 warnings per `bun test`, on a run where the guards it claimed were absent had run.

## The bug

`createTestServer` gated its globals warning on `http.middleware === undefined`, the caller's **argument**. Since 3.1.0 the argument is not the only source: `resolveHttpOptions` runs inside `HttpFactory.create` and reconciles it with the bound `HttpOptionsProvider`, so the harness was warning about a question it never asked.

Reproduced before the fix, with the provider's guard answering `403` and the warning printing `no global guard runs` above it:

```
status: 403 (the provider guard RAN)
warned: YES -> "DenyGuard implement Middleware ... no global guard runs"
```

Two things made it worse than a stray line:

- **The advice was backwards.** "Export one `httpOptions(config)` and give it to both" is the pre-3.1.0 pattern `HttpOptionsProvider` exists to replace, so an app that had already done the better thing was told to undo it.
- **There was no way to silence it.** `middleware: []` suppresses the warning by overriding the provider with nothing, which turns a false alarm into the real bug the warning was invented to catch.

## The fix

The gate consults the resolved options as well as the argument:

```ts
const settings = app.get(HttpOptionsProvider);
if (http.middleware === undefined && settings.middleware.length === 0)
```

Verified in both directions before writing it, so the warning stays exact for the case it was written for:

```
with provider: resolved middleware = [ "Blocker" ]  -> would warn: false
no provider:   resolved middleware = []             -> would warn: true
```

`onError` had the same split: the message asserted "`onError` is the default mapper" unconditionally while nothing checked it. That clause is now conditional on the resolved handler being absent, and the closing advice points at `HttpOptionsProvider` first, keeping `middleware: []` for a deliberate omission.

## Tests, and the example that was missing

Two tests in `packages/testing/src/server.test.ts`, both failing before the change: one for the provider-supplied middleware, one asserting the mapper clause is dropped when a provider supplied `onError`.

Per Rule 4, `examples/testing` now binds its global middleware through an `HttpOptionsProvider` and asserts the fixture runs the same chain with no warning. Nothing carried that end to end before: `examples/full` has an `AppHttpOptions`, but it supplies `trustProxy` and `prefix` rather than middleware, and its suite uses the real `createApp()` rather than the harness on purpose. The new example test fails against the pre-fix build and passes after.

## Gates

`bun run ci` green on `build`, `static`, `docs`, `examples`, `coverage`, plus `bun run ci unit` separately, and the file-sensitive gates re-run in a clean worktree of the commit. `@dunx/testing` stays at 100% lines. `browser` cannot run here (no Chrome) and is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for globally configured middleware in test servers.
  - Requests now receive an `x-request-id` header, preserving existing IDs or generating new ones.
  - Added support for custom error-handling settings in test-server configuration.

- **Bug Fixes**
  - Prevented misleading warnings when middleware or error handling is supplied through shared configuration.
  - Improved guidance when global middleware is intentionally omitted.

- **Tests**
  - Added integration coverage for request IDs, middleware execution, guards, and custom error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->