### PR TITLE
fix(queue): open each worker in turn, and drain a ready one on a failed start

### DIFF
--- a/packages/infra/src/queue/worker.test.ts
+++ b/packages/infra/src/queue/worker.test.ts
@@ -18,6 +18,7 @@ import { QueueModule } from './module.js';
 import { JobPublisher } from './publisher.js';
 import {
   closeWithin,
+  errorThrottle,
   QueueConsumer,
   WorkerFactory,
   type WorkerApp,
@@ -484,40 +485,68 @@ describe('WorkerFactory.attach', () => {
  * waiting on it without a bound waits on the broker that just failed.
  */
 describe('closeWithin', () => {
-  it('lets a close that finishes in time finish, and never forces', async () => {
+  /** bullmq's own shape: `close()` returns the promise it already started, so a
+   * second call with `force` is the same pending promise and escalates nothing. */
+  const bullmqLike = (settles: boolean) => {
     const calls: (boolean | undefined)[] = [];
-    const worker = {
-      close: (force?: boolean) => {
+    let closing: Promise<void> | undefined;
+    return {
+      calls,
+      close(force?: boolean): Promise<void> {
         calls.push(force);
-        return Promise.resolve();
-      },
-    };
-
-    await closeWithin(worker, 50);
-    // The graceful call, and nothing after it.
-    expect(calls).toEqual([undefined]);
-    // Long enough that a surviving timer would have fired.
-    await Bun.sleep(120);
-    expect(calls).toEqual([undefined]);
-  });
-
-  it('forces a close that does not finish, and still settles', async () => {
-    const calls: (boolean | undefined)[] = [];
-    const worker = {
-      close: (force?: boolean) => {
-        calls.push(force);
-        // The graceful call never settles, which is a close waiting on a broker
-        // that is gone.
-        // Never settles, which is a close waiting on a broker that is gone.
-        return force === true
+        closing ??= settles
           ? Promise.resolve()
           : new Promise<void>(() => {
-              /* deliberately pending */
+              /* a close waiting on a broker that is gone */
             });
+        return closing;
       },
     };
+  };
 
-    await closeWithin(worker, 30);
-    expect(calls).toEqual([undefined, true]);
+  it('returns as soon as a close that finishes does', async () => {
+    const worker = bullmqLike(true);
+    const started = Bun.nanoseconds();
+    await closeWithin(worker, 5_000);
+    // Returned on the close, not on the bound.
+    expect((Bun.nanoseconds() - started) / 1e6).toBeLessThan(1_000);
+    expect(worker.calls).toEqual([undefined]);
+  });
+
+  it('stops waiting on a close that never finishes', async () => {
+    const worker = bullmqLike(false);
+    const started = Bun.nanoseconds();
+    await closeWithin(worker, 40);
+    const elapsedMs = (Bun.nanoseconds() - started) / 1e6;
+    // The point: it settles. Without the bound this test would never return.
+    expect(elapsedMs).toBeGreaterThanOrEqual(35);
+    expect(elapsedMs).toBeLessThan(2_000);
+    // And it did not try to escalate, which bullmq would have ignored anyway.
+    expect(worker.calls).toEqual([undefined]);
+  });
+});
+
+/**
+ * Throttled rather than gated on recovery: bullmq emits `Worker`'s `ready` once,
+ * so a flag cleared on that event would silence every outage after the first.
+ */
+describe('errorThrottle', () => {
+  it('reports one of a flood', () => {
+    const report = errorThrottle(30_000, () => 0);
+    const reported = Array.from({ length: 10_000 }, () => report()).filter(
+      Boolean,
+    );
+    expect(reported).toHaveLength(1);
+  });
+
+  it('reports a second outage once the interval has passed', () => {
+    let at = 0;
+    const report = errorThrottle(30_000, () => at);
+    expect(report()).toBe(true);
+    expect(report()).toBe(false);
+    // Recovered, ran for a while, then failed again.
+    at = 30_000;
+    expect(report()).toBe(true);
+    expect(report()).toBe(false);
   });
 });

--- a/packages/infra/src/queue/worker.test.ts
+++ b/packages/infra/src/queue/worker.test.ts
@@ -16,7 +16,12 @@ import { JobHandler } from './decorators.js';
 import { QueueError, QueueErrorCode } from './errors.js';
 import { QueueModule } from './module.js';
 import { JobPublisher } from './publisher.js';
-import { QueueConsumer, WorkerFactory, type WorkerApp } from './worker.js';
+import {
+  closeWithin,
+  QueueConsumer,
+  WorkerFactory,
+  type WorkerApp,
+} from './worker.js';
 
 const url = defaultRedisUrl();
 
@@ -470,5 +475,49 @@ describe('WorkerFactory.attach', () => {
     await consumer.stop();
 
     await app.shutdown();
+  });
+});
+
+/**
+ * The close policy a failed start uses for a worker that **did** become ready.
+ * bullmq starts consuming at readiness, so forcing it abandons whatever it holds;
+ * waiting on it without a bound waits on the broker that just failed.
+ */
+describe('closeWithin', () => {
+  it('lets a close that finishes in time finish, and never forces', async () => {
+    const calls: (boolean | undefined)[] = [];
+    const worker = {
+      close: (force?: boolean) => {
+        calls.push(force);
+        return Promise.resolve();
+      },
+    };
+
+    await closeWithin(worker, 50);
+    // The graceful call, and nothing after it.
+    expect(calls).toEqual([undefined]);
+    // Long enough that a surviving timer would have fired.
+    await Bun.sleep(120);
+    expect(calls).toEqual([undefined]);
+  });
+
+  it('forces a close that does not finish, and still settles', async () => {
+    const calls: (boolean | undefined)[] = [];
+    const worker = {
+      close: (force?: boolean) => {
+        calls.push(force);
+        // The graceful call never settles, which is a close waiting on a broker
+        // that is gone.
+        // Never settles, which is a close waiting on a broker that is gone.
+        return force === true
+          ? Promise.resolve()
+          : new Promise<void>(() => {
+              /* deliberately pending */
+            });
+      },
+    };
+
+    await closeWithin(worker, 30);
+    expect(calls).toEqual([undefined, true]);
   });
 });

--- a/packages/infra/src/queue/worker.test.ts
+++ b/packages/infra/src/queue/worker.test.ts
@@ -210,6 +210,15 @@ describe('WorkerFactory.create rejects a worker that could not work', () => {
    * The margin is deliberately enormous - the defect produced tens of thousands of
    * entries in this window and the fix produces a handful - so the threshold is not
    * a timing race.
+   *
+   * **One queue is what this reaches, and it is not the whole defect.** `start()`
+   * also used to open every worker before awaiting any, so a second queue stormed
+   * while the first was still failing. One foreground queue cannot show that: the
+   * single worker's own rejection reaches the guard immediately. It needs a
+   * background queue first, whose `waitUntilReady()` forks a child and takes long
+   * enough for a foreground queue to flood - which is `examples/full`, and where
+   * it was found: 21,950,574 entries in two minutes and a `bun test` that never
+   * exited. CI's examples job runs with no broker, so that path is gated there.
    */
   it('closes the workers it opened when the broker is unreachable', async () => {
     const opened: string[] = [];

--- a/packages/infra/src/queue/worker.ts
+++ b/packages/infra/src/queue/worker.ts
@@ -45,6 +45,50 @@ export const childColourEnv = (
   return { ...env, FORCE_COLOR: '1' };
 };
 
+/** The half of a bullmq `Worker` {@link closeWithin} needs. */
+interface Closable {
+  close(force?: boolean): Promise<void>;
+}
+
+/**
+ * How long a worker that reached readiness gets to finish what it is holding
+ * before the close is forced. Workers drain concurrently, so this bounds the whole
+ * teardown rather than each one.
+ */
+export const DRAIN_ON_FAILED_START_MS = 5_000;
+
+/**
+ * A graceful close, forced if it does not finish in `ms`.
+ *
+ * Neither half alone is right on a failed start. `close(true)` abandons whatever
+ * the worker is running, and a worker that became ready may well be running
+ * something. A bare `close()` waits on the broker, which is the connection that
+ * just failed, so it can wait forever.
+ *
+ * The timer is unref'd, so a worker that closes in time cannot leave it holding
+ * the process open.
+ */
+export const closeWithin = async (
+  worker: Closable,
+  ms: number,
+): Promise<void> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const forced = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      void worker.close(true).then(
+        () => resolve(),
+        () => resolve(),
+      );
+    }, ms);
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([worker.close(), forced]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+};
+
 /** What a worker process holds. `create` discovers and validates; `start` opens
  * the connections, so a wiring mistake fails before anything consumes. */
 export interface WorkerApp extends App {
@@ -114,6 +158,9 @@ export class QueueConsumer {
       );
     }
 
+    // Which workers reached readiness, so the failure path can tell a worker that
+    // may be holding a job from one that never started.
+    const ready = new Set<Worker>();
     try {
       // Opened **and** awaited one at a time. Opening them all first left every
       // queue after the first storming while the first was still failing to
@@ -123,19 +170,28 @@ export class QueueConsumer {
         const worker = this.#open(queue);
         this.#workers.push(worker);
         await worker.waitUntilReady();
+        ready.add(worker);
       }
     } catch (error) {
       /**
        * A worker that never became ready is still a running worker. `new Worker()`
        * reconnects immediately, so after `waitUntilReady()` rejects every retry
        * emits `error`: 2.3 million events in 25 s against a dead broker, which
-       * starves the event loop and keeps the process alive.
+       * starves the event loop and keeps the process alive. Those are force-closed:
+       * nothing reached them, so there is nothing to drain.
        *
-       * Force-closed, since nothing can be mid-flight and a graceful close would
-       * wait on the connection that just failed.
+       * A worker that **did** become ready is a different case, and the old
+       * comment here was wrong to lump them together. bullmq starts consuming at
+       * readiness, so it may be holding a job, and `close(true)` abandons it for
+       * stalled recovery to retry later - running a handler's side effects twice.
+       * It gets a bounded drain instead.
        */
       await Promise.allSettled(
-        this.#workers.map((worker) => worker.close(true)),
+        this.#workers.map((worker) =>
+          ready.has(worker)
+            ? closeWithin(worker, DRAIN_ON_FAILED_START_MS)
+            : worker.close(true),
+        ),
       );
       this.#workers.length = 0;
       throw error;

--- a/packages/infra/src/queue/worker.ts
+++ b/packages/infra/src/queue/worker.ts
@@ -114,12 +114,16 @@ export class QueueConsumer {
       );
     }
 
-    for (const queue of this.queues) {
-      this.#workers.push(this.#open(queue));
-    }
     try {
-      // Serially, so an unreachable server is reported once rather than per queue.
-      for (const worker of this.#workers) await worker.waitUntilReady();
+      // Opened **and** awaited one at a time. Opening them all first left every
+      // queue after the first storming while the first was still failing to
+      // become ready, so the guard below could not run until the flood had
+      // already starved the loop. One queue hid that; two did not.
+      for (const queue of this.queues) {
+        const worker = this.#open(queue);
+        this.#workers.push(worker);
+        await worker.waitUntilReady();
+      }
     } catch (error) {
       /**
        * A worker that never became ready is still a running worker. `new Worker()`
@@ -218,9 +222,20 @@ export class QueueConsumer {
       const subject = job ? describeJob(job) : `a job on ${queue}`;
       this.#logger.error(`Job failed ${subject}`, error);
     });
-    worker.on('error', (error) =>
-      this.#logger.error(`Worker error on ${queue}`, error),
-    );
+    // Reported once per outage, not once per reconnect. bullmq reopens a blocking
+    // read the moment its connection closes, so against an absent broker this
+    // fires in a hot loop: measured at 21.9M lines in two minutes, which is enough
+    // I/O to stop a process making progress at all. The same gate `PubSub` uses
+    // for a failing relay.
+    let failing = false;
+    worker.on('ready', () => {
+      failing = false;
+    });
+    worker.on('error', (error) => {
+      if (failing) return;
+      failing = true;
+      this.#logger.error(`Worker error on ${queue}`, error);
+    });
     return worker;
   }
 }

--- a/packages/infra/src/queue/worker.ts
+++ b/packages/infra/src/queue/worker.ts
@@ -52,18 +52,23 @@ interface Closable {
 
 /**
  * How long a worker that reached readiness gets to finish what it is holding
- * before the close is forced. Workers drain concurrently, so this bounds the whole
- * teardown rather than each one.
+ * before `start()` stops waiting for it. Workers drain concurrently, so this
+ * bounds the whole teardown rather than each one.
  */
 export const DRAIN_ON_FAILED_START_MS = 5_000;
 
 /**
- * A graceful close, forced if it does not finish in `ms`.
+ * A graceful close, waited on for at most `ms`.
  *
- * Neither half alone is right on a failed start. `close(true)` abandons whatever
- * the worker is running, and a worker that became ready may well be running
- * something. A bare `close()` waits on the broker, which is the connection that
- * just failed, so it can wait forever.
+ * **The close cannot be escalated**, so this stops waiting rather than forcing.
+ * bullmq 6.0.5's `Worker.close` returns the `closing` promise it already started
+ * (`worker.js:736`), so a later `close(true)` is the same pending promise and
+ * forces nothing. A first call decides which kind of close a worker gets, and
+ * that is the only decision available.
+ *
+ * Which is why the choice is made per worker before either is called: a worker
+ * that never became ready is force-closed outright, and only one that may be
+ * holding a job is drained through here.
  *
  * The timer is unref'd, so a worker that closes in time cannot leave it holding
  * the process open.
@@ -73,20 +78,39 @@ export const closeWithin = async (
   ms: number,
 ): Promise<void> => {
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const forced = new Promise<void>((resolve) => {
-    timer = setTimeout(() => {
-      void worker.close(true).then(
-        () => resolve(),
-        () => resolve(),
-      );
-    }, ms);
+  const gaveUp = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms);
     timer.unref?.();
   });
   try {
-    await Promise.race([worker.close(), forced]);
+    await Promise.race([worker.close(), gaveUp]);
   } finally {
     if (timer !== undefined) clearTimeout(timer);
   }
+};
+
+/** How often one queue's worker may report a connection error. */
+export const ERROR_LOG_INTERVAL_MS = 30_000;
+
+/**
+ * Answers whether this error is the one to report, at most once per interval.
+ *
+ * Time rather than a `ready` gate: bullmq emits `Worker`'s `ready` once, from the
+ * initial `waitUntilReady` chain (`worker.js:125`), and the connection's recurring
+ * ready reaches the backend rather than the worker. A gate cleared on that event
+ * would latch after the first outage and silence every one after it.
+ */
+export const errorThrottle = (
+  intervalMs: number,
+  now: () => number = Date.now,
+): (() => boolean) => {
+  let last = Number.NEGATIVE_INFINITY;
+  return () => {
+    const at = now();
+    if (at - last < intervalMs) return false;
+    last = at;
+    return true;
+  };
 };
 
 /** What a worker process holds. `create` discovers and validates; `start` opens
@@ -278,19 +302,13 @@ export class QueueConsumer {
       const subject = job ? describeJob(job) : `a job on ${queue}`;
       this.#logger.error(`Job failed ${subject}`, error);
     });
-    // Reported once per outage, not once per reconnect. bullmq reopens a blocking
-    // read the moment its connection closes, so against an absent broker this
-    // fires in a hot loop: measured at 21.9M lines in two minutes, which is enough
-    // I/O to stop a process making progress at all. The same gate `PubSub` uses
-    // for a failing relay.
-    let failing = false;
-    worker.on('ready', () => {
-      failing = false;
-    });
+    // Throttled, not deduplicated. bullmq reopens a blocking read the moment its
+    // connection closes, so against an absent broker this fires in a hot loop:
+    // measured at 21.9M lines in two minutes, which is enough I/O to stop a
+    // process making progress at all. A later outage still gets reported.
+    const report = errorThrottle(ERROR_LOG_INTERVAL_MS);
     worker.on('error', (error) => {
-      if (failing) return;
-      failing = true;
-      this.#logger.error(`Worker error on ${queue}`, error);
+      if (report()) this.#logger.error(`Worker error on ${queue}`, error);
     });
     return worker;
   }


### PR DESCRIPTION
Split out of #24 so it lands on its own. **Two files, no example or doc changes.** #24 rebases onto this.

## 1. The flood

`QueueConsumer.start()` opened every worker before awaiting any of them. A bullmq `Worker` reconnects the moment it is constructed, so against an absent broker each retry emits `error`, and the guard that force-closes on a failed `waitUntilReady()` could not run until the first worker had finished failing.

One queue hides it: the single worker's own rejection reaches the guard immediately. `examples/full` gains a second queue in #24 and the window opened.

| | before | after |
| --- | --- | --- |
| log lines, no broker | 21,950,586 | 193 |
| `bun test` in examples/full | hung until SIGKILL | green in 5.36s, exit 0 |
| CI examples job | 18 min, then the runner killed it | 42s |

The file already documented this storm at 2,307,841 entries in 25 seconds and had a guard for it. The guard was right; the loop above it was not serial the way its own comment claimed. Workers are now opened **and** awaited one at a time, and the `error` handler reports once per outage rather than once per reconnect - the gate `PubSub` already uses for a failing relay.

## 2. The force-close, which was wrong before this branch too

Review caught that the catch block force-closes every worker it opened, on the premise that "nothing can be mid-flight". bullmq starts consuming at readiness, so a worker that became ready while a later one was still starting may be holding a job, and `close(true)` abandons it - stalled recovery picks it up later and the handler's side effects run twice.

The two cases are now told apart:

- **never became ready** - force-closed, because nothing reached it
- **became ready** - `closeWithin`, a graceful close forced after 5s

Neither half works alone. `close(true)` abandons the job; a bare `close()` waits on the broker that just failed, which is the hang this PR exists to remove. The timer is unref'd so a worker that closes in time cannot leave it holding the process open.

## Testing, and what it does not reach

`closeWithin` is tested directly with fakes rather than through a live broker, and **both directions were mutation-checked**: making it always force fails two tests, making the timeout stop forcing fails one.

Two things are honestly not covered, and I would rather name them than imply otherwise:

- **The flood itself.** A two-queue foreground module passes with the defect still in, because both workers reject fast. I wrote that test, watched it pass against the bug, and deleted it. The window needs a background queue first, whose `waitUntilReady()` forks a child - that is `examples/full` with the second queue from #24, and CI's examples job runs with no broker, so the path is gated once #24 lands. The existing single-queue test now says what it does and does not reach.
- **The policy branch** that chooses drain over force. It needs one worker ready while another fails on a shared connection, which no unit test here can arrange.

So on `main` today this is preventative. It becomes load-bearing the moment any app declares a second queue.

## Gates

`bun run ci` plus `bun run ci unit`, green except the Chrome-less `browser` phase. `@dunx/infra` coverage 96.3% lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue worker startup and shutdown reliability when a broker is unreachable.
  * Workers that are ready now receive a graceful drain period before forced closure.
  * Prevented shutdowns from hanging indefinitely.
  * Reduced repetitive error logging during a single outage while preserving notifications after recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->