### PR TITLE
chore(deps): zod 4.5, and the $ref root it now emits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
         "bullmq": "^6.0.5",
         "drizzle-orm": "^0.45.2",
         "ioredis": "^6.0.0",
-        "zod": "^4.4.3",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "@dunx/testing": "workspace:*",
@@ -68,7 +68,7 @@
         "@dunx/core": "workspace:*",
         "@dunx/http": "workspace:*",
         "@dunx/transform": "workspace:*",
-        "zod": "^4.4.3",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "@dunx/testing": "workspace:*",
@@ -93,7 +93,7 @@
         "fastify": "^5.6.1",
         "hono": "^4.10.6",
         "valibot": "^1.4.2",
-        "zod": "^4.4.3",
+        "zod": "^4.5.4",
       },
       "devDependencies": {
         "@nestjs/common": "^11.1.28",
@@ -264,7 +264,7 @@
         "@dunx/core": "workspace:*",
         "@dunx/http": "workspace:*",
         "@dunx/testing": "workspace:*",
-        "zod": "^4.4.3",
+        "zod": "^4.5.4",
       },
       "peerDependencies": {
         "@dunx/core": "workspace:*",
@@ -1341,7 +1341,7 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/docs/architecture/cost-of-validation.md
+++ b/docs/architecture/cost-of-validation.md
@@ -202,3 +202,46 @@ handler's return value. Removing it means generating per-route source and `eval`
 it, which is Elysia's approach; it would trade a readable dispatch path for a code
 generator, and at 1.3 µs on a request whose parse alone is 2.9 µs it is not the next
 thing worth doing.
+
+### zod 4.5, measured through the seam dunx actually uses
+
+zod 4.5 landed with two claims: a 9x smaller schema footprint and `z.compile()` for
+3-9x faster parsing. Neither is quotable here as written, because dunx calls
+`schema['~standard'].validate()` rather than `.parse()`, so that is what was
+measured. Median of five runs, **each variant in its own process**, on a shaped
+request body of five fields. Running them in one process undercounts the compiled
+figure by half, since the first variant warms the JIT for the second.
+
+| per validation  | 4.4.3    | 4.5.4    | 4.5.4 + `z.compile()` |
+| --------------- | -------- | -------- | --------------------- |
+| valid           | 0.581 us | 0.547 us | 0.157 us              |
+| one bad field   | 2.516 us | 1.356 us | 1.818 us              |
+| four bad fields | 6.345 us | 2.128 us | 2.669 us              |
+| memory          | 72.6 KB  | 29.4 KB  | 39.5 KB               |
+
+Memory is bytes per schema, linear across 500, 2,000 and 8,000 schemas, so it is
+per-schema cost rather than fixed overhead.
+
+**The upgrade improves rejection and memory.** Valid input moved 0.581 to 0.547 us,
+inside the run-to-run spread. Rejection got 1.9x to 3.0x faster, and a schema costs
+2.5x less to hold.
+
+**`z.compile()` is not adopted.** It reaches 3.5x on valid input, so that claim
+holds. It is also 1.25x to 1.34x **slower** on rejected input and costs 34% more
+memory, and request validation rejects routinely. Whether it pays depends on an
+app's own valid-to-invalid ratio. A compiled schema keeps `~standard` and still
+converts through `z.toJSONSchema`, so a consumer that wants one passes it to a route
+and needs nothing from dunx.
+
+None of it is visible per request. The harness above puts `dunx:zod` at 65,215
+req/s before and 66,117 after, against standard deviations of 2,733 and 6,450, and
+the subjects that touch no validator moved by as much in both directions. Saving
+0.25 us on a request costing tens of microseconds sits under that noise floor.
+
+**The upgrade cost `@dunx/openapi` work.** 4.5 hoists any schema carrying
+`.meta({ id })` into `$defs` and leaves a `$ref` at the root, where 4.4 emitted it
+inline, and a cyclic root moved from `$ref: "#"` to `$ref: "#/$defs/<name>"`. Ten
+tests failed. `convertRoot` now resolves that root back to its definition, so
+`convertObject` still sees an object to split into parameters, and it leaves the
+root's own entry for the caller to register rather than storing it eagerly, which
+had put an unreferenced component in the document for every named params schema.

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -26,7 +26,7 @@
     "bullmq": "^6.0.5",
     "drizzle-orm": "^0.45.2",
     "ioredis": "^6.0.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@dunx/testing": "workspace:*"

--- a/examples/full/src/tour.test.ts
+++ b/examples/full/src/tour.test.ts
@@ -97,10 +97,14 @@ it('generates a JSON Schema from the same zod schema', () => {
   // its `title` when there is one and by its `components/schemas` key otherwise,
   // so a prose title makes the Schemas list read as sentences rather than type
   // names. Verified against Swagger UI 5.32.14.
+  // zod 4.5 hoists the **root** into `$defs` too and leaves a `$ref` behind it,
+  // where 4.4 emitted the root inline and only named children were hoisted. The
+  // named child is still there; what moved is the top of the document.
+  expect(tour.text).toContain('"$ref":"#/$defs/CreateUser"');
   expect(tour.text).toContain(
-    '"$defs":{"Tag":{"type":"object","properties":{"label":{"type":"string",' +
+    '"Tag":{"type":"object","properties":{"label":{"type":"string",' +
       '"minLength":1}},"required":["label"],"additionalProperties":false,' +
-      '"description":"A label attached to a user"}}',
+      '"description":"A label attached to a user"}',
   );
   expect(tour.text).toContain('"description":"Create a user"');
 });

--- a/examples/testing/package.json
+++ b/examples/testing/package.json
@@ -14,7 +14,7 @@
     "@dunx/core": "workspace:*",
     "@dunx/http": "workspace:*",
     "@dunx/transform": "workspace:*",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@dunx/testing": "workspace:*"

--- a/internal/bench/package.json
+++ b/internal/bench/package.json
@@ -41,7 +41,7 @@
     "fastify": "^5.6.1",
     "hono": "^4.10.6",
     "valibot": "^1.4.2",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@nestjs/common": "^11.1.28",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -54,7 +54,7 @@
     "@dunx/core": "workspace:*",
     "@dunx/http": "workspace:*",
     "@dunx/testing": "workspace:*",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "peerDependencies": {
     "@dunx/core": "workspace:*",

--- a/packages/openapi/src/convert.ts
+++ b/packages/openapi/src/convert.ts
@@ -124,6 +124,26 @@ interface RootConversion {
 }
 
 /**
+ * zod 4.5's self-hoisted root, resolved to the definition it points at. Anything
+ * else is returned untouched, including a root that carries siblings alongside a
+ * `$ref`, which is not the shape this is for.
+ */
+const vendorRootKey = (
+  root: Record<string, unknown>,
+  defs: unknown,
+): string | undefined => {
+  const ref = root['$ref'];
+  if (typeof ref !== 'string' || Object.keys(root).length !== 1) {
+    return undefined;
+  }
+  if (!ref.startsWith(DEFS_PREFIX)) return undefined;
+  if (typeof defs !== 'object' || defs === null) return undefined;
+  const key = ref.slice(DEFS_PREFIX.length);
+  const target = (defs as Record<string, unknown>)[key];
+  return typeof target === 'object' && target !== null ? key : undefined;
+};
+
+/**
  * Converts, hoists `$defs` into `components/schemas`, and rewrites the refs that
  * pointed at them. zod emits `#/$defs/Tag`; OpenAPI wants
  * `#/components/schemas/Tag`. That is the whole difference - the definitions
@@ -171,7 +191,25 @@ const convertRoot = async (
     return { root: undefined, unconverted: vendor };
   }
 
-  const { $schema: _schema, $defs: defs, ...rest } = emitted;
+  const { $schema: _schema, $defs: defs, ...vendorRoot } = emitted;
+  // zod 4.5 hoists a schema carrying `.meta({ id })` into `$defs` and leaves a
+  // bare `$ref` at the root, where 4.4 emitted it inline. Resolved back here so
+  // everything downstream reads a schema rather than a reference: `convertObject`
+  // splits the root into `parameters`, which a `$ref` cannot be, and `store.add`
+  // deep-equals, so re-registering the resolved definition is idempotent rather
+  // than a name collision with the one the `$defs` loop already stored.
+  const selfHoisted = vendorRootKey(vendorRoot, defs);
+  const rest =
+    selfHoisted === undefined
+      ? vendorRoot
+      : ((defs as Record<string, unknown>)[selfHoisted] as Record<
+          string,
+          unknown
+        >);
+  // zod 4.4 spelled a self-reference `#`; 4.5 spells it `#/$defs/<name>`.
+  const cyclic =
+    selfHoisted !== undefined &&
+    collectRefs(rest).has(`${DEFS_PREFIX}${selfHoisted}`);
   const id = metaOf(schema)?.id;
   // A cyclic schema refs the document root as `#`, which means "this schema" -
   // true where zod emitted it, false once it is one entry among many. Hoisting is
@@ -186,12 +224,20 @@ const convertRoot = async (
 
   if (defs !== undefined && typeof defs === 'object' && defs !== null) {
     for (const [key, definition] of Object.entries(defs)) {
+      // The entry that *is* the root is the caller's to register or inline:
+      // `convertSchema` hoists it, `convertObject` splits it into parameters and
+      // wants it in neither. Storing it here left an unreferenced component in
+      // the document for every named params schema.
+      //
+      // Unless it refers to itself. A cyclic root needs a component to point at,
+      // which is the same reason `selfReferential` forces a hoist below.
+      if (key === selfHoisted && !cyclic) continue;
       store.add(key, rewriteRefs(definition, map) as JsonSchema);
     }
   }
 
   const root = rewriteRefs(rest, map) as JsonSchema;
-  const selfReferential = collectRefs(rest).has('#');
+  const selfReferential = collectRefs(rest).has('#') || cyclic;
   return {
     root,
     ...(id !== undefined || selfReferential ? { id: name } : {}),

--- a/tools/create-app/src/generate.ts
+++ b/tools/create-app/src/generate.ts
@@ -83,7 +83,7 @@ export const manifest = (features: readonly Feature[]): string => {
  * silently diverging from a version combination that is actually exercised.
  */
 export const THIRD_PARTY: Readonly<Record<string, string>> = Object.freeze({
-  zod: '^4.4.3',
+  zod: '^4.5.4',
   'drizzle-orm': '^0.45.2',
   'better-auth': '^1.6.25',
   bullmq: '^6.0.5',


### PR DESCRIPTION
Upgrades zod 4.4.3 to 4.5.4, measured rather than taken on the release note, and adapts `@dunx/openapi` to the `toJSONSchema` change that came with it.

## Measured through the seam dunx actually calls

dunx validates with `schema['~standard'].validate()`, not `.parse()`, so that is what was measured. Median of five runs, **each variant in its own process** - running them in one undercounts the compiled figure by half, because the first warms the JIT for the second. That mistake is why an earlier draft of these numbers was wrong.

| per validation | 4.4.3 | 4.5.4 | 4.5.4 + `z.compile()` |
| --- | --- | --- | --- |
| valid | 0.581 us | 0.547 us | **0.157 us** |
| one bad field | 2.516 us | **1.356 us** | 1.818 us |
| four bad fields | 6.345 us | **2.128 us** | 2.669 us |
| memory | 72.6 KB | **29.4 KB** | 39.5 KB |

Memory is bytes per schema, linear across 500, 2,000 and 8,000 schemas, so it is per-schema cost rather than fixed overhead.

**The upgrade improves rejection and memory.** Valid input is unchanged inside the spread. Rejection is 1.9x to 3.0x faster and a schema costs 2.5x less to hold.

**`z.compile()` is not adopted.** It reaches 3.5x on valid input, so that claim holds. It is also 1.25x to 1.34x slower on rejected input and costs 34% more memory, and request validation rejects routinely. A compiled schema keeps `~standard` and still converts through `z.toJSONSchema`, so a consumer who wants one passes it to a route and needs nothing from dunx.

**None of it is visible per request.** The repo's own harness puts `dunx:zod` at 65,215 req/s before and 66,117 after, against standard deviations of 2,733 and 6,450, and the subjects that touch no validator moved by as much in both directions. Saving 0.25 us on a request costing tens of microseconds sits under that noise floor.

Recorded in `docs/architecture/cost-of-validation.md`.

## What the upgrade cost

zod 4.5 hoists any schema carrying `.meta({ id })` into `$defs` and leaves a `$ref` at the root, where 4.4 emitted it inline. A cyclic root moved from `$ref: "#"` to `$ref: "#/$defs/<name>"`. **Ten tests failed in `@dunx/openapi`.**

`convertRoot` now:

- **resolves that root back to its definition**, so `convertObject` still has an object to split into `parameters`. A `$ref` cannot be split, which is what produced "the schema is not an object" for every named params schema.
- **leaves the root's own `$defs` entry for the caller to register** rather than storing it eagerly. Storing it there both collided with `convertSchema`'s own `store.add` under the same name, and put an unreferenced component in the document for every named params schema.
- **keeps a cyclic root stored**, since its self-reference needs somewhere to land. Skipping that case was my first attempt and it broke two tests, which is how the distinction got found.

`tour.test.ts` asserts on zod's raw output and was updated to the new shape. The scaffolder's pinned zod version moved with the example it is tested against.

## Gates

`bun run ci` plus `bun run ci unit`, green except the Chrome-less `browser` phase. `sync:templates` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved OpenAPI schema generation for named and cyclic root schemas.
  - Updated generated app templates and examples to use Zod 4.5.4.
  - Root schemas are now represented consistently through reusable references.

- **Bug Fixes**
  - Fixed handling of root schema references in generated OpenAPI components.
  - Improved compatibility with schemas that reference themselves.

- **Documentation**
  - Added benchmark results covering validation speed, rejection performance, and memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->