### PR TITLE
docs: humanize and improve readability across all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ provider with a constructor parameter.
 
 ## How the DI differs
 
+The constructor injection above reads like NestJS. The mechanism resolving it
+underneath is different, in four places.
+
 **No `reflect-metadata`, and no `experimentalDecorators`.** dunx uses standard
 TC39 decorators. `@dunx/transform` reads each class's constructor parameter
 types at load time with [`oxc-parser`](https://github.com/oxc-project/oxc), a
@@ -147,8 +150,9 @@ specifier is a compile error rather than a runtime surprise.
 ## Performance
 
 Structure on Bun does not have to cost throughput. `@dunx/http` is a layer over
-`Bun.serve({ routes })` and lands at 85-100% of the raw server, within noise of
-Elysia, and 3.3-4.7x NestJS on Fastify. Boot is 55 ms against 287 ms.
+`Bun.serve({ routes })`. It lands at 85-100% of the raw server's throughput,
+within noise of Elysia, and 3.3-4.7x NestJS on Fastify. Boot is 55 ms against
+287 ms.
 
 Median req/s, 64 connections, 5 runs:
 
@@ -160,12 +164,12 @@ Median req/s, 64 connections, 5 runs:
 | NestJS (Fastify)   | 37,075      | 36,219      | 32,967      | 16,033          |
 | _Bun.serve (raw)_  | _136,940_   | _133,311_   | _128,930_   | _89,047_        |
 
-The harness runs Go, Rust and JVM subjects alongside these, and the NestJS
-subject is real NestJS with real `reflect-metadata`. It also states what it
-cannot measure: the load generator shares a machine with the subject, and the
+The harness also runs Go, Rust and JVM subjects alongside these. The NestJS
+subject is real NestJS with real `reflect-metadata`. It states what it cannot
+measure, too: the load generator shares a machine with the subject, and the
 closed-loop design is subject to coordinated omission.
 
-Reproduce it with `bun run --filter '@dunx/bench' start`; the methodology is in
+Reproduce it with `bun run --filter '@dunx/bench' start`. The methodology is in
 [internal/bench/README.md](internal/bench/README.md).
 
 ## When not to use it
@@ -194,7 +198,7 @@ backend files, on `@dunx/core`, `@dunx/http`, `@dunx/infra`, `@dunx/auth`,
 
 ## Examples
 
-Each is kept alive by CI, and each exits 0 with no database, Redis or S3
+Each is kept alive by CI. Each also exits 0 with no database, Redis or S3
 installed.
 
 | Example                                      | Answers                                                              |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,11 @@
 # Architecture
 
 The design record: what was measured, what was rejected, and why. It exists so a
-decision is not re-litigated, and so a constraint that was probed on real Bun is not
-re-derived from memory.
+decision is not re-litigated. A constraint that was probed on real Bun should not
+have to be re-derived from memory.
 
 **Not a tutorial.** If you want to learn dunx, start with the
-[Introduction](./guide/01-introduction.md); each page below assumes you already
+[Introduction](./guide/01-introduction.md). Each page below assumes you already
 know what the thing being justified does.
 
 One page per subject. Read the one you need.
@@ -13,8 +13,8 @@ One page per subject. Read the one you need.
 ## Read this first
 
 [**Verified constraints**](./architecture/constraints.md) - what was probed on real
-Bun, and what each result rules out. Every other page rests on it, and a decision
-that contradicts it is a decision made without measuring.
+Bun, and what each result rules out. Every other page rests on it. A decision that
+contradicts it is a decision made without measuring.
 
 ## The framework
 
@@ -25,7 +25,7 @@ that contradicts it is a decision made without measuring.
 
 ## The integrations
 
-Five areas are a mature library wired in rather than dunx code, which is the second
+Five areas are a mature library wired in rather than dunx code. This is the second
 half of the principle above: **never reimplement what Bun does, never invent what a
 mature library already solves.** None of them restates the library's own surface.
 
@@ -37,8 +37,8 @@ mature library already solves.** None of them restates the library's own surface
 | [Logging](./architecture/logging.md)               | `@arkv/logger`, and where a fix belongs        |
 
 The fifth is **swagger-ui-dist**, which `@dunx/openapi` mounts for its `/docs` page.
-It is written up with the tooling rather than here, because what it replaced was a
-frontend of dunx's own: [The tools](./architecture/tooling.md), "The API explorer".
+It is written up with the tooling rather than here: what it replaced was a frontend
+of dunx's own. See [The tools](./architecture/tooling.md), "The API explorer".
 
 ## Shipping it
 
@@ -62,14 +62,15 @@ relative ranking on one machine.
 ## What is not here
 
 - **What to build next** is [ROADMAP.md](./ROADMAP.md), with one file per open item
-  under [`internal/notes/roadmap/`](../internal/notes/roadmap/). The phase plan used to be in this file and is
-  now there, where the rest of the planning already was.
+  under [`internal/notes/roadmap/`](../internal/notes/roadmap/). The phase plan used
+  to be in this file. It now lives there, with the rest of the planning.
 - **Whether something can be built at all**, with the probe output behind the answer,
-  is [`internal/notes/research/`](../internal/notes/research/) - one file per investigated capability, written to
-  be superseded. The pipeline is research, then roadmap, then here: a measurement
-  arrives in `research/`, an accepted item becomes a `roadmap/` file, and what survives
-  delivery lands in `architecture/`. [research/README.md](../internal/notes/research/README.md) holds
-  the verdict table.
+  is [`internal/notes/research/`](../internal/notes/research/) - one file per
+  investigated capability, written to be superseded. The pipeline runs research,
+  then roadmap, then here: a measurement arrives in `research/`, an accepted item
+  becomes a `roadmap/` file, and what survives delivery lands in `architecture/`.
+  [research/README.md](../internal/notes/research/README.md) holds the verdict
+  table.
 - **The rules a change has to satisfy** are in `CLAUDE.md` at the repo root. This
   file records decisions; that one constrains them.
 - **How to contribute** is [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/MIGRATION-FROM-NEST.md
+++ b/docs/MIGRATION-FROM-NEST.md
@@ -22,26 +22,27 @@ preload = ["@dunx/transform/preload"]
 ```
 
 Constructor injection needs no decorator because a load-time plugin records each
-class's parameter types instead. Without the plugin a class with constructor
-parameters has no record, and the container compares that against
-`Function.prototype.length` and fails at boot naming the class.
+class's parameter types instead. Without the plugin, a class with constructor
+parameters has no record. The container compares that against
+`Function.prototype.length` and fails at boot, naming the class.
 
 - **Both entries are needed.** Bun's test runner reads its own `preload`, so missing
   the second gives you a working app and a failing suite.
 - **It is a runtime dependency.** A `--production` install, or a `.dockerignore` that
   drops `bunfig.toml`, breaks the deploy rather than the build.
 
-Deploying a **built** tree changes the answer. The plugin's filter is `/\.tsx?$/`, so
-it never sees emitted JavaScript and no preload setting makes it. Record the
-dependencies at build time instead, with `Bun.build({ plugins: [depsPlugin] })`. The
-boot error tells you which of the two situations you are in.
+Deploying a **built** tree changes the answer. The plugin's filter is `/\.tsx?$/`,
+so it never sees emitted JavaScript, and no preload setting changes that. Record
+the dependencies at build time instead, with `Bun.build({ plugins: [depsPlugin] })`.
+The boot error tells you which of the two situations you are in.
 
 **2. A constructor parameter must name something that exists at runtime.**
 
-An interface, a primitive, a union, a class type parameter or a value imported with
-`import type` all erase, so there is no token to resolve.
+An interface, a primitive, a union, a class type parameter, or a value imported with
+`import type` all erase at runtime. There is no token left to resolve.
 `emitDecoratorMetadata` degrades those to `Object` and hands you `undefined` three
-frames from the mistake. dunx fails at boot naming the parameter and its position.
+frames from the mistake. dunx fails at boot instead, naming the parameter and its
+position.
 
 Replace the type with an abstract class, or bind it with `token()` and declare the
 parameter as that token. Every `*Options` in the framework is a class for this reason.
@@ -71,7 +72,7 @@ One migration hit this three times in three repositories before it stuck.
 
 A scope is keyed on the module **reference**, and `forRoot()` returns a fresh object
 on every call. So `@Module` on a class that also has a `static forRoot()` registers
-its contents twice, and two importers each calling `forRoot()` build two scopes with
+its contents twice. Two importers each calling `forRoot()` build two scopes, with
 two instances of everything in them. Take one:
 
 | The module          | Spelling                                                |
@@ -99,21 +100,21 @@ specifier at all.
 
 ## One handler per job name
 
-Not a boot failure you will hit in the first hour, but a semantic difference worth
-knowing before the queue work starts.
+This is not a boot failure hit in the first hour. It is a semantic difference that
+matters once queue work starts.
 
 A Nest dispatcher that fans one routing key out to every subscriber has no dunx
-equivalent: two handlers claiming the same `(queue, name)` is a boot error.
+equivalent: two handlers claiming the same `(queue, name)` is a boot error instead.
 
-An app doing fan-out decides, per channel, what a retry means there. One migration
-landed on the in-app notification firing on the first attempt only, since a toast
-arriving after a backoff is stale, and the Slack notification awaited and
-rethrowing, since it benefits from retries.
+An app doing fan-out has to decide, per channel, what a retry means there. One
+migration fired the in-app notification on the first attempt only, since a toast
+arriving after a backoff is stale. The same migration awaited and rethrew on the
+Slack notification, since that one benefits from retries.
 
-`QueueModule.forRoot({ consume: 'if-any' })` exists for the other half of this: it
+`QueueModule.forRoot({ consume: 'if-any' })` covers the other half of this: it
 stands down instead of failing when the graph has no `@JobHandler` yet, so the queue
-wiring can land several commits before the first handler. `consume: true` keeps
-refusing.
+wiring can land several commits before the first handler exists. `consume: true`
+keeps refusing.
 
 ## Core DI
 
@@ -316,8 +317,8 @@ to collate across files.
 
 `createParamDecorator` has no successor and will not get one: TC39 decorators have
 no parameter decorators, so there is nowhere for it to come from. The reference app
-has 14 usages across `@CurrentUser` and `@UuidParam`, and the two halves of that
-migrate differently.
+has 14 usages across `@CurrentUser` and `@UuidParam`, and the two halves migrate
+differently.
 
 `@UuidParam` and its relatives are **validation**, and are answered: the schema moves
 onto the route decorator, where it also coerces and documents. See
@@ -341,18 +342,17 @@ export class ProfileController {
 throws a 401. `SessionGuard` is what calls `run()` to establish it, and a job or a
 socket handler that resolved a session itself can call `run()` too.
 
-The gain over a parameter decorator is that it reaches **anything the handler calls,
-however deep**, rather than only the handler's own signature. The cost is that the
-caller is not in the method signature, so it does not appear in the handler's type.
-An app wanting its own `@CurrentUser` writes a one-method service over `AuthContext`
-and injects that.
+The gain over a parameter decorator is that it reaches **anything the handler
+calls, however deep**. A parameter decorator reaches only the handler's own
+signature. The cost is that the caller is not in the method signature, so it does
+not appear in the handler's type. An app wanting its own `@CurrentUser` writes a
+one-method service over `AuthContext` and injects that.
 
 ### `@Optional()`
 
-No equivalent, and no design. Every constructor parameter is required, and a
-parameter whose type is erased is a boot error rather than an `undefined`. An
-optional collaborator is expressed today as a provider that binds a no-op
-implementation.
+No equivalent, and no design. Every constructor parameter is required. A parameter
+whose type is erased is a boot error rather than an `undefined`. An optional
+collaborator is expressed today as a provider that binds a no-op implementation.
 
 ## Out of scope
 
@@ -385,8 +385,7 @@ CRUD controllers, an auth guard reading `@Roles`, OpenAPI, queues and a health
 endpoint. [`examples/full`](https://github.com/petarzarkov/dunx/tree/main/examples/full)
 is the version of that which CI keeps alive.
 
-It exercises the question module scoping introduced, which is which
-cross-cutting guards were only ever cross-cutting because Nest offered nowhere
-else to put them. `SessionGuard` stays app-wide. A throttle on one feature's
-routes, or an audit stamp on one feature's writes, becomes a
-`@Module({ middleware })` line.
+It exercises the question module scoping introduced: which cross-cutting guards
+were only ever cross-cutting because Nest offered nowhere else to put them.
+`SessionGuard` stays app-wide. A throttle on one feature's routes, or an audit
+stamp on one feature's writes, becomes a `@Module({ middleware })` line.

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -4,12 +4,14 @@ better-auth mounted on Bun.serve: the module, the guard and two Bun-native adapt
 
 ## Authentication (`@dunx/auth`)
 
-**better-auth is the authentication system.** `@dunx/auth` is the wiring around it and
-nothing else: no sign-in flow, no session table, no password reset, no OAuth dance.
-Never inventing what a mature library solves is not a close call here - an auth
-system is years of edge cases,
-and a half-built one is a liability dressed as a feature. `better-auth` is an optional
-`peerDependency`, as is `drizzle-orm` behind the `@dunx/auth/drizzle` subpath.
+**better-auth is the authentication system.** `@dunx/auth` is the wiring around it
+and nothing else: no sign-in flow, no session table, no password reset, no OAuth
+dance.
+
+Never inventing what a mature library solves is not a close call here. An auth
+system is years of edge cases, and a half-built one is a liability dressed as a
+feature. `better-auth` is an optional `peerDependency`, as is `drizzle-orm` behind
+the `@dunx/auth/drizzle` subpath.
 
 ### `better-auth` is a required peer, `drizzle-orm` an optional one
 
@@ -29,9 +31,11 @@ optional exactly when the entry point a consumer imports does not need it.
 The guard is `@dunx/http` middleware and reads `@dunx/http`'s `PUBLIC` and `ROLES`
 metadata keys, so the code needs `@dunx/http`'s types. `@dunx/infra` must not depend
 on the web layer - the same coupling was proposed for a request logger in `/logger`
-and refused for the same reason: `@dunx/infra` is what a CLI script, a seeder or a
-queue worker imports, and none of those have an HTTP server. A package that pulled
-`@dunx/http` in behind `@dunx/infra/db` would put a route table in every one of them.
+and refused for the same reason.
+
+`@dunx/infra` is what a CLI script, a seeder or a queue worker imports, and none of
+those have an HTTP server. A package that pulled `@dunx/http` in behind
+`@dunx/infra/db` would put a route table in every one of them.
 
 So the dependency runs the other way: `@dunx/auth` depends on `@dunx/core` and
 `@dunx/http`, and on `@dunx/infra` **not at all**.
@@ -50,10 +54,12 @@ is a much milder fault and the ordinary one for an integration package.
 The decisive argument is consistency, and it cuts the other way from the proposal.
 Every dunx integration is named for the **capability**, never the vendor:
 `@dunx/infra/db` is drizzle and nothing else, `@dunx/infra/queue` is bullmq and
-nothing else, and neither is called `@dunx/drizzle` or `@dunx/bullmq`. Renaming auth
-alone would make it the single vendor-named package in the set - a _less_ coherent
-scheme rather than a more legible one. The vendor belongs in the description, the README and
-the peer dependency, where it already is in all three cases.
+nothing else, and neither is called `@dunx/drizzle` or `@dunx/bullmq`.
+
+Renaming auth alone would make it the single vendor-named package in the set - a
+_less_ coherent scheme rather than a more legible one. The vendor belongs in the
+description, the README and the peer dependency, where it already is in all three
+cases.
 
 It also keeps the name from becoming a hostage. A capability name survives replacing
 the library behind it; `@dunx/better-auth` would be a dead package the day it did not
@@ -67,13 +73,15 @@ other than the name reading oddly.
 
 ### Not depending on `@dunx/infra`, while still using its connections
 
-`drizzleDatabase(connection)` and `redisStorage(connection)` are the two adapters that
-matter, and both would naturally import `DbConnection` and `RedisConnection`. Neither
-does. `DrizzleSource` (`{ dialect, db }`) and `RedisStore` (six methods) are **restated
+`drizzleDatabase(connection)` and `redisStorage(connection)` are the two adapters
+that matter, and both would naturally import `DbConnection` and `RedisConnection`.
+Neither does.
+
+`DrizzleSource` (`{ dialect, db }`) and `RedisStore` (six methods) are **restated
 structurally**, exactly as `@dunx/http` restates Standard Schema and for the same
-reasons: `@dunx/infra`'s real classes satisfy them with no adapter in between, a bare
-`drizzle({ client, schema })` handle works too, and the package's dependency list
-stays at two.
+reasons: `@dunx/infra`'s real classes satisfy them with no adapter in between, a
+bare `drizzle({ client, schema })` handle works too, and the package's dependency
+list stays at two.
 
 The concrete forcing function was a build-order race. `@dunx/infra` as a
 `devDependency` of `@dunx/auth` is not an edge `bun run --filter '*'` orders on, so
@@ -95,11 +103,13 @@ and it is what makes `constructor(private readonly auth: Auth)` work at all.
 
 It is generic over the options, the `BunSQLiteDatabase<typeof schema>` trick
 again: the token is the erased class, the type argument rides on the annotation, so
-`Auth<typeof authOptions>` recovers the plugin-widened `api`. Measured: assigning
-`betterAuth(opts)` to `Auth<typeof opts>` typechecks, and **widening `Auth<O>` to
-`Auth<BetterAuthOptions>` does not** - `$context` is invariant through
-`PluginContext<O>`. So the module narrows the token variable rather than widening the
-value, the same move `DbModule` makes with `DbConnection`.
+`Auth<typeof authOptions>` recovers the plugin-widened `api`.
+
+Measured: assigning `betterAuth(opts)` to `Auth<typeof opts>` typechecks, and
+**widening `Auth<O>` to `Auth<BetterAuthOptions>` does not** - `$context` is
+invariant through `PluginContext<O>`. So the module narrows the token variable
+rather than widening the value, the same move `DbModule` makes with
+`DbConnection`.
 
 `Auth`'s constructor throws when `new.target` is `Auth` itself, copying
 `RedisConnection`: every class self-binds in the container, and an unbound abstract
@@ -108,11 +118,13 @@ token would otherwise resolve to an object whose every member is `undefined`.
 ### Mounting: five wildcard routes, and Bun is still the router
 
 `Bun.serve({ routes })` matches `<basePath>/*` natively - verified on Bun 1.3.14,
-including that it does **not** match the bare `<basePath>`, which better-auth has no
-endpoint at. `AuthHandler` declares one route per verb (`GET`, `POST`, `PUT`, `PATCH`,
-`DELETE`; the last three because a plugin may declare them) and each returns
-`auth.handler(req)` untouched. `buildRoutes` passes a `Response` straight through, so
-`Set-Cookie` and redirects survive.
+including that it does **not** match the bare `<basePath>`, which better-auth has
+no endpoint at.
+
+`AuthHandler` declares one route per verb (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`;
+the last three because a plugin may declare them) and each returns
+`auth.handler(req)` untouched. `buildRoutes` passes a `Response` straight through,
+so `Set-Cookie` and redirects survive.
 
 The controller is a **subclass** created in `forRoot` - `Controller(basePath)(class
 MountedAuthHandler extends AuthHandler {})` - rather than `@Controller` on the shared
@@ -147,7 +159,7 @@ throws an `AuthError` naming both, instead of letting better-auth 404 silently.
 `AuthContext` owns an `AsyncLocalStorage<Principal>`; `SessionGuard` runs `next()`
 inside it. Two alternatives were rejected: request-scoped DI was measured and turned
 down (see **Rejected**), and attaching the principal to `req` reaches a route handler
-but nothing a route handler calls, and that is the case that matters, since the caller is
+but nothing a route handler calls, and that is the case that matters. The caller is
 usually wanted three constructor hops down.
 
 It is **not** a key in `@dunx/core`'s `RequestContext`. That store is the
@@ -158,49 +170,53 @@ every log line inside a guarded request is already correlated to the user.
 
 ### `@Public()` skips the guard outright
 
-The alternative considered was resolving the session best-effort on a public route, so
-`AuthContext.current()` would work there. It was dropped: the mounted auth endpoints
-are all `@Public()`, so it would have put a duplicate session lookup on the busiest
-public path in the app, `get-session` included. A public route that wants an optional
-caller calls `auth.api.getSession({ headers: req.headers })` - one line, explicit, and
-it costs nothing anywhere else.
+The alternative considered was resolving the session best-effort on a public route,
+so `AuthContext.current()` would work there. It was dropped: the mounted auth
+endpoints are all `@Public()`, so it would have put a duplicate session lookup on
+the busiest public path in the app, `get-session` included.
+
+A public route that wants an optional caller calls `auth.api.getSession({ headers:
+req.headers })` - one line, explicit, and it costs nothing anywhere else.
 
 ### `Bun.password` replaces better-auth's scrypt
 
 better-auth's default hasher is a **pure-JavaScript scrypt**; `AuthModule`
 substitutes native bcrypt through `Bun.password` whenever `emailAndPassword` is
-enabled and no `password` was supplied. Bun's own primitive rather than a
+enabled and no `password` was supplied. That is Bun's own primitive rather than a
 library, and it is what `nestjs-template/src/auth/auth.config.ts` already does.
+
 Bun pre-hashes the input, so bcrypt's 72-byte cap is a non-issue even for a
-maximum-length multibyte password, and `verify` swallows Bun's
-`UnsupportedAlgorithm` throw so a hash from another algorithm is a clean 401
-rather than a 500.
+maximum-length multibyte password. `verify` swallows Bun's `UnsupportedAlgorithm`
+throw, so a hash from another algorithm is a clean 401 rather than a 500.
 
 The cost is recorded in the README: an existing scrypt-hashed user table needs
 password resets, or its own `password` implementation.
 
 ### `redisStorage` implements the atomic pair the reference could not
 
-better-auth's `secondaryStorage` marks `getAndDelete` and `increment` optional because
-most clients cannot do them atomically. `Bun.RedisClient` can, through `GETDEL` and
-`INCR`, both already on `@dunx/infra/redis`'s contract - so all five methods are
-implemented rather than the three that are mandatory. Without them better-auth falls
-back to read-then-delete for single-use credentials, which is a race, and to a
-non-atomic rate-limit counter. `increment`'s TTL is applied only when `INCR` returns
-`1`, keeping the window fixed rather than sliding.
+better-auth's `secondaryStorage` marks `getAndDelete` and `increment` optional
+because most clients cannot do them atomically. `Bun.RedisClient` can, through
+`GETDEL` and `INCR`, both already on `@dunx/infra/redis`'s contract - so all five
+methods are implemented rather than the three that are mandatory.
+
+Without them, better-auth falls back to read-then-delete for single-use
+credentials, which is a race, and to a non-atomic rate-limit counter.
+`increment`'s TTL is applied only when `INCR` returns `1`, keeping the window
+fixed rather than sliding.
 
 Redis being unreachable is not softened: a swallowed `null` from `get`
 reads as "no session" and would sign every user out.
 
 ### No schema
 
-The four better-auth tables are better-auth's, they change with the plugins an app
+The four better-auth tables are better-auth's. They change with the plugins an app
 enables, and its own CLI generates them (`bunx @better-auth/cli generate`). A copy
-inside dunx is a copy that rots against the library that reads it. `examples/full` has
-a generated one at `src/database/auth.schema.ts`, re-exported into the app's single
-schema object - which is all `drizzleDatabase(connection)` needs, because
-`@dunx/infra/db` builds its handle with `drizzle({ client, schema })` and the adapter
-reads `db._.fullSchema`.
+inside dunx is a copy that rots against the library that reads it.
+
+`examples/full` has a generated one at `src/database/auth.schema.ts`, re-exported
+into the app's single schema object - which is all `drizzleDatabase(connection)`
+needs, because `@dunx/infra/db` builds its handle with `drizzle({ client, schema })`
+and the adapter reads `db._.fullSchema`.
 
 Two findings from building that fixture, both worth remembering: `db.run(sql\`…\`)`goes through`bun:sqlite`'s `prepare`, which compiles **one** statement and silently
 drops what follows the first semicolon - four `CREATE TABLE`s in one template gives

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -10,7 +10,7 @@ dance.
 
 Never inventing what a mature library solves is not a close call here. An auth
 system is years of edge cases, and a half-built one is a liability dressed as a
-feature. `better-auth` is an optional `peerDependency`, as is `drizzle-orm` behind
+feature. `better-auth` is a required `peerDependency`. `drizzle-orm` is optional behind
 the `@dunx/auth/drizzle` subpath.
 
 ### `better-auth` is a required peer, `drizzle-orm` an optional one

--- a/docs/architecture/benchmarks.md
+++ b/docs/architecture/benchmarks.md
@@ -10,53 +10,58 @@ and the measurements behind them.
 
 **The first thing the harness found was a regression dunx had shipped to itself.**
 `@dunx/http` had just made `RequestLoggingMiddleware` a default, and the bench
-subject predated it, so the suite was quietly measuring the logger. dunx fell from
-~86-94% of raw `Bun.serve` to **34% on `json`, 33% on `params` and 9.6% on
-`validate`** - 8.5k req/s against 88k, a p50 of 7.4 ms. Setting
+subject predated it. The suite was quietly measuring the logger instead.
+
+dunx fell from ~86-94% of raw `Bun.serve` to **34% on `json`, 33% on `params` and
+9.6% on `validate`** - 8.5k req/s against 88k, a p50 of 7.4 ms. Setting
 `requestLogging: false` restored ~89%, which located the fault precisely.
 
 Three causes, in order of cost:
 
 - **`response.clone().text()` on every JSON response**, and `req.clone().text()` on
   every JSON request body. Two clone-and-buffer passes over every payload, on the
-  hot path, to fill fields most responses never need read. Both are now **off by
-  default**, correct for privacy and log volume independently of
-  speed, since the response body is also the field most likely to carry a secret.
+  hot path, to fill fields most responses never read. Both are now **off by
+  default**. That is correct for privacy and log volume independently of speed:
+  the response body is also the field most likely to carry a secret.
 - **`new URL(req.url)` per request**, parsing scheme, host, port, query and hash to
   reach a pathname. Replaced with an `indexOf` slice; the query string is parsed
   only when there is one.
-- What remains is `JSON.stringify` plus a `write` per line, the irreducible
-  price of logging and is why `dunx-logging` is its own subject rather than folded
-  into the framework's number.
+- What remains is `JSON.stringify` plus a `write` per line: the irreducible price
+  of logging. `dunx-logging` is measured as its own subject for that reason,
+  rather than folded into the framework's number.
 
 **The rest of the gap to Elysia was async machinery on values that were never
 promises.** The general request path is
 `async (req) => toResponse(await handler(await read(req)), status)` wrapped in an
-`async` try/catch. For a route with no middleware, no CORS and no declared schemas,
-`read` is the identity reader and a sync handler returns a plain object - so both
-`await`s cost an async frame and a microtask tick for nothing, twice per request.
+`async` try/catch.
 
-`buildRoutes` now emits a **synchronous handler** for exactly that shape, returning a
-`Response` rather than a `Promise<Response>` (Bun accepts either). A handler that
-does return a promise is adopted instead of awaited by a wrapper. Measured on
-`plaintext`: **89.5% -> 97.2%** of raw `Bun.serve`, which puts dunx within 0.8
-points of Elysia there and within 1.5 points on every scenario. Elysia's advantage was that it
-compiles this shape ahead of time; this reaches most of the same place without a
-code generator.
+For a route with no middleware, no CORS and no declared schemas, `read` is the
+identity reader, and a sync handler returns a plain object. Both `await`s cost an
+async frame and a microtask tick for nothing, twice per request.
+
+`buildRoutes` now emits a **synchronous handler** for exactly that shape, returning
+a `Response` rather than a `Promise<Response>` (Bun accepts either). A handler that
+does return a promise is adopted instead of awaited by a wrapper.
+
+Measured on `plaintext`: **89.5% -> 97.2%** of raw `Bun.serve`, which puts dunx
+within 0.8 points of Elysia there and within 1.5 points on every scenario. Elysia's
+advantage was compiling this shape ahead of time; this reaches most of the same
+place without a code generator.
 
 The lesson worth keeping: a default that is convenient in development can be the
 single largest cost in production, and nobody would have known without a harness
-that compares against the floor. `Bun.serve` as a subject is what made the
-regression legible - a 9.6% row is impossible to rationalise.
+that compares against the floor. `Bun.serve` as a subject made the regression
+legible - a 9.6% row is impossible to rationalise.
 
 **The load generator is native, and that was measured rather than assumed.**
 The harness supports two: [oha](https://github.com/hatoo/oha) (Rust, via `bun
-run setup`) and a fallback driver written on Bun's `fetch` across worker
-threads. Against the same raw `Bun.serve` process at 64 connections, oha
-extracts **135k req/s** and the JavaScript driver plateaus at **80k**,
-collapsing to **23k** at 256 connections as thirty worker threads contend on
-Bun's connection pool. The JS driver would have understated every Bun subject
-by roughly 40% and compressed the whole ranking.
+run setup`) and a fallback driver written on Bun's `fetch` across worker threads.
+
+Against the same raw `Bun.serve` process at 64 connections, oha extracts **135k
+req/s** and the JavaScript driver plateaus at **80k**, collapsing to **23k** at 256
+connections as thirty worker threads contend on Bun's connection pool. The JS
+driver would have understated every Bun subject by roughly 40% and compressed the
+whole ranking.
 
 This is "native over JavaScript reimplementation" holding in a place where it
 is easy to check: `oxc-parser` over a JS AST library is the same call.
@@ -79,14 +84,14 @@ Using it would have inflated the ceiling `@dunx/http` is measured against.
 **Every subject validates with the same zod schema**, including Fastify and Elysia,
 which ship faster compiled validators. Holding the validator constant is what makes
 `validate` minus `json` readable as one framework's validation plumbing. It
-understates Fastify and Elysia, and the JSON report records each subject's validator
+understates Fastify and Elysia. The JSON report records each subject's validator,
 so the handicap is visible rather than implied.
 
-**Latency histograms in place of reservoir sampling.** The fallback driver buckets latencies
-at 1 µs up to 100 ms and merges `Uint32Array`s across workers. The alternative -
-sampling a subset - needs an RNG, and a sampled p99 is a p99 with an error bar nobody
-reads. It also keeps `Math.random` out of a number that matters, per the `@arkv/rng`
-rule.
+**Latency histograms in place of reservoir sampling.** The fallback driver buckets
+latencies at 1 µs up to 100 ms and merges `Uint32Array`s across workers. The
+alternative - sampling a subset - needs an RNG. A sampled p99 is a p99 with an
+error bar nobody reads. It also keeps `Math.random` out of a number that matters,
+per the `@arkv/rng` rule.
 
 What the harness found, in one line each:
 
@@ -164,6 +169,7 @@ subjects existed, and this is that rule earning its place.
 **Every subject is one process on one thread.** For Bun and Node that is a fact
 about the runtime. For Go, tokio and Tomcat it is a decision the harness
 imposes - `GOMAXPROCS(1)`, a `current_thread` runtime, `tomcat.threads.max=1`.
+
 Lift it and `net/http` goes to ~230,000 and Axum to ~503,000 at the same 64
 connections, while neither Bun subject can move at all. **These rows flatter
 Bun by exactly the factor the reader is not shown**, which the bench README

--- a/docs/architecture/constraints.md
+++ b/docs/architecture/constraints.md
@@ -204,7 +204,7 @@ Four results worth keeping:
   modifier when checking assignability, so the object branch exists to reach nested
   arrays. A function is returned untouched, because mapping over one discards its
   call signature.
-- **`infer R extends ResponseMap` is load bearing.** Without the constraint the
+- **`infer R extends ResponseMap` is load-bearing.** Without the constraint the
   narrowed `O` in the branch is `{ response: R } & O`, whose `response` no longer
   satisfies `RouteSchemas`, and the nested `SuccessStatus<O, M>` fails with
   `TS2344`. Measured both ways.

--- a/docs/architecture/constraints.md
+++ b/docs/architecture/constraints.md
@@ -5,10 +5,10 @@ What was measured on real Bun, and what each measurement rules out. Every other 
 ## Why this exists
 
 Elysia and Hono own Bun's web-framework space and are mature. Neither offers
-dependency injection, modules, or class-based controllers, and Elysia's chained
-builder API is precisely what NestJS refugees bounce off. That gap is the whole
-product. dunx should stay a **DI + structure** framework that happens to serve
-HTTP - not drift into a general web framework.
+dependency injection, modules, or class-based controllers. Elysia's chained
+builder API is precisely what NestJS refugees bounce off, and that gap is the
+whole product. dunx should stay a **DI + structure** framework that happens to
+serve HTTP - not drift into a general web framework.
 
 ## Verified constraints
 
@@ -26,10 +26,10 @@ There is no reason to build a radix tree in JavaScript. dunx's job is to _emit_
 the `routes` object at boot and hand it to Bun.
 
 **`server.upgrade(req)` works from inside a `routes` handler.** Bun's own types
-bless it - `Serve.RoutesWithUpgrade` allows `Response | undefined | void` when
+bless it: `Serve.RoutesWithUpgrade` allows `Response | undefined | void` when
 `websocket` is present. So a WebSocket gateway is mounted as a native `GET`
-route rather than needing a hand-written `fetch` fallback, which means **Bun's
-router does run on the upgrade path** and a gateway path may be a pattern
+route rather than needing a hand-written `fetch` fallback. That means **Bun's
+router does run on the upgrade path**, and a gateway path may be a pattern
 (`/room/:room`, with `req.params.room` readable in `@OnUpgrade`).
 
 An earlier note claiming the opposite was wrong and is retired. With no `fetch`
@@ -65,8 +65,8 @@ server.requestIP(req) -> {"address":"::ffff:127.0.0.1","family":"IPv6","port":41
 
 That is what `'trust proxy'` chooses between: the first `X-Forwarded-For` entry
 when trusted, this address otherwise. `Response` headers are also mutable after
-construction, which is what lets CORS headers be applied outside the error mapper
-so a mapped 500 still carries them.
+construction. This lets CORS headers be applied outside the error mapper, so a
+mapped 500 still carries them.
 
 **`emitDecoratorMetadata` is lossy.** With `experimentalDecorators` +
 `emitDecoratorMetadata`, `constructor(db: Db, cache: Cache, n: number)` yields:
@@ -93,8 +93,8 @@ member list   member one   class Users
 
 **`ctx.metadata` is write-only in Bun, and leaks in both directions.** Bun 1.3.14
 hands a `ctx.metadata` object to decorators but leaves `Symbol.metadata`
-undefined, so nothing can read it back off the class without a polyfill - the
-exact "must be the first import" fragility being escaped. Polyfill it and each
+undefined. Nothing can read it back off the class without a polyfill - the exact
+"must be the first import" fragility being escaped. Polyfilling it means each
 class's metadata object gets its parent's as its **prototype**, so `routes ??= []`
 in a subclass resolves through the chain and mutates the _parent's_ array:
 
@@ -141,8 +141,8 @@ Orphan: GET /leaked <- proto Orphan.leaked  # found, but in no other class's cha
 ```
 
 Two subclasses of one undecorated abstract base both resolve the base's route. A
-field handler's arrow captures `this` (`users.one`), and a field declared before
-the field it reads still works, because handlers run per request (`late-value`).
+field handler's arrow captures `this` (`users.one`). A field declared before the
+field it reads still works too, because handlers run per request (`late-value`).
 
 **A route decorator can _check_ a handler's input type but cannot _infer_ it.**
 Measured with `tsc`, because this is a type-level claim `bun` cannot answer. Given
@@ -155,10 +155,10 @@ unannotated parameter          -> TS7006: Parameter 'input' implicitly has an 'a
 annotated with the wrong type  -> TS1241 + TS1270, naming the mismatched property
 ```
 
-A standard method decorator is `(value: V, ctx: ClassMethodDecoratorContext) => V | void`,
-so it can reject a mismatched `V` but has no way to contextually type an
-unannotated parameter. Input must therefore be annotated - and the annotation is a
-type-level function over the options object, so each type is still written once:
+A standard method decorator is `(value: V, ctx: ClassMethodDecoratorContext) => V | void`.
+It can reject a mismatched `V` but has no way to contextually type an unannotated
+parameter, so input must be annotated. The annotation is a type-level function
+over the options object, so each type is still written once:
 
 ```ts
 const createNote = { body: CreateNote, status: HttpStatusCode.CREATED } as const;
@@ -202,16 +202,16 @@ Four results worth keeping:
   every array in the declared shape to `readonly`, which the mutable one still
   satisfies. Only arrays need it: TypeScript already ignores a property's `readonly`
   modifier when checking assignability, so the object branch exists to reach nested
-  arrays, and a function is returned untouched because mapping over one discards its
+  arrays. A function is returned untouched, because mapping over one discards its
   call signature.
 - **`infer R extends ResponseMap` is load bearing.** Without the constraint the
   narrowed `O` in the branch is `{ response: R } & O`, whose `response` no longer
   satisfies `RouteSchemas`, and the nested `SuccessStatus<O, M>` fails with
   `TS2344`. Measured both ways.
 - **A plain `JsonSchema` entry turns the check off for that route**, becoming
-  `unknown`, which absorbs any return type. There is no type to infer from JSON, and
-  that is the deliberate escape hatch for a response no schema value describes.
-  Options widened by a missing `as const` do the same thing.
+  `unknown`, which absorbs any return type. There is no type to infer from JSON, so
+  this is the escape hatch for a response no schema value describes. Options
+  widened by a missing `as const` do the same thing.
 
 It found a real defect on the first run: `examples/full` documented `User` with a
 `tags: string[]` the `users` table has no column for, so every user response
@@ -221,8 +221,8 @@ advertised an array no handler returned.
 closed.** `@dunx/transform` is `oxc-parser`: a single-file syntax parser with no
 program and no checker. It reads a return type's syntax fine, but
 `Promise<UserDto>` is a name that needs cross-file resolution, generics and mapped
-types to become a schema - a type checker, which is what `@nestjs/swagger`'s plugin
-runs during `nest build`.
+types to become a schema. That requires a type checker, the same kind
+`@nestjs/swagger`'s plugin runs during `nest build`.
 
 A class return type gives a runtime value whose field annotations are erased, and
 the two things Nest leans on for that (`emitDecoratorMetadata`, parameter
@@ -231,9 +231,9 @@ decorators) are both banned here.
 Probed: the one extractable case is a return type whose syntax names a runtime
 value, as `z.infer<typeof User>` does, where `TSTypeQuery.exprName` is the schema.
 It was rejected anyway. `Promise<z.infer<typeof User>[]>` silently yields `User`,
-losing the array, and fixing that means implementing `[]`, `Array<>`, `Partial<>`
-and `Pick<>` as operations over a runtime schema value. It also only helps someone
-who already holds the schema value they could have written into `response`.
+losing the array. Fixing that means implementing `[]`, `Array<>`, `Partial<>` and
+`Pick<>` as operations over a runtime schema value. It also only helps someone who
+already holds the schema value they could have written into `response`.
 
 **`drizzle-orm/bun-sql` is Postgres, not `Bun.SQL`.** `Bun.SQL` speaks four
 dialects - `postgres`, `mysql`, `mariadb`, `sqlite`, quoted from its own rejection
@@ -245,7 +245,7 @@ const dialect = new PgDialect({ casing: config.casing });
 ```
 
 Unconditional, with no branch on `client.options.adapter` anywhere in the module.
-Pointed at a `sqlite://` client it does not error - it compiles `$1` placeholders
+Pointed at a `sqlite://` client it does not error. It compiles `$1` placeholders
 and Postgres identifier quoting against SQLite, and the trivial cases pass, which
 is worse than failing.
 
@@ -272,8 +272,8 @@ nativeTx[config.behavior ?? 'deferred']();
 ```
 
 Measured on Bun 1.3.14: insert, `await Bun.sleep(1)`, throw, catch - the row is
-still there. So `drizzle` being a mature library does not make this one safe,
-and `@dunx/infra/db` exports a standalone `transaction(db, fn)` that issues
+still there. So `drizzle` being a mature library does not make this one safe.
+`@dunx/infra/db` exports a standalone `transaction(db, fn)` that issues
 `BEGIN`/`COMMIT`/`ROLLBACK` itself. There is one connection, so overlapping
 top-level transactions queue rather than nest a second `BEGIN`; a nested call
 is already inside the holder's turn and takes a savepoint instead.
@@ -297,8 +297,8 @@ cannot tell the type system it is there.
 This is why **entity decorators were rejected**. drizzle's whole value is the table
 object's _type_ carrying column types into every query; a decorator could build a
 working table at runtime while every query degraded to `unknown`. Recovering the
-types would mean hand-writing a mapped type mirroring drizzle's `BuildColumns` - a
-second source of truth that drifts from the first, which is exactly the duplication
+types would mean hand-writing a mapped type mirroring drizzle's `BuildColumns`: a
+second source of truth that drifts from the first, undoing the duplication
 decorators were meant to remove. drizzle's native `sqliteTable` object schema is the
 supported path.
 
@@ -307,6 +307,9 @@ annotation but not _infer_ it. Decorators observe; they do not type. Note the
 contrast with `@Controller`, `@Get`, `@Module`, `@Gateway` and `@Roles`, which all
 work fine - they only _record_ metadata read back at boot, and publish nothing to
 the type system.
+
+The constraints above cover the request path and dependency injection. The one
+below covers testing the dashboard itself.
 
 ## `Bun.WebView` drives the dashboard headlessly, on Bun 1.4.0
 
@@ -334,10 +337,10 @@ screenshot bytes: 67832
 What each number rules out. 227 nodes means the inlined bundle ran, since the
 served shell is a handful of elements. 8 `<style>` tags and a computed
 `background-color` of `rgb(36, 36, 36)` matching `--mantine-color-body: #242424`
-mean the cascade resolved, which is the assertion happy-dom cannot make at all. The
-panel text and a 67 KB screenshot cover the render.
+mean the cascade resolved: happy-dom cannot make that assertion at all. The panel
+text and a 67 KB screenshot cover the render.
 
-Three things worth knowing before building on it:
+Three things to consider before building on it:
 
 - **No display is needed and none is used.** The same probe produces a
   byte-identical 3,510-byte screenshot of a trivial page with `DISPLAY=:0` and with
@@ -356,4 +359,5 @@ The surface is `navigate`, `evaluate`, `screenshot`, `cdp`, `click`, `type`,
 **Playwright was not measured, because this answered the question first.** It is
 permitted here - `internal/*` is exempt from Rule 1 - and would be the fallback if
 a test needed more than the list above. `Bun.WebView` costs no dependency and no
-browser download, so it is what a dashboard smoke test should be written against.
+browser download. That makes it what a dashboard smoke test should be written
+against.

--- a/docs/architecture/cost-of-logging.md
+++ b/docs/architecture/cost-of-logging.md
@@ -22,12 +22,13 @@ and a `GET` has no body. `bun run logging:bodies` adds a ladder on `POST /valida
 
 The two request-body rows differ by one `Request.clone()`. Decomposed on raw
 `Bun.serve`, cloning a request whose body is an unread network stream costs ~8 µs
-before either half is read and ~20 µs once one is; the second buffer and the second
-`JSON.parse` are 0.32 µs together, and putting the body in the entry is 0.27 µs.
+before either half is read and ~20 µs once one is. The second buffer and the
+second `JSON.parse` are 0.32 µs together, and putting the body in the entry is
+0.27 µs.
 
 **So the expensive part was never the parsing, which is where everyone looks.** A
 route declaring a `body` schema now has its buffered text handed to the logger
-through `RawBody`, and only an unvalidated route still clones. The old figure was
+through `RawBody`. Only an unvalidated route still clones. The old figure was
 right about the old code and only ever described the unvalidated case.
 
 ### The default path, re-measured
@@ -64,11 +65,11 @@ largest step overall before the write.
 
 ## The cost of request logging on Bun 1.3.14 (`internal/bench` logging harness)
 
-`bun run logging` is the third harness, and it exists because `dunx-logging` in the
+`bun run logging` is the third harness. It exists because `dunx-logging` in the
 main suite was **one number for at least eight different things**. It sat at 40-45%
 of raw `Bun.serve` while `dunx` sat at 90-98%, so dunx's _default_ configuration -
-the one nearly every user runs - cost more than half the throughput, and nothing said
-which half.
+the one nearly every user runs - cost more than half the throughput, and nothing
+said which half.
 
 `servers/logging/dunx.ts` is one app whose middleware is truncated at a step chosen
 by `$LOGGING_VARIANT`, plus three stand-in `Logger` bindings that stop after the
@@ -100,11 +101,11 @@ subsequent write until the kernel finds room. Seven of the eight subjects log
 nothing, so only `dunx-logging` ever hit it - the one row where it mattered.
 
 Measured, on the `json` scenario: an unbatched writer into an unread pipe cost
-**2.68 µs/request** more than the same writer into `/dev/null`. Subjects now write to
-`/dev/null` (`StdoutSink` in `src/subject-process.ts`), which is a real `write(2)`
-that can never block, and the blocked-pipe case survives as an explicit row rather
-than as the default. The docstring in `servers/dunx-logging.ts` claimed the harness
-drained that pipe; it never did.
+**2.68 µs/request** more than the same writer into `/dev/null`. Subjects now write
+to `/dev/null` (`StdoutSink` in `src/subject-process.ts`), which is a real
+`write(2)` that can never block. The blocked-pipe case survives as an explicit row
+rather than as the default. The docstring in `servers/dunx-logging.ts` claimed the
+harness drained that pipe; it never did.
 
 ### Where the time went
 
@@ -140,18 +141,18 @@ Three suspicions were wrong, recorded here as wrong:
 
 What actually costs: **the first touch of `req.headers`** (1.29 µs - Bun
 materialises the whole header map, and the inbound `x-request-id` is part of the
-contract, so it is irreducible), the **`AsyncLocalStorage` scope** (0.91 µs, which is
-what makes a handler's own log lines carry `requestId`), and **building and
-serialising the entry** (2.05 µs, most of it `JSON.stringify`).
+contract, so it is irreducible), the **`AsyncLocalStorage` scope** (0.91 µs, the
+mechanism that makes a handler's own log lines carry `requestId`), and **building
+and serialising the entry** (2.05 µs, most of it `JSON.stringify`).
 
 ### The write was the largest single component, and batching removed it
 
-One `console.log` per request measured **+1.24 µs** against not writing at all - more
-than the `JSON.stringify` that produced the line. `ConsoleLogger` now concatenates
-entries at `info` and below into one string and writes it once per event-loop turn,
-and the write becomes **unmeasurable** (−0.62 µs against the serialise-only row, i.e.
-inside the noise floor). It also largely defuses the blocked-pipe case: with batching
-an unread pipe costs 1.16 µs instead of 2.68.
+One `console.log` per request measured **+1.24 µs** against not writing at all -
+more than the `JSON.stringify` that produced the line. `ConsoleLogger` now
+concatenates entries at `info` and below into one string and writes it once per
+event-loop turn. The write becomes **unmeasurable** (−0.62 µs against the
+serialise-only row, i.e. inside the noise floor). It also largely defuses the
+blocked-pipe case: with batching an unread pipe costs 1.16 µs instead of 2.68.
 
 Things that were measured and did **not** work, all in a real `Bun.serve` handler:
 
@@ -169,8 +170,8 @@ Things that were measured and did **not** work, all in a real `Bun.serve` handle
 this work preferred a library to the platform primitive. A `FileSink.write()`
 encodes into its own
 buffer on every call, so it pays per entry exactly what it was meant to save; a JS
-string concatenation is a rope and pays almost nothing. Only the _flush_ is a write,
-and once per turn it does not matter which API performs it - so the flush goes
+string concatenation is a rope and pays almost nothing. Only the _flush_ is a
+write, and once per turn it does not matter which API performs it. The flush goes
 through `console.log`, which is also what keeps `console` interception working in
 tests.
 
@@ -200,7 +201,7 @@ things bound it, and they are asserted in `packages/core/src/logger/console.test
 they returned `{}` immediately, so every request paid two async frames and two
 `await`s on values that were never promises. They now return `Promise<unknown>
 | undefined`, where `undefined` means there is nothing to read and the caller
-stays synchronous, and the scope callback passed to `runWithContext` is a plain
+stays synchronous. The scope callback passed to `runWithContext` is now a plain
 function using `.then` rather than an `async` arrow.
 
 This is the same fault the input reader had, found the same way, and an
@@ -212,17 +213,18 @@ one. The pathname and the query string now come out of **one** pair of
 shape every framework call has. The general path spends two array allocations (the
 rest parameter, then `[message, ...rest]`), a third object and an `Object.assign` to
 reach an entry the fast path builds as one literal. The timestamp is cached by
-millisecond: at any rate worth logging, `Date.now()` has not moved since the previous
-entry, and `new Date().toISOString()` measured ~170 ns.
+millisecond: at any rate worth logging, `Date.now()` has not moved since the
+previous entry. `new Date().toISOString()` measured ~170 ns.
 
 ### Rejected: skipping the entry when the level would drop it
 
 `Logger` exposes `logLevel`, so `RequestLoggingMiddleware` could check at
 construction whether `info` survives and skip building the `request` object. It was
-not done. The default level _is_ `info`, so the gate never fires in the configuration
-being optimised; and a 4xx logs at `warn` and a 5xx at `error`, both of which need
-the same `request` object, which is not known until after `next()` resolves. The
-branch would add a field and a condition to buy nothing on the default path.
+not done. The default level _is_ `info`, so the gate never fires in the
+configuration being optimised. A 4xx logs at `warn` and a 5xx at `error`, both of
+which need the same `request` object, which is not known until after `next()`
+resolves. The branch would add a field and a condition to buy nothing on the
+default path.
 
 ### Rejected: a cheaper request id
 
@@ -236,8 +238,8 @@ It used to be `req.headers.get(REQUEST_ID_HEADER) ?? crypto.randomUUID()`, so
 `curl -H 'x-request-id: MY-OWN-ID'` was echoed on the response and written into
 every line the request produced. That is a caller-supplied string on a trust
 boundary: it can carry a newline, be a megabyte long, or be set to somebody else's
-trace id knowingly. `nestjs-template` ran `isUuid()` on it first, and that is what
-was adopted, the accepted shape matching what this middleware mints.
+trace id knowingly. `nestjs-template` ran `isUuid()` on it first. dunx adopted the
+same check, the accepted shape matching what this middleware mints.
 
 Any UUID version passes; the check reads the layout rather than the version nibble, because
 an upstream service minting v7 is not a threat model. The order matters more than
@@ -249,13 +251,12 @@ can resolve, and below the `crypto.randomUUID()` call that follows it either way
 
 ### `ignore` skips everything, and `correlateIgnored` buys back the half worth having
 
-`ignore` returns `next()` before anything else happens, which makes it
-free and also means an ignored path has no `x-request-id` and no
-`AsyncLocalStorage` scope - so a health check's own log lines were
-uncorrelated, and guide 12 claimed the id was "always set on the response".
-Splitting `ignore` into two lists was rejected: the cost is not the path list,
-it is the work, and a second list would still not say which work.
-`correlateIgnored: boolean` names the work instead.
+`ignore` returns `next()` before anything else happens, which makes it free. It
+also means an ignored path has no `x-request-id` and no `AsyncLocalStorage`
+scope, so a health check's own log lines were uncorrelated, and guide 12 claimed
+the id was "always set on the response". Splitting `ignore` into two lists was
+rejected: the cost is not the path list, it is the work, and a second list would
+still not say which work. `correlateIgnored: boolean` names the work instead.
 
 On an ignored path it pays for the header read, the id, the scope and one
 `Headers.set` - the four rows above that sum to ~2.2 µs of the ~5.4 the full
@@ -265,10 +266,10 @@ path costs, and never for the entry, the expensive half. Default
 ### The 500's stack goes through the bound `Logger`
 
 `defaultErrorMapper` wrote it with `console.error`. In a JSON-only service that
-is one structured entry from request logging plus a multi-line, Bun-formatted
-dump that a collector reads as several broken records, and a custom `onError`
-was the only way to suppress it. `errorMapper(logger)` is now the real
-implementation and `HttpApplication` builds the default from `app.get(Logger)`,
+means one structured entry from request logging plus a multi-line, Bun-formatted
+dump that a collector reads as several broken records. A custom `onError` was
+the only way to suppress it. `errorMapper(logger)` is now the real
+implementation, and `HttpApplication` builds the default from `app.get(Logger)`,
 so the stack lands in the same stream and the same shape as everything else.
 
 `defaultErrorMapper` remains as `errorMapper(new ConsoleLogger())` for

--- a/docs/architecture/cost-of-logging.md
+++ b/docs/architecture/cost-of-logging.md
@@ -26,10 +26,11 @@ before either half is read and ~20 µs once one is. The second buffer and the
 second `JSON.parse` are 0.32 µs together, and putting the body in the entry is
 0.27 µs.
 
-**So the expensive part was never the parsing, which is where everyone looks.** A
-route declaring a `body` schema now has its buffered text handed to the logger
-through `RawBody`. Only an unvalidated route still clones. The old figure was
-right about the old code and only ever described the unvalidated case.
+**So the expensive part was never the parsing, which is where everyone looks.**
+For a JSON route declaring a `body` schema, `RawBody` records the buffered text
+when request-body logging is enabled. Only an unvalidated route still clones.
+The old figure was right about the old code and only ever described the
+unvalidated case.
 
 ### The default path, re-measured
 

--- a/docs/architecture/cost-of-validation.md
+++ b/docs/architecture/cost-of-validation.md
@@ -5,25 +5,25 @@ Reading the body costs about three times as much as validating it. Measured, wit
 ## The cost of request validation (`internal/bench` validation harness)
 
 `bun run validation` in `internal/bench` is a second harness, separate from
-`bun run start`, because the main suite deliberately cannot answer two questions: it
-holds the validator constant at zod so `validate` minus `json` reads as one
-framework's plumbing, which folds **the absolute cost of parsing and validating**
-together with **dunx's own overhead**. This one separates them. `servers/validation/`
-has two subjects - raw `Bun.serve` and a dunx app - each serving routes that add one
-step at a time, and `$VALIDATOR` swaps the library behind `~standard` without
-changing anything else.
+`bun run start`. The main suite cannot answer two questions at once: it holds the
+validator constant at zod, so `validate` minus `json` reads as one framework's
+plumbing. That folds **the absolute cost of parsing and validating** together with
+**dunx's own overhead**. This harness separates them. `servers/validation/` has two
+subjects, raw `Bun.serve` and a dunx app, each serving routes that add one step at a
+time. `$VALIDATOR` swaps the library behind `~standard` without changing anything
+else.
 
 **The first version of this harness measured each row to completion in turn,
-and that was wrong.** The differences it exists to report are 2-4%, and the
-machine's own throughput drifts by more than that over the minutes a run takes -
+and that was wrong.** The differences it exists to report are 2-4%. The
+machine's own throughput drifts by more than that over the minutes a run takes,
 so the drift landed on whichever row happened to be measured while it was
 happening. It produced `raw:parse` as _slower_ than `raw:noop`, which does
 strictly more work, and several negative validator costs.
 
 The runner now brings every unit up first and measures them **round-robin**,
-which spreads the drift across all rows equally; the ordering came out
+which spreads the drift across all rows equally. The ordering came out
 monotonic on the first attempt afterwards. Noise floor at this throughput is
-about **±0.3 µs**, and figures below it are reported rather than clamped.
+about **±0.3 µs**; figures below it are reported rather than clamped.
 
 ### Parsing costs 3x what validating costs
 
@@ -34,11 +34,11 @@ about **±0.3 µs**, and figures below it are reported rather than clamped.
 | `POST` + `await req.json()`              |  12.14 | +3.10 µs |
 | `POST` + `req.json()` + zod              |  13.09 | +0.94 µs |
 
-Putting a body on the wire is near-free; reading it is 3.10 µs and validating it is
-0.94 µs. The ~30% drop from the `json` scenario to the `validate` scenario that every
-subject in the main suite pays is therefore **77% `req.json()` and 23% zod**. The
-primitive that would fix it is a validating parser Bun does not ship - recorded in
-[bun-apis.md](../bun-apis.md), along with why dunx must not write one.
+Putting a body on the wire is near-free. Reading it costs 3.10 µs, and validating it
+costs 0.94 µs. Every subject in the main suite sees about a 30% jump from the `json`
+scenario to the `validate` scenario, and that gap is **77% `req.json()` and 23%
+zod**. The primitive that would fix it is a validating parser Bun does not ship,
+recorded in [bun-apis.md](../bun-apis.md) along with why dunx must not write one.
 
 ### Every validator is cheaper than the parse
 
@@ -54,34 +54,33 @@ changed. Cost is that validator's own time, taken as the raw `Bun.serve` subject
 | Valibot                     |  0.89 µs | native      |
 | zod                         |  0.94 µs | native      |
 
-**zod, Valibot and ArkType are within noise of each other**, and both compiled
-options land at or under the noise floor - TypeBox's compiled checker is
-indistinguishable from not validating at all on a three-field payload. All five
-are under the 3.10 µs the parse costs, so **there is no throughput argument for
-steering a user off zod**: a 0.9 µs saving on a request that takes 13 µs is 7%,
-against giving up zod's ecosystem, error messages and `z.toJSONSchema` (which
-`@dunx/openapi` uses).
+**zod, Valibot and ArkType are within noise of each other.** Both compiled options
+land at or under the noise floor: TypeBox's compiled checker is indistinguishable
+from not validating at all on a three-field payload. All five are under the 3.10
+µs the parse costs, so **there is no throughput argument for steering a user off
+zod**. A 0.9 µs saving on a request that takes 13 µs is 7%, against giving up
+zod's ecosystem, error messages and `z.toJSONSchema` (which `@dunx/openapi` uses).
 
-The advice this produces is "pick on API, not on this table", and the table
-exists so that advice is checkable. It would very likely read differently on a
-deeply nested schema, where compiled straight-line code diverges from an
-interpreter far more than at this size - which is a limitation of the payload,
-and is recorded in the harness's README.
+The advice this produces is "pick on API, not on this table," and the table exists
+so that advice is checkable. On a deeply nested schema the result would likely
+differ: compiled straight-line code diverges from an interpreter far more than it
+does at this size. That is a limitation of the payload, recorded in the harness's
+README.
 
 Neither TypeBox 0.34 nor ajv 8 exposes `~standard`. Both were bridged in about ten
-lines each in `servers/validation/schemas.ts` - a boolean `Check` plus their error
-iterator, wrapped in a `~standard.validate`. That a compiled JSON Schema checker
-drops into a dunx route with no change to `@dunx/http` is the payoff of targeting an
-interface instead of a library, and it is worth knowing it was tested rather than
-assumed. Valibot and ArkType need no bridge; ArkType's `ArkErrors` is an `Array`
-subclass with an `issues` getter, which the existing code already handles.
+lines each in `servers/validation/schemas.ts`: a boolean `Check` plus their error
+iterator, wrapped in a `~standard.validate`. A compiled JSON Schema checker drops
+into a dunx route with no change to `@dunx/http` - that is the payoff of targeting
+an interface instead of a library, tested rather than assumed. Valibot and ArkType
+need no bridge; ArkType's `ArkErrors` is an `Array` subclass with an `issues`
+getter, which the existing code already handles.
 
 ### Where dunx's 11 points went: async machinery, not validation
 
-The main suite's `validate` row sat at **84.0% of raw `Bun.serve`** while `json` sat
-at 95.3%. Splitting dunx's side the same way - two extra dunx routes that declare no
-schemas and do the parse and the validation inside the handler, so they stay on the
-synchronous dispatch path - located it. Measured **before** the changes below:
+The main suite's `validate` row sat at **84.0% of raw `Bun.serve`**, while `json`
+sat at 95.3%. Splitting dunx's side the same way located it: two extra dunx routes
+declare no schemas and do the parse and the validation inside the handler, so they
+stay on the synchronous dispatch path. Measured **before** the changes below:
 
 | Subject                                       | µs/req | dunx's share        |
 | --------------------------------------------- | -----: | ------------------- |
@@ -105,14 +104,14 @@ Valibot or ArkType ever does - verified, all three return a plain object.
 Three changes, each measured:
 
 1. **`packages/http/src/server/input.ts`: nothing is `async` any more.** `Fill` is
-   `(draft) => InputDraft | Promise<InputDraft>` and every step looks at what it got
+   `(draft) => InputDraft | Promise<InputDraft>`, and every step looks at what it got
    instead of awaiting it. A `query`- or `params`-only route with a synchronous
-   validator now returns the input **with no promise at all**; a `body` route pays one
-   promise link on `req.json()` instead of six frames. The `then` fold returns the
-   draft rather than `void` precisely so the reader can be `(req) => fill({ req })` -
+   validator now returns the input **with no promise at all**. A `body` route pays
+   one promise link on `req.json()` instead of six frames. The `then` fold returns
+   the draft rather than `void`, so the reader can be `(req) => fill({ req })`:
    threading the draft back through a second `then` cost a measurable 58 ns.
    `mediaTypeOf` also short-circuits on a verbatim `application/json` header rather
-   than slicing, trimming and lowercasing it: worth ~70 ns when the header is bare.
+   than slicing, trimming and lowercasing it, saving ~70 ns when the header is bare.
 2. **`packages/http/src/server/routes.ts`: the direct dispatch path now covers routes
    that read input.** It used to require `readsNothing`; the condition is now just "no
    middleware and no CORS", and `readsNothing` is gone because the general code
@@ -120,24 +119,24 @@ Three changes, each measured:
    rather than awaited.
 3. **A `query` route stopped parsing the whole URL, and `grouped` stopped iterating.**
    `new URL(req.url).searchParams` resolved scheme, host, port, path and fragment to
-   reach a query string, then built a `URLSearchParams` anyway - measured at **~1,040
-   of the ~1,520 ns** a three-pair query route cost, which was more than the entire
-   body reader. An `indexOf('?')` slice into `new URLSearchParams` removes the URL
-   parse; the fragment is still stripped, because `new URL` stripped it and a
-   request-target that carries one should not change what a schema sees.
-   `RequestLoggingMiddleware` had taken exactly this slice for exactly this reason -
-   the same fault twice, in two files, found the same way.
+   reach a query string, then built a `URLSearchParams` anyway. That cost **~1,040 of
+   the ~1,520 ns** a three-pair query route took, more than the entire body reader.
+   An `indexOf('?')` slice into `new URLSearchParams` removes the URL parse. The
+   fragment is still stripped: `new URL` stripped it too, and a request-target that
+   carries one should not change what a schema sees. `RequestLoggingMiddleware`
+   had taken exactly this slice for exactly this reason: the same fault twice, in two
+   files, found the same way.
 
    `grouped` then switched from `for…of` destructuring to `forEach`, which both
-   `URLSearchParams` and `FormData` implement natively: destructuring an iterator
-   allocates a two-element array per entry, and dropping it was worth another ~140 ns.
+   `URLSearchParams` and `FormData` implement natively. Destructuring an iterator
+   allocates a two-element array per entry, and dropping it saved another ~140 ns.
    Together: **1,520 -> 1,024 ns**, a third of a query route's cost.
 
    What is left is `new URLSearchParams(search)` at ~624 ns, and it stays. Splitting
-   on `&`/`=` and calling `decodeURIComponent` by hand would be faster and is exactly
-   exactly what is ruled out: a JavaScript reimplementation of a Web standard
-   Bun implements natively, with `+`-versus-`%20`, repeated keys, empty values and
-   malformed escapes to get wrong.
+   on `&`/`=` and calling `decodeURIComponent` by hand would be faster. It would also
+   be a JavaScript reimplementation of a Web standard Bun already implements, with
+   `+`-versus-`%20`, repeated keys, empty values and malformed escapes to get wrong,
+   so it stays ruled out.
 
 Measured one change at a time, as dunx's own overhead per request on the zod validate
 route:
@@ -148,12 +147,12 @@ route:
 | after the reader change   |       2.64 µs |       83.0% |
 | after the dispatch change |       1.40 µs |       90.3% |
 
-In the main suite that is **`validate` 84.0% -> 92.3% of raw `Bun.serve`**,
-which also puts dunx **9 points ahead of Elysia** on the one scenario where it
-used to be level (Elysia is at 83.2% in the same run). The reader now costs
-_less_ than doing the same work by hand in a handler - the "framework does it"
-row comes out 0.19 µs **below** the hand-written one, inside the noise floor,
-which is the honest reading of "no longer costs anything".
+In the main suite that is **`validate` 84.0% -> 92.3% of raw `Bun.serve`**. It
+also puts dunx **9 points ahead of Elysia** on the one scenario where it used to
+be level (Elysia is at 83.2% in the same run). The reader now costs _less_ than
+doing the same work by hand in a handler: the "framework does it" row comes out
+0.19 µs **below** the hand-written one, inside the noise floor, which is the
+honest reading of "no longer costs anything".
 
 The microbenchmark agrees and can resolve it: the reader's plumbing went from
 **597 ns to 146 ns** with a no-op schema, a 4.1x improvement, and a
@@ -163,11 +162,11 @@ ns** with no promise allocated at all.
 Nothing about the `json`, `params` or `plaintext` rows moved, which is the check that
 changes 1 and 2 are confined to routes that declare a schema.
 
-Change 3 has **no HTTP evidence at all**, and that is a gap rather than a detail:
-neither harness has a route with a declared `query` schema - the main suite's `params`
-scenario reads `input.req.params` with no schema, so it never touches the query path.
-The 1,520 -> 1,024 ns is microbenchmark-only, and the right fix is a `query` scenario
-in the harness rather than a larger claim here.
+Change 3 has **no HTTP evidence at all**, and that is a gap rather than a detail.
+Neither harness has a route with a declared `query` schema: the main suite's
+`params` scenario reads `input.req.params` with no schema, so it never touches the
+query path. The 1,520 -> 1,024 ns figure is microbenchmark-only. The right fix is a
+`query` scenario in the harness rather than a larger claim here.
 
 ### Tried and rejected: a specialised single-schema reader
 
@@ -176,41 +175,43 @@ avoidable: a hand-written body-only reader that builds `{ req, body }` as one li
 and calls `~standard.validate` inline measured **306 ns/request against the shipped
 reader's 394 ns** on the same microbenchmark - a real, repeatable 88 ns.
 
-Rejected. 88 ns is 0.6% of a 14 µs request, which is **below the noise floor of
-the HTTP harness** (run-to-run stddev is 1-3%), so the win cannot be
-demonstrated at the level anyone experiences it - and unlike the `forEach`
-change above, which is a comparable 140 ns, it does not pay for itself in
-simplicity. It would need one code path per declared combination to be
-consistent, and would duplicate the 415 and 400 handling that `bodyFill` owns,
-where `forEach` replaced a `for…of` with fewer moving parts than it had before.
+Rejected. 88 ns is 0.6% of a 14 µs request, below the noise floor of the HTTP
+harness (run-to-run stddev is 1-3%), so the win cannot be demonstrated at the
+level anyone experiences it. Unlike the `forEach` change above, which is a
+comparable 140 ns, it does not pay for itself in simplicity: it would need one
+code path per declared combination to stay consistent, and it would duplicate the
+415 and 400 handling that `bodyFill` owns. `forEach` replaced a `for…of` with
+fewer moving parts than it had before; this change would not.
 
 That asymmetry is the rule this file is applying: a sub-noise-floor win is
 worth taking when the code gets simpler and not when it does not.
 
-Also rejected: pre-seeding the draft with the declared keys set to `undefined` so the
-property stores do not transition the object's shape. It changes `Object.keys(input)`
-for a route whose validator rejects, which is observable, for a fraction of the 88 ns
-above.
+Also rejected: pre-seeding the draft with the declared keys set to `undefined` so
+the property stores do not transition the object's shape. It changes
+`Object.keys(input)` for a route whose validator rejects. That is observable, for
+a fraction of the 88 ns above.
 
 ### What still costs, and why it is not obviously fixable
 
-dunx's remaining ~1.3 µs on this route is **dispatch, not validation**: a dunx route
-whose handler does the parse itself still costs 1.17 µs over the identical raw
-`Bun.serve` handler, and the input reader now adds almost nothing on top. That
+dunx's remaining ~1.3 µs on this route is **dispatch, not validation**. A dunx
+route whose handler does the parse itself still costs 1.17 µs over the identical
+raw `Bun.serve` handler, and the input reader adds almost nothing on top. That
 residue is the closure indirection and the one extra promise link needed to adopt a
-handler's return value. Removing it means generating per-route source and `eval`-ing
-it, which is Elysia's approach; it would trade a readable dispatch path for a code
-generator, and at 1.3 µs on a request whose parse alone is 2.9 µs it is not the next
-thing worth doing.
+handler's return value.
+
+Removing it means generating per-route source and `eval`-ing it, which is Elysia's
+approach. That trades a readable dispatch path for a code generator, and at 1.3 µs
+on a request whose parse alone is 2.9 µs, it is not the next thing worth doing.
 
 ### zod 4.5, measured through the seam dunx actually uses
 
 zod 4.5 landed with two claims: a 9x smaller schema footprint and `z.compile()` for
 3-9x faster parsing. Neither is quotable here as written, because dunx calls
 `schema['~standard'].validate()` rather than `.parse()`, so that is what was
-measured. Median of five runs, **each variant in its own process**, on a shaped
-request body of five fields. Running them in one process undercounts the compiled
-figure by half, since the first variant warms the JIT for the second.
+measured. Figures below are the median of five runs, **each variant in its own
+process**, on a shaped request body of five fields. Running them in one process
+undercounts the compiled figure by half, since the first variant warms the JIT
+for the second.
 
 | per validation  | 4.4.3    | 4.5.4    | 4.5.4 + `z.compile()` |
 | --------------- | -------- | -------- | --------------------- |
@@ -240,8 +241,9 @@ the subjects that touch no validator moved by as much in both directions. Saving
 
 **The upgrade cost `@dunx/openapi` work.** 4.5 hoists any schema carrying
 `.meta({ id })` into `$defs` and leaves a `$ref` at the root, where 4.4 emitted it
-inline, and a cyclic root moved from `$ref: "#"` to `$ref: "#/$defs/<name>"`. Ten
+inline. A cyclic root moved from `$ref: "#"` to `$ref: "#/$defs/<name>"`, and ten
 tests failed. `convertRoot` now resolves that root back to its definition, so
-`convertObject` still sees an object to split into parameters, and it leaves the
-root's own entry for the caller to register rather than storing it eagerly, which
-had put an unreferenced component in the document for every named params schema.
+`convertObject` still sees an object to split into parameters. It also leaves the
+root's own entry for the caller to register rather than storing it eagerly: storing
+it eagerly had put an unreferenced component in the document for every named
+params schema.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -13,10 +13,10 @@ This is the second half of the principle - _never invent what a mature library
 already solves_ - applied to the one place it was being violated. The
 hand-rolled contract was an ORM's front half: it had a query surface, so it
 would have grown result mapping, relations, and a migration story, each one a
-worse version of something drizzle already ships. The rule's own resolution of
-the tension is what the layer now looks like: **the library owns the
-abstraction, Bun owns the I/O**, via `drizzle-orm/bun-sqlite` over `bun:sqlite`
-and `drizzle-orm/bun-sql` over `Bun.SQL`.
+worse version of something drizzle already ships. The layer now reflects the
+rule's own resolution of that tension: **the library owns the abstraction, Bun
+owns the I/O**, via `drizzle-orm/bun-sqlite` over `bun:sqlite` and
+`drizzle-orm/bun-sql` over `Bun.SQL`.
 
 No `pg`, no `better-sqlite3`. `drizzle-orm` is an optional `peerDependency`, so
 the consumer owns the version and an app that never touches a database never
@@ -29,9 +29,9 @@ What remains is only what a drizzle handle genuinely lacks:
   driver handle. drizzle has none of these; it does not even know whether its
   driver is open.
 - **Module wiring.** `DbModule` binds three tokens: `DbOptions`, `DbConnection`,
-  and **drizzle's own database class**. That last one is the whole trick - drizzle's
+  and **drizzle's own database class**. That last one is the whole trick: drizzle's
   `BunSQLiteDatabase` and `BunSQLDatabase` are real runtime classes, so a class is
-  usable as a token directly, and `@dunx/transform` records the bare type name from
+  usable as a token directly. `@dunx/transform` records the bare type name from
   `db: BunSQLiteDatabase<typeof schema>` while ignoring the type argument. One
   erased class is the token; the schema types stay on the annotation. No wrapper
   object, and no `token()` call.
@@ -43,12 +43,12 @@ What remains is only what a drizzle handle genuinely lacks:
   two journals never contend.
 
 **`casing` and `logger` are drizzle's and are forwarded rather than restated.** Both
-backends forwarded only `schema` to `drizzle()`, which put two of drizzle's
-four config keys out of reach of anything constructed inside the container -
-`casing: 'snake_case'` being the standard drizzle idiom, and the query `logger`
-being how a slow endpoint gets diagnosed. The port of `nestjs-template` worked
-around it by spelling out every column name and dropping `casing` from
-`drizzle.config.ts` so drizzle-kit and the runtime handle would agree, and
+backends forwarded only `schema` to `drizzle()`, which put two of drizzle's four
+config keys out of reach of anything constructed inside the container:
+`casing: 'snake_case'` is the standard drizzle idiom, and the query `logger` is
+how a slow endpoint gets diagnosed. The port of `nestjs-template` worked around
+it by spelling out every column name and dropping `casing` from
+`drizzle.config.ts`, so drizzle-kit and the runtime handle would agree. It also
 dropped a `DB_LOG_QUERIES` env var as unimplementable.
 
 Both init types now extend `DrizzleInit`, whose two fields are spread into
@@ -58,12 +58,12 @@ so this package holds no opinion about either and cannot fall behind them.
 exactly as it does `schema` and `url`.
 
 Two costs are accepted rather than papered over. `DbModule.forRootAsync` has to
-take the token as its first argument, because which drizzle class the token is only
-becomes knowable after the options factory has run - too late to register a
-provider under it. And because schema modules are dialect-specific (`sqliteTable`
-vs `pgTable`), the two backends are a build-time choice; "one `DATABASE_URL` naming
-either" is no longer a supported shape, and the old contract only ever supported it
-by hiding the differences.
+take the token as its first argument, because which drizzle class the token is,
+only becomes knowable after the options factory has run - too late to register a
+provider under it. Because schema modules are dialect-specific (`sqliteTable` vs
+`pgTable`), the two backends are also a build-time choice: "one `DATABASE_URL`
+naming either" is no longer a supported shape, and the old contract only ever
+supported it by hiding the differences.
 
 Entity decorators were the alternative considered for the schema and were
 **measured and rejected** - see **Verified constraints**, "A decorator cannot
@@ -72,12 +72,12 @@ the supported path.
 
 ### Synchronous SQLite mode
 
-`bun:sqlite` is synchronous underneath and `@dunx/http` has a dispatch path that
-allocates no promise when a handler returns a plain value, so a request can in
-principle go parse → query → respond without yielding. Reads already could -
-drizzle's bun-sqlite builders have `.all()`/`.get()`/`.run()`. What stopped a
-_write_ was `transaction()`, which returns a promise, so any route that wrote
-anything went back to `async`.
+`bun:sqlite` is synchronous underneath, and `@dunx/http` has a dispatch path
+that allocates no promise when a handler returns a plain value. So a request
+can in principle go parse → query → respond without yielding. Reads already
+could: drizzle's bun-sqlite builders have `.all()`/`.get()`/`.run()`. What
+stopped a _write_ was `transaction()`, which returns a promise, so any route
+that wrote anything went back to `async`.
 
 `SyncSqliteOptions` closes that. The mode is a **sibling options class rather than a
 flag**, because the mode decides the handle type and the handle type is what
@@ -87,9 +87,9 @@ token becomes `SyncDatabase`, and `transactionSync(db, fn)` becomes reachable.
 
 **`SyncDatabase` is an empty subclass of drizzle's `BunSQLiteDatabase` with one
 declared property, `synchronous: true`.** The property is what stops the two
-from being structurally identical, and that is the whole mechanism - TypeScript is
-structural, so an empty subclass would be mutually assignable and would gate
-nothing. `SyncSqliteConnection` defines the property on the handle drizzle
+from being structurally identical. TypeScript is structural, so without it an
+empty subclass would be mutually assignable and would gate nothing.
+`SyncSqliteConnection` defines the property on the handle drizzle
 built, so the type is true rather than claimed; it is non-enumerable, so
 nothing that walks the handle sees it.
 
@@ -109,8 +109,8 @@ That second one is the interesting half, because **it inverts the finding
 above.** `transaction()` exists because drizzle's bun-sqlite transaction
 commits when the callback returns, so an async callback commits before its
 first `await` resumes. Every part of that failure is downstream of the callback
-being asynchronous. Remove the promise and `bun:sqlite`'s own wrapper is
-exactly right, so `transactionSync` **delegates to drizzle's
+being asynchronous. Remove the promise, and `bun:sqlite`'s own wrapper is
+exactly right. So `transactionSync` **delegates to drizzle's
 `db.transaction()`** instead of issuing `BEGIN`/`COMMIT` itself: no statement
 strings, no serialising queue, no promise.
 
@@ -128,21 +128,22 @@ API cannot pretend the two backends are symmetric.
 
 One deliberate ugliness: `SqliteConnection` gained a second type parameter for the
 handle, and assigns it with `as unknown as TDb`. The alternatives were a subclass
-redeclaring `db` - which TypeScript 7 rejects as `declare override`, and which
-without `declare` would define the field as `undefined` over the base's assignment -
-or a standalone `SyncSqliteConnection` that is not a `SqliteConnection`, breaking
-`connection instanceof SqliteConnection` for the raw-handle escape hatch. One cast
-in one constructor, immediately made true by the subclass, was the smaller cost.
+redeclaring `db`, which TypeScript 7 rejects as `declare override` and which,
+without `declare`, would define the field as `undefined` over the base's
+assignment. The other option was a standalone `SyncSqliteConnection` that is not a
+`SqliteConnection`, breaking `connection instanceof SqliteConnection` for the
+raw-handle escape hatch. One cast in one constructor, immediately made true by the
+subclass, was the smaller cost.
 
 #### What it measures, which is less than the pitch
 
-`internal/bench`'s `bun run db-modes` runs the comparison end to end through a real
-`Bun.serve`, interleaved round-robin for the reason the validation harness records.
-Two scenarios per mode, `requestLogging: false` so every route stays on the direct
-dispatch path: a single indexed `SELECT`, and a transaction doing two `UPDATE`s and
-a read. An earlier version inserted rows instead of updating them and had to be
-thrown away - the table grew under later rounds, so the write scenario measured its
-own history (σ was twice the median).
+`internal/bench`'s `bun run db-modes` runs the comparison end to end through a
+real `Bun.serve`, interleaved round-robin for the reason the validation harness
+records. Two scenarios run per mode, with `requestLogging: false` so every route
+stays on the direct dispatch path: a single indexed `SELECT`, and a transaction
+doing two `UPDATE`s and a read. An earlier version inserted rows instead of
+updating them and had to be thrown away, because the table grew under later
+rounds, so the write scenario measured its own history (σ was twice the median).
 
 AMD Ryzen 9 5950X, 32 threads, Bun 1.3.14, oha 1.15.0, 64 connections, 11 rounds of
 5 s, medians:
@@ -182,8 +183,8 @@ caller can act on, and the information needed to say so is in the driver's error
 on `AppError.status`, an integer, so `@dunx/infra` still imports nothing of the
 web layer. `CursorError` and `PageOptionsError` already worked this way.
 
-Four kinds are distinguished, being the four every supported dialect reports
-separately: unique and foreign key answer 409, not-null and check answer 400. A
+Four kinds are distinguished: the four every supported dialect reports
+separately. Unique and foreign key answer 409, not-null and check answer 400. A
 foreign key sits with the 409s because its two causes - inserting a child with no
 parent, and deleting a parent with children - share one driver code, and only the
 first is a bad value from the caller.
@@ -192,11 +193,11 @@ The driver's message stays out of the response. `@dunx/http` sends `error.messag
 to the caller for a 4xx, and a driver names the table, the column and the index in
 its own: `duplicate key value violates unique constraint "users_email_key"` would
 put the schema in a response body. `ConstraintError` carries a generic message per
-kind and holds the original as `cause`, which is what gets logged.
+kind and holds the original as `cause`. That original is what gets logged.
 
 **Where it is applied.** `transaction`, `transactionSync` and `runSeeds` classify
-on the way out, those being the query paths this package owns. Drizzle owns the
-rest, and wrapping `db.insert()` would mean restating drizzle's surface, so a
+on the way out: those are the query paths this package owns. Drizzle owns the
+rest. Wrapping `db.insert()` would mean restating drizzle's surface, so a
 repository calls `toDatabaseError` in its own `catch` - one line, shown in
 `examples/full/src/users/users.repository.ts`.
 

--- a/docs/architecture/dependency-injection.md
+++ b/docs/architecture/dependency-injection.md
@@ -352,9 +352,9 @@ into three:
 - Two modules binding one token is legal and silent.
 - An importer seeing one token from two imports is legal. It takes the
   **last** and **warns**, naming both modules, but only when the bindings
-  actually differ - a diamond re-export stays silent. Warnings surface on
-  `App.warnings` rather than being logged, because core has no logger and
-  the caller knows what level they belong at.
+  actually differ - a diamond re-export stays silent. `AppFactory.create`
+  logs each warning through `Logger.warn` and also collects them on
+  `App.warnings` for programmatic access.
 
 Nest is silent here and it costs people hours, so the warning exists.
 

--- a/docs/architecture/dependency-injection.md
+++ b/docs/architecture/dependency-injection.md
@@ -5,10 +5,11 @@ The decorator dialect, how constructor types are recorded without metadata, and 
 ## The decorator dialect decision
 
 `tsyringe` and `@Inject()`-style constructor injection are locked to legacy
-`experimentalDecorators` **permanently**: TC39 standard decorators have no
+`experimentalDecorators` **permanently**. TC39 standard decorators have no
 parameter decorators, so `constructor(@inject(X) x: X)` has no migration path.
-Building a new framework on the dialect TypeScript is walking away from, in
-order to buy a lossy metadata table you then work around, is a bad trade.
+TypeScript itself is walking away from that dialect. Building a new framework
+on it anyway, just to buy a lossy metadata table you then have to work around,
+is a bad trade.
 
 dunx uses **standard decorators only**. The root `tsconfig.json` must not set
 `experimentalDecorators` or `emitDecoratorMetadata`.
@@ -19,9 +20,9 @@ out constructor injection - see below.
 ## Constructor injection without decorator metadata
 
 An earlier draft of this document concluded that constructor injection was
-unavailable and that `inject()` in field initializers was the only option. That
-conclusion was wrong: it assumed the parameter types had to be recovered at
-runtime, the only thing decorators could have done. They can be read at
+unavailable, and that `inject()` in field initializers was the only option.
+That conclusion was wrong. It assumed the parameter types had to be recovered
+at runtime, the only thing decorators could have done. They can be read at
 **load time** instead, from the source that still has them.
 
 `@dunx/transform` is a Bun plugin. On load it parses each file with `oxc-parser`,
@@ -72,12 +73,12 @@ It would make DI **import-order dependent**. Bun's `onLoad` only affects modules
 loaded after registration, and static imports are evaluated depth-first in source
 order. `import { AppFactory } from '@dunx/core'` before
 `import { AppModule } from './app.module.js'` would work; the reverse order would
-silently skip the transform, reproducing the "`reflect-metadata` must be the
+silently skip the transform. That reproduces the "`reflect-metadata` must be the
 first import" fragility this framework exists to avoid, and no amount of
 documentation fixes an ordering rule.
 
 It would also cost `@dunx/core` its empty dependency list. The transform needs
-`oxc-parser`, a native binary, which every production deployment would then carry
+`oxc-parser`, a native binary. Every production deployment would then carry it,
 in order to run code that was already transformed at build time.
 
 So registration stays explicit, and the failure mode is closed off instead:
@@ -89,7 +90,7 @@ TypeScript's parameter properties are compiled away (measured: a constructor wit
 two parameter properties has `length === 2`). So the container can tell the
 difference between "this class needs nothing" and "nobody told me what this class
 needs". No recorded dependencies plus a non-zero arity means the plugin never saw
-the file, raising a boot error that carries the fix:
+the file. That raises a boot error that carries the fix:
 
 ```
 UsersController declares 1 constructor parameter(s) but no dependencies were
@@ -100,18 +101,19 @@ Register the plugin, then retry:
   preload = ["@dunx/transform/preload"]
 ```
 
-The check cannot produce a false positive. A constructor whose parameters all have
-defaults has `length === 0` and is genuinely callable with no arguments; a class
-bound with `useValue` is never constructed; and the transform only ever writes a
-record whose length equals the parameter count, so a present record is never empty.
+The check cannot produce a false positive, for three reasons. A constructor whose
+parameters all have defaults has `length === 0` and is genuinely callable with no
+arguments. A class bound with `useValue` is never constructed. And the transform
+only ever writes a record whose length equals the parameter count, so a present
+record is never empty.
 
 Three properties follow, and each is strictly better than the
 `emitDecoratorMetadata` equivalent measured above:
 
 **Erased types are named rather than degraded.** `emitDecoratorMetadata` turns an
 interface into `Object` and a primitive into `Number`, so Nest needs
-`@Inject(TOKEN)` for both. The transform can see the difference in the source, so
-it records the parameter as `unresolved` along with its original text, and the
+`@Inject(TOKEN)` for both. The transform can see the difference in the source.
+So it records the parameter as `unresolved` along with its original text, and the
 container throws at boot naming it:
 
 ```
@@ -124,8 +126,8 @@ a class type parameter, a primitive, and a union are all detected this way.
 
 **The record is a thunk, so there is no temporal dead zone.** An eagerly
 evaluated array would crash on a dependency declared later in the file or reached
-through a circular import. Deferring the body to resolution time is what removes
-the need for `forwardRef`.
+through a circular import. Deferring the body to resolution time removes the
+need for `forwardRef`.
 
 **Inheritance falls out of the prototype chain.** `readDeps` does a plain lookup
 rather than `Object.hasOwn`, so a subclass that declares no constructor inherits
@@ -134,12 +136,13 @@ one gets its own record, which shadows the base's.
 
 Two limits. The transform only rewrites **class declarations**: a
 `ClassExpression`'s own name is bound inside the class body, so a statement
-appended after `const X = class Inner {}` could not reference `Inner`. And because
-a plugin sees one file at a time, it cannot tell a DI provider from a plain data
-class - `new HttpError(404, 'x')` also has constructor parameters. So it records
-metadata for every annotated class and lets the container raise the error only if
-something is actually resolved as a provider, so the error is a boot
-error and not a build error.
+appended after `const X = class Inner {}` could not reference `Inner`.
+
+Also, because a plugin sees one file at a time, it cannot tell a DI provider from
+a plain data class - `new HttpError(404, 'x')` also has constructor parameters.
+So it records metadata for every annotated class and lets the container raise the
+error only if something is actually resolved as a provider. The error surfaces at
+boot, rather than at build time.
 
 `inject()` remains available for a value with no constructor parameter to hang
 off, and both mechanisms may be used in the same class.
@@ -157,10 +160,10 @@ There is no `@Injectable()` - every class is injectable by default.
 | `@Module({imports, providers})`                        | Class decorator. Registration only - see below           |
 | `AppFactory.create(RootModule)`                        | Builds, resolves, runs `onInit`. Returns a live `App`    |
 
-`AppFactory.create()` is async and there is no separate `init()`: resolution is
+`AppFactory.create()` is async and there is no separate `init()`. Resolution is
 eager, so an app that exists is an app that booted. `app.enableShutdownHooks()`
-registers `SIGTERM`/`SIGINT` handlers and `app.closed` resolves once shutdown has
-finished, whoever triggered it.
+registers `SIGTERM`/`SIGINT` handlers, and `app.closed` resolves once shutdown
+has finished, whoever triggered it.
 
 ### `token()` is the escape hatch rather than the default
 
@@ -170,7 +173,7 @@ Anything that is a **runtime value** can be its own token, so most code needs no
 1. **A concrete class** - `inject(Config)`. Nothing to declare; an unbound class
    self-binds.
 2. **An abstract class** for a contract whose implementation is built elsewhere.
-   It is a runtime value, so it works as a token, and it cannot be constructed, so
+   It is a runtime value, so it works as a token. It cannot be constructed, so
    the container will not self-bind it by accident:
 
    ```ts
@@ -186,9 +189,8 @@ Anything that is a **runtime value** can be its own token, so most code needs no
 
 An `interface` is erased at compile time, so `inject(SomeInterface)` cannot exist -
 that is the same erasure the `emitDecoratorMetadata` measurement above shows
-degrading to `Object`. Replacing the interface with an abstract class is what makes
-the token disappear. `examples/full` uses zero `token()` calls for this
-reason.
+degrading to `Object`. Replacing the interface with an abstract class removes
+the token entirely, so `examples/full` uses zero `token()` calls.
 
 `token<T>()` returns a **unique object**; the name is only a label for error
 messages. Two `token<Config>('config')` calls are two distinct tokens, so nominal
@@ -200,13 +202,14 @@ class that is injected but never bound gets self-bound and constructed into a
 useless object rather than erroring. TypeScript blocks it in the `providers` array
 (a bare entry must be constructible), but not at the `inject()` call site.
 
-`@Module` is a marker rather than a container. It writes its options onto the class as a
-`Symbol.for('dunx.module')` property - the same technique as route discovery, no
-accumulator - and the class is **never instantiated**. Reading it uses
-`Object.hasOwn`, so subclassing a module does not inherit its bindings; that
-throws instead. The class name is where the duplicate-binding error gets "bound by
-module X and module Y". `controllers` and `middleware` arrive with Phase 2, since
-there is nothing to put in them until there is HTTP.
+`@Module` is a marker rather than a container. It writes its options onto the
+class as a `Symbol.for('dunx.module')` property - the same technique as route
+discovery, no accumulator. The class is **never instantiated**.
+
+Reading it uses `Object.hasOwn`, so subclassing a module does not inherit its
+bindings; that throws instead. The class name is where the duplicate-binding
+error gets "bound by module X and module Y". `controllers` and `middleware`
+arrive with Phase 2, since there is nothing to put in them until there is HTTP.
 
 A bare class in `providers` is shorthand for binding it to itself, so the ordinary
 case carries no function calls at all:
@@ -234,13 +237,13 @@ export class UsersController {
 
 ### Resolution mechanism
 
-Constructor arguments are resolved **before** the injector swap, because argument
-resolution recurses back through `get()` and must not see the class being built as
-its own scope. Then a module-level `currentInjector` is set around the `new
-Klass()` call itself, so any `inject()` in a field initializer resolves against
-it. Field initializers run synchronously inside the constructor, so there is no
-async gap and no `AsyncLocalStorage` cost. Calling `inject()` outside construction
-throws with a clear message.
+Constructor arguments are resolved **before** the injector swap. Argument
+resolution recurses back through `get()` and must not see the class being
+built as its own scope. Then a module-level `currentInjector` is set around
+the `new Klass()` call itself, so any `inject()` in a field initializer
+resolves against it. Field initializers run synchronously inside the
+constructor, so there is no async gap and no `AsyncLocalStorage` cost.
+Calling `inject()` outside construction throws with a clear message.
 
 Both paths go through the same `get()`, so cycle detection, duplicate-binding
 rejection, and the async-factory retry below apply identically whether a
@@ -249,18 +252,20 @@ dependency arrived as a constructor parameter or an `inject()` call.
 ### Eager-only, no lazy resolution
 
 `AppFactory.create()` instantiates every provider and awaits async factories
-before the server binds. Wiring errors surface at boot rather than at first request. This
-is what lets `inject()` stay synchronous: by the time any constructor runs, every
-async provider is already resolved.
+before the server binds, so wiring errors surface at boot rather than at
+first request. That lets `inject()` stay synchronous: by the time any
+constructor runs, every async provider is already resolved.
 
 There is no static graph to topologically sort - `inject()` calls are only
-discovered by running the field initializers. So construction is recursive and
-synchronous, and an async factory reached from inside a constructor parks its
+discovered by running the field initializers. So construction is recursive
+and synchronous.
+
+When an async factory is reached from inside a constructor, it parks its
 promise, throws a private signal to unwind, and the async caller awaits the
 token and **retries the construction**. Each retry resolves at least one more
-async binding, so it terminates in at most one pass per async dependency, and a
-factory is never invoked twice because the promise is parked before the signal
-is thrown.
+async binding, so it terminates in at most one pass per async dependency. A
+factory is never invoked twice, because the promise is parked before the
+signal is thrown.
 
 The cost is that a constructor aborted this way runs its already-evaluated
 field initializers again, so field initializers must stay pure
@@ -292,14 +297,16 @@ unreadable stack.
 
 ## Modules encapsulate: `exports`, `global`, and a scope each
 
-**This replaced a flat container, and the section that argued for one is worth reading
-in the history rather than here.** The short version of what changed and why: the flat
-container had no `exports`, no visibility boundary and therefore no "provider is not
-exported from module X" error, and it was defended on those grounds. What it could not
-express was **module-scoped middleware** - a module providing a guard for its own
-routes, resolved from its own scope - or per-module rebinding. A DI framework is
-expected to have both. Nobody was consuming dunx yet, so the reversal cost no
-migration.
+**This replaced a flat container.** The section that argued for the flat
+design is worth reading in the history rather than here. The short version:
+the flat container had no `exports`, no visibility boundary, and therefore no
+"provider is not exported from module X" error - and it was defended on
+those grounds.
+
+What it could not express was **module-scoped middleware**: a module
+providing a guard for its own routes, resolved from its own scope, or
+per-module rebinding. A DI framework is expected to have both. Nobody was
+consuming dunx yet, so the reversal cost no migration.
 
 The model is three concepts.
 
@@ -309,14 +316,16 @@ with the per-reference deduplication `collectModules` already did.
 
 **`exports` is visibility.** A module lists the tokens an importer may resolve;
 everything else stays private. It accepts a token or a `ModuleRef`, and a `ModuleRef`
-re-exports whatever that module exports, letting `DatabaseModule` pass the
-drizzle handle on so a feature module imports _it_ rather than `@dunx/infra/db`.
+re-exports whatever that module exports. That lets `DatabaseModule` pass the
+drizzle handle on, so a feature module imports _it_ rather than `@dunx/infra/db`.
 
-**`global: true`** publishes a module's exports to every scope with no import needed.
-`ConfigModule` and `LoggerModule` are global because configuration and the `Logger`
-contract are read everywhere; `@dunx/http`'s own wrapper is global because it _imports_
-the app's root rather than being imported by it, so its `PubSub` would otherwise be
-invisible to the whole app.
+**`global: true`** publishes a module's exports to every scope with no import
+needed. `ConfigModule` and `LoggerModule` are global because configuration and
+the `Logger` contract are read everywhere.
+
+`@dunx/http`'s own wrapper is global for a different reason: it _imports_ the
+app's root rather than being imported by it, so without global scope its
+`PubSub` would be invisible to the whole app.
 
 ### Resolution, and why it is still one lookup
 
@@ -324,11 +333,12 @@ For a token requested while constructing a provider in module `M`: `M`'s own
 providers, then the exports of what `M` imports, then the global scope. **Local shadows
 imported**, the rebinding this exists to allow.
 
-Visibility is **flattened once at boot** into one `Map` per scope. Walking an import
-chain per lookup would make every construction O(depth); computing the closure once
-keeps resolution the single `Map.get` it was when the container was flat and moves the
-cost to boot, the trade this architecture makes everywhere else. A boot-time
-regression was accepted for the encapsulation.
+Visibility is **flattened once at boot** into one `Map` per scope. Walking an
+import chain per lookup would make every construction O(depth). Computing the
+closure once keeps resolution the single `Map.get` it was when the container
+was flat, and moves the cost to boot instead, the trade this architecture
+makes everywhere else. A boot-time regression was accepted for the
+encapsulation.
 
 Instance caches key on the **binding** rather than the token, so two modules that each declare
 one class hold two instances.
@@ -340,10 +350,11 @@ into three:
 
 - The same token twice **in one module** is still an error.
 - Two modules binding one token is legal and silent.
-- An importer seeing one token from two imports is legal, takes the **last**, and
-  **warns** - naming both modules. Only when the bindings actually differ, so a diamond
-  re-export stays silent. Warnings surface on `App.warnings` rather than being logged,
-  because core has no logger and the caller knows what level they belong at.
+- An importer seeing one token from two imports is legal. It takes the
+  **last** and **warns**, naming both modules, but only when the bindings
+  actually differ - a diamond re-export stays silent. Warnings surface on
+  `App.warnings` rather than being logged, because core has no logger and
+  the caller knows what level they belong at.
 
 Nest is silent here and it costs people hours, so the warning exists.
 
@@ -368,11 +379,14 @@ lets a module cycle whose providers have no cycle resolve fine.
 
 ### `app.get()` is more permissive
 
-Constructor injection is strict. `app.get(token)` tries the root scope's view, then any
-single module that declares the token, and errors on ambiguity; `app.get(token, Module)`
-_prefers_ that module's view and falls back to the same search. It is a bootstrap and
-debugging call rather than a dependency edge, and requiring every caller to know the
-owning module would make `exports` painful for no safety gain.
+Constructor injection is strict. `app.get(token)` tries the root scope's
+view, then any single module that declares the token, and errors on
+ambiguity. `app.get(token, Module)` _prefers_ that module's view and falls
+back to the same search.
+
+It is a bootstrap and debugging call rather than a dependency edge.
+Requiring every caller to know the owning module would make `exports`
+painful for no safety gain.
 
 ### `forRootAsync` factories take `imports`
 
@@ -396,36 +410,47 @@ provider into "ReportsModule".
 ```
 
 Every branch is answerable: declared-but-not-exported, declared-but-not-imported,
-declared-nowhere. Two findings from the migration are baked in - a class token nothing
-_visible_ binds no longer silently self-binds when some module declares it (that
-reported "did the transform run?" instead of the real problem), and a module exporting
-a token it neither declares nor can reach is caught where the mistake is rather than in
-some other module.
+declared-nowhere.
+
+Two findings from the migration are baked in. A class token that nothing
+_visible_ binds no longer silently self-binds when some module declares it -
+that used to report "did the transform run?" instead of the real problem.
+And a module exporting a token it neither declares nor can reach is caught
+where the mistake is, rather than in some other module.
 
 ### `exports` of a module reference is a structural test
 
-Re-exporting a module reference is what makes a facade module work, and the reference
-is almost always a `DynamicModule` from a static factory whose class carries **no**
-`@Module` decorator - `MailerModule` in the guide, and `DbModule`, `RedisModule`,
-`AuthModule`, every configured module in `@dunx/infra`. Classifying an `exports` entry
-with `isModuleRef`, which demands the marker, therefore rejected the exact case the
-feature exists for and reported it as an unresolvable token named `undefined`.
+Re-exporting a module reference is what makes a facade module work. The
+reference is almost always a `DynamicModule` from a static factory whose
+class carries **no** `@Module` decorator: `MailerModule` in the guide, and
+`DbModule`, `RedisModule`, `AuthModule`, every configured module in
+`@dunx/infra`.
+
+Classifying an `exports` entry with `isModuleRef`, which demands the marker,
+therefore rejected the exact case the feature exists for, and reported it as
+an unresolvable token named `undefined`.
 
 `isModuleExport` is the classifier the export path uses instead: a function is a module
 only if decorated, an object is one if it has a `module` function property. The
 alternatives are disjoint, so nothing else can match - a `Token` is `{ description }`.
-`findRootModule` keeps the strict `isModuleRef`, because there recognising a root among
-a file's arbitrary exports is the whole job.
+`findRootModule` keeps the strict `isModuleRef`, because recognising a root
+among a file's arbitrary exports is the whole job there.
 
 Found by migrating `dunx-template`, the job an acceptance app exists for.
 
 ### Overrides replace in every scope
 
-`createTestApp({ overrides })` replaces a token's binding in **every** scope that holds
-it. A suite stubbing `Logger` should not have to know how many modules bind it, and
-making it name a scope would push container topology into every test. "An override that
-replaced nothing is an error" still holds, and matters more here: it catches an override
-aimed at a token that has moved behind a boundary.
+`createTestApp({ overrides })` replaces a token's binding in **every** scope
+that holds it. A suite stubbing `Logger` should not have to know how many
+modules bind it, and making it name a scope would push container topology
+into every test.
+
+"An override that replaced nothing is an error" still holds, and matters more
+here: it catches an override aimed at a token that has moved behind a
+boundary.
+
+Scoping governs what a class can resolve. What happens once a request
+reaches one is a separate concern: middleware.
 
 ## One extension point in place of five
 
@@ -442,10 +467,10 @@ interface Middleware {
 ```
 
 A guard is still middleware that throws - there is no `CanActivate`. What
-`@UseGuards`, `@Roles` and `@Public` added is not a sixth extension point but a
-**scope** and a **metadata channel** for the one that already existed. `ctx.get(key)`
-reads metadata merged handler-first-then-class at discovery, so a method-level
-`@Public()` overrides a class-level `@Roles()`.
+`@UseGuards`, `@Roles` and `@Public` added is not a sixth extension point,
+but a **scope** and a **metadata channel** for the one that already existed.
+`ctx.get(key)` reads metadata merged handler-first-then-class at discovery,
+so a method-level `@Public()` overrides a class-level `@Roles()`.
 
 Guards are middleware that throw. Interceptors wrap `next()`. Pipes become
 schema validation in the route options. Filters become one error mapper. Chains
@@ -464,6 +489,9 @@ create(req: BunRequest<'/users'>, input: { body: CreateUser; query: Paging }) {}
 
 Validation targets the **Standard Schema** spec (`~standard.validate`), so
 Zod 4, Valibot, and ArkType all work with zero dependencies in `@dunx/*`.
+
+That covers what arrives on a request. The remaining piece is how a module
+configures itself before any request exists.
 
 ## A decorated module that also configures itself
 
@@ -493,7 +521,8 @@ one class serves both an app that configures it and a test that does not.
 concatenated. `union` and `unionProviders` replaced `concat`, keying on the token
 so a collision resolves rather than throws.
 
-Making that collision an error again was proposed and implemented, and it broke
+Making that collision an error again was proposed and implemented. It broke
 three of those tests: forbidding the collision forbids the feature, since the
 collision is how a default gets replaced. If the silent half ever needs
-surfacing, it is a `warnings` entry naming the class and the token, not an error.
+surfacing, it is a `warnings` entry naming the class and the token, not an
+error.

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -17,14 +17,15 @@ The Bun.serve adapter, how routes are discovered, and multi-node websocket fan-o
    already folded in
 6. Hand to `Bun.serve`
 
-Step 2 needs the instance, not just the class, so that the handler can be bound off
-it - which is what makes an undecorated override in a subclass dispatch correctly.
-That ordering is guaranteed: container resolution is eager and completes first.
+Step 2 needs the instance, not just the class, so the handler can be bound off it.
+Binding off the instance is what makes an undecorated override in a subclass
+dispatch correctly. That ordering is guaranteed: container resolution is eager
+and completes first.
 
-Field-initialized routes are part of **Route discovery** but not yet implemented:
-the thing that produces them is the `route.*` builder, which exists to sidestep the
-decorator inference limit, so it lands with Phase 3 rather than as a scan with no
-producer.
+Field-initialized routes are part of **Route discovery** but not yet
+implemented. The thing that produces them is the `route.*` builder, which
+sidesteps the decorator inference limit. It lands with Phase 3 rather than
+as a scan with no producer.
 
 Middleware is a **class** with `handle(req, ctx, next)`, resolved from the container
 so it gets constructor injection. It has three homes, one per scope it can belong
@@ -59,11 +60,13 @@ That second one is the first concrete cost the "no ancestor layer" decision has 
 and it is still the right decision: the alternative surprise - importing a module
 changes the importer's request path - is worse and unbounded.
 
-What did move was something the design never named. The app's queue controller had a
-private `degrades()` helper wrapped around all five of its route bodies, translating
-an unreachable broker into a 503. That is a per-controller `@Catch` filter written by
-hand, it is the one thing `HttpOptions.middleware` could not express, and it is now
-one `@Module({ middleware })` line.
+What did move was something the design never named. The app's queue
+controller had a private `degrades()` helper wrapped around all five of its
+route bodies, translating an unreachable broker into a 503.
+
+That is a per-controller `@Catch` filter written by hand: the one thing
+`HttpOptions.middleware` could not express. It is now one
+`@Module({ middleware })` line.
 
 **The generalisation: the first real use of module middleware was a filter, not a
 guard.** A guard that applies to exactly one feature is uncommon, because a global
@@ -74,23 +77,25 @@ sense for one feature's routes is common, and had nowhere to live.
 
 `HttpFactory` wraps the app's root in a `global: true` module that binds and
 exports `PubSub`, `ClientAddress` and `RequestLoggingMiddleware`. Two of those
-could be left to self-binding under the flat container and cannot be under
-scoping: an unbound class self-binds into **whichever scope asks first**, so a
-second module injecting `ClientAddress` was a boot error naming the first
-module, and even with one consumer `listen()` could attach the live server to
-an instance nothing else held.
+could be left to self-binding under the flat container, but not under scoping.
 
-They are framework services with no module for an app to import, which is
-exactly what the global scope is for.
-`@dunx/http`'s client-address suite pins it.
+An unbound class self-binds into **whichever scope asks first**. A second
+module injecting `ClientAddress` was therefore a boot error naming the first
+module, and even with a single consumer, `listen()` could attach the live
+server to an instance nothing else held.
+
+They are framework services with no module for an app to import, and the
+global scope exists for exactly that. `@dunx/http`'s client-address suite
+pins it.
 
 Per request the framework does exactly four things: validate declared schemas,
 call the method, pass a `Response` through or wrap the return in
-`Response.json()`, and map thrown errors. No lookup, no DI, no metadata read -
-route metadata and the `RouteContext` join the **boot-time** set, not the
-per-request one. The context is frozen and shared by every request to its route, and
-`ctx.get` is a `Map` lookup over an already-merged record rather than a prototype
-walk.
+`Response.json()`, and map thrown errors. No lookup, no DI, no metadata read
+happens on that path: route metadata and the `RouteContext` join the
+**boot-time** set, not the per-request one.
+
+The context is frozen and shared by every request to its route. `ctx.get` is
+a `Map` lookup over an already-merged record, rather than a prototype walk.
 
 ## Route discovery
 
@@ -136,17 +141,19 @@ No `Symbol.metadata`, no polyfill, no import-order dependence.
 
 ### Declined: trailing-slash normalisation
 
-`GET /t` is a 200 and `GET /t/` is a 404, and Nest, Express and Fastify all
-normalise, so it is the one thing that breaks a ported client - as a 404 that reads
-like a missing route. It stays a 404, and the reason is where the two candidate
-implementations would have to live.
+`GET /t` is a 200, and `GET /t/` is a 404. Nest, Express and Fastify all
+normalise, so this is the one thing that breaks a ported client - it shows up
+as a 404 that reads like a missing route. It stays a 404 here, because of
+where the two candidate implementations would have to live.
 
-`joinPath` already normalises the **declared** side, so `@Get('sub/')` is
-`/t/sub` and both spellings are never live at once. The inbound side is Bun's:
-by the time anything in dunx can see that nothing matched, it is inside the
-`fetch` fallback, which holds middleware and the error mapper and **no route
-patterns**. Stripping the slash and re-dispatching there means matching `/t/7/`
-against `/t/:id` in JavaScript, which is the router this repo will not write.
+`joinPath` already normalises the **declared** side, so `@Get('sub/')`
+becomes `/t/sub`, and both spellings are never live at once.
+
+The inbound side belongs to Bun. By the time anything in dunx can see that
+nothing matched, it is inside the `fetch` fallback, which holds middleware
+and the error mapper and **no route patterns**. Stripping the slash and
+re-dispatching there would mean matching `/t/7/` against `/t/:id` in
+JavaScript: exactly the router this repo will not write.
 
 Registering `/t/` as a second entry in the `Bun.serve` table was the other
 option - native, and free per request - and was rejected as blast radius: it
@@ -182,25 +189,30 @@ carries one, `@arkv/shared`, for the outbound client behind `./client`; the rela
 does not touch it.
 
 **The rejected alternative was putting it in `@dunx/infra/redis`**, where the
-connection handling, retry policy and error classification already exist. It was
-rejected on the dependency direction: the relay has to be reachable from `PubSub`,
-`PubSub` is `@dunx/http`, and `@dunx/infra` must not depend on the web layer. That
-coupling has now been refused three times - for the request logger, for `@dunx/auth`,
-and here - for the same reason each time: `@dunx/infra` is what a CLI script, a
-seeder or a queue worker imports, and none of those have an HTTP server.
+connection handling, retry policy and error classification already exist. It
+was rejected on the dependency direction: the relay has to be reachable from
+`PubSub`, `PubSub` is `@dunx/http`, and `@dunx/infra` must not depend on the
+web layer.
+
+That coupling has now been refused three times - for the request logger, for
+`@dunx/auth`, and here - and for the same reason each time. `@dunx/infra` is
+what a CLI script, a seeder or a queue worker imports, and none of those have
+an HTTP server.
 
 The cost accepted is a small amount of **relay-specific connection glue** that does
 not reuse `@dunx/infra/redis`'s general-purpose client: URL validation, the
 `maxRetries` default, lazy client creation, and unsubscribe-before-close. That is
 about 60 lines, and it buys a package with one dependency.
 
-An app that would rather reuse its existing connections satisfies the two methods
-itself - and `@dunx/infra`'s `RedisConnection` **already does, structurally**:
-`publish(channel, message)` and `subscribe(channel, listener)` are its own names and
-shapes, so `app.get(PubSub).relayThrough(app.get(RedisConnection))` typechecks with
-no adapter between them. That is the `@dunx/auth` `RedisStore` precedent - declare
-the shape, let the app supply anything that fits - and `examples/full` runs its
-second node that way on purpose.
+An app that would rather reuse its existing connections can satisfy the two
+methods itself. `@dunx/infra`'s `RedisConnection` **already does, structurally**:
+`publish(channel, message)` and `subscribe(channel, listener)` are its own names
+and shapes, so `app.get(PubSub).relayThrough(app.get(RedisConnection))` typechecks
+with no adapter between them.
+
+This is the same `@dunx/auth` `RedisStore` precedent: declare the shape, and
+let the app supply anything that fits. `examples/full` runs its second node
+that way on purpose.
 
 ### A Postgres relay over `LISTEN`/`NOTIFY`
 
@@ -251,10 +263,12 @@ so an `HttpOptionsProvider` naming `WsRelay` does not change when the backend do
 
 The choice sits in the method name, and one measurement forces it.
 **Providers are instantiated eagerly**: a factory bound to a token runs during
-`AppFactory.create`, measured on a module whose unused factory threw at boot. A
-single `forRootAsync` reading its backend from the resolved settings would still
-declare both bindings up front, so the unpicked one would be a `RedisRelay`
-constructed against a Postgres url. Two methods declare two static binding sets.
+`AppFactory.create`, measured on a module whose unused factory threw at boot.
+
+A single `forRootAsync` reading its backend from the resolved settings would
+still declare both bindings up front, so the unpicked one would be a
+`RedisRelay` constructed against a Postgres url. Two methods declare two
+static binding sets instead.
 
 The cost is that the backend cannot come from validated config, since config is
 resolved after the module graph is built. An app deciding at run time reads the
@@ -277,9 +291,9 @@ Two reasons, both forced:
 - `psubscribe` is unusable on Bun 1.3.14 (see [bun-apis.md](../bun-apis.md)), so a
   wildcard subscription is not available either.
 
-The cost is that every node reads every relayed frame and drops the ones for topics
-it has no local subscriber on - a `server.publish` returning `0`. Two apps sharing
-one Redis need two channels, which is what `relayChannel` is for.
+The cost is that every node reads every relayed frame and drops the ones for
+topics it has no local subscriber on - a `server.publish` returning `0`. Two
+apps sharing one Redis need two channels. `relayChannel` exists for that.
 
 ### Duplicate delivery is the failure mode, and an origin id is the defence
 
@@ -327,10 +341,11 @@ symptom of both is a service that shut down cleanly and then hangs forever:
   rescue this one, because the client is not in subscriber mode.
 
 Both were already latent in `@dunx/infra/redis` and are fixed there too. The
-measurements are in [bun-apis.md](../bun-apis.md). The guards have to be **spawn-based
-tests**: `bun test` exits the runner process itself, so a held-open event loop is
-invisible from inside the suite - which is exactly why this survived until an example
-app tried to shut down.
+measurements are in [bun-apis.md](../bun-apis.md).
+
+The guards have to be **spawn-based tests**, because `bun test` exits the
+runner process itself and a held-open event loop is invisible from inside
+the suite. This bug went unnoticed until an example app tried to shut down.
 
 Absence is tolerated at every step: a failed subscribe reports once and leaves local
 fan-out untouched; a failed publish reports once and not again until one succeeds;
@@ -366,12 +381,14 @@ an existing app does. A field the argument omits is the provider's to answer,
 which lets configuration move into the container one field at a time.
 
 **Promoted rather than bound in the HTTP scope.** `AppOptions.promote` is the
-mechanism core already used for `Logger` and `RequestContext`: the binding is laid
-into every scope holding no view of its own, and a module declaring the token
-replaces it with no shadowing warning. Binding it in `HttpModule`'s own providers
-was tried first. It put the token in that scope's `own` map, which warned every
-app that declared a subclass, and the HTTP scope went on resolving its own default
-because a scope prefers what it owns.
+mechanism core already used for `Logger` and `RequestContext`: the binding is
+laid into every scope holding no view of its own, and a module declaring the
+token replaces it with no shadowing warning.
+
+Binding it in `HttpModule`'s own providers was tried first, and failed
+differently. It put the token in that scope's `own` map, which warned every
+app that declared a subclass, while the HTTP scope kept resolving its own
+default because a scope prefers what it owns.
 
 **The imperative methods are unchanged.** `setGlobalPrefix`, `enableCors`, `set`
 and `enableShutdownHooks` all still work, and each now has a field alongside it.

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -5,38 +5,38 @@
 ## Colour in `@dunx/infra/logger`, and where the fix belongs
 
 `LoggerModule.forRoot()` used to write ANSI escapes into its JSON whenever stdout was
-not a terminal, which makes the logs unparseable for anything downstream. Measured:
+not a terminal. That makes the logs unparseable for anything downstream. Measured:
 with `Bun.enableANSIColors === false` and `process.stdout.isTTY === undefined`, a
 default entry came out as `{\u001b[36m"level":\u001b[39m...`, 26 escapes in one line.
 Neither `NO_COLOR=1` nor `FORCE_COLOR=0` suppressed it.
 
 The cause is upstream and it is not an edge case. `@arkv/logger` picks the pretty
-formatter from `isDevelopment`, which defaults to `process.env.NODE_ENV !== 'production'`,
-and **nothing on the colour path asks whether the output is a terminal** - not the
-logger, `ConsoleTransport` and the formatter alike. So the zero-argument
-`LoggerModule.forRoot()` in a container with `NODE_ENV` unset hit it, beyond just an app
-that passed `isDevelopment: true`.
+formatter from `isDevelopment`, which defaults to `process.env.NODE_ENV !== 'production'`.
+**Nothing on the colour path asks whether the output is a terminal**, not the
+logger, `ConsoleTransport`, or the formatter. So the zero-argument
+`LoggerModule.forRoot()` in a container with `NODE_ENV` unset hit it. That went
+beyond just an app that passed `isDevelopment: true`.
 
 This split cleanly along the boundary CLAUDE.md already draws, so both halves were
 done rather than one:
 
 - **dunx supplies the default, because the good answer is Bun-specific.**
   `isDevelopment` now defaults to `Bun.enableANSIColors`, which already folds in TTY
-  detection, `NO_COLOR` and `FORCE_COLOR`. That is not a patch, a wrapper or a
-  vendored copy - it is dunx choosing the default for an option upstream exposes, and
-  a consumer passing `isDevelopment` still wins. `Bun.enableANSIColors` is also
-  strictly the better question: upstream's option controls colour and nothing else,
-  so `NODE_ENV` was never what it wanted to know.
+  detection, `NO_COLOR` and `FORCE_COLOR`. That is not a patch, a wrapper, or a
+  vendored copy. It is dunx choosing the default for an option upstream exposes, and
+  a consumer that passes `isDevelopment` explicitly still wins. `Bun.enableANSIColors`
+  is also strictly the better question: upstream's option controls colour and
+  nothing else, so `NODE_ENV` was never what it wanted to know.
 - **The portable gate belongs upstream and stays there.** `@arkv` targets Node and
-  the web, so it cannot use `Bun.*`; its own `@arkv/colors` already exports
-  `isColorSupported()` and nothing in the logger calls it. That proposal, with the
-  exact call site and a second defect it turned up (`FORCE_COLOR=0` is read as
-  presence, so it forces colour _on_), shipped upstream in `@arkv/logger` 0.8.2.
+  the web, so it cannot use `Bun.*`. Its own `@arkv/colors` already exports
+  `isColorSupported()`, and nothing in the logger calls it. That proposal shipped
+  upstream in `@arkv/logger` 0.8.2, with the exact call site and a second defect it
+  turned up: `FORCE_COLOR=0` is read as presence, so it forces colour _on_.
 
-The two compose: once the upstream gate lands, dunx's default is still the right one
-and nothing here has to be undone. `packages/infra/src/logger/module.test.ts` asserts
-the entry is coloured **exactly when** `Bun.enableANSIColors` is true, which holds at
-a terminal and in a pipe and fails on the old default.
+The two compose: once the upstream gate lands, dunx's default is still the right
+one, and nothing here has to be undone. `packages/infra/src/logger/module.test.ts`
+asserts the entry is coloured **exactly when** `Bun.enableANSIColors` is true. That
+holds at a terminal and in a pipe, and fails on the old default.
 
 ### The second colour defect, also upstream, also fixed there
 
@@ -53,26 +53,26 @@ both visible in one line:
 - The lookahead has no `}`, so the last value's colour span ran to end of line and
   swallowed the closing brace.
 
-The red `{` is the part to record, the obvious explanation being wrong. It
+The red `{` is the detail that matters: the obvious explanation is wrong. It
 is not the terminal: **Bun wraps `console.error` output in red itself**, emitting
 `\u001b[0m\u001b[31m` before the line and `\u001b[0m` after. Every token the formatter
-colours overrides that wrapper; every character it leaves bare keeps it. So the fix is
-not only to tokenise but to colour the punctuation too, which nothing did before.
+colours overrides that wrapper. Every character it leaves bare keeps it. So the fix
+has to tokenise and colour the punctuation too. Nothing did that before.
 
-The fix is a scanner over `safeStringify`'s output rather than a re-serialisation, so
-escapes are only ever _inserted_ and the stripped bytes stay byte-identical - which is
-what keeps a pretty line parseable, and gets every `JSON.stringify` edge case
-(dropped `undefined`, `toJSON`, non-finite numbers, the circular fallback) for free.
+The fix is a scanner over `safeStringify`'s output rather than a re-serialisation.
+Escapes are only ever _inserted_, so the stripped bytes stay byte-identical and a
+pretty line stays parseable. That also gets every `JSON.stringify` edge case for
+free: dropped `undefined`, `toJSON`, non-finite numbers, the circular fallback.
 
-**Upstream, in `~/repos/arkv/packages/logger/src/format.ts`,** per Rule 1: it needs no
-`Bun.*` API, it is a defect every `@arkv/logger` consumer has, and a local wrapper
-would have forked a package the owner maintains.
+**Upstream, in `~/repos/arkv/packages/logger/src/format.ts`,** per Rule 1: it needs
+no `Bun.*` API, and it is a defect every `@arkv/logger` consumer has. A local
+wrapper would have forked a package the owner maintains.
 
 ## What else of `@arkv` dunx uses, and what it does not
 
 The workspace was read end to end against the question that matters: is dunx doing
 something worse than a package the owner already maintains? Nothing to adopt came
-back, and the two standing candidates both died on inspection.
+back. The two standing candidates both died on inspection.
 
 | package           | in dunx                                                                                                                                                                                                         |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -84,15 +84,15 @@ back, and the two standing candidates both died on inspection.
 
 **Backoff was the first candidate, and the premise was wrong.** It is implemented
 once in dunx, in the websocket relay's resubscribe - the queue does not
-retry, bullmq does. And there is nothing upstream to share with: `@arkv/shared`'s
-`retry` takes a constant delay with no multiplier, jitter, cap or signal, and a
+retry, bullmq does. There is nothing upstream to share with: `@arkv/shared`'s
+`retry` takes a constant delay with no multiplier, jitter, cap, or signal. A
 workspace-wide grep for `backoff|jitter|exponential|circuit` returns nothing.
 
 **Redaction was the second.** `sanitizeLogEntry` is real and good, and as of
 `@arkv/logger` 0.8.2 it is exported. dunx still does not consume it: `@dunx/core`
 having zero dependencies is load-bearing, and `ConsoleLogger` not sanitizing is
-precisely the reason to swap in `@dunx/infra/logger`.
+the reason to swap in `@dunx/infra/logger`.
 
-Three fixes did go the other way, the direction the rule points in - a
+Three fixes went the other way, the direction the rule points in: a
 colour-support gate, `FORCE_COLOR=0` no longer forcing colour _on_, and that
 sanitizer export. All three shipped in 0.8.2 rather than being patched here.

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -1,13 +1,13 @@
 # The MCP server (`@dunx/mcp`)
 
 **Shipped as `tools/mcp`.** Six read-only tools: `dunx_overview`, `dunx_routes`,
-`dunx_providers`, `dunx_gateways`, `dunx_modules`, `dunx_openapi`. What follows is the
-reasoning that produced it, kept because the decisions are still the load-bearing
-ones; the answers to the four questions it opened are recorded at the bottom.
+`dunx_providers`, `dunx_gateways`, `dunx_modules`, `dunx_openapi`. What follows is
+the reasoning that produced it, kept because the decisions are still load-bearing.
+The answers to the four questions it opened are recorded at the bottom.
 
 Two of those decisions are now load-bearing for a second consumer. The
-static-not-boot rule is the one `@dunx/dashboard` inverts, and the readers behind
-these tools are the ones it needs, so they belong in `@dunx/core` and
+static-not-boot rule is the one `@dunx/dashboard` inverts. The readers behind
+these tools are what it needs too, so they belong in `@dunx/core` and
 `@dunx/http` rather than here.
 
 A Model Context Protocol server so an agent working in a dunx app can ask the
@@ -16,13 +16,13 @@ framework about itself instead of grepping for the answer.
 ## Why this is worth having
 
 The information an agent most often needs about a dunx app is already computed and
-already structured, it is just not reachable without booting the app:
+already structured. It is just not reachable without booting the app:
 
 - **The route table.** `describeRoutes(module)` walks the module graph without
   constructing anything, so "what routes exist, with which schemas, guards and
   roles" is answerable with no database and no port.
 - **The container graph.** `readDeps` plus the module records give every provider,
-  what it depends on, and which module bound it, matching what a
+  what it depends on, and which module bound it. That matches what a
   missing-binding error makes someone reconstruct by hand.
 - **The OpenAPI document.** Already derived from the same zod schemas.
 - **The measurements.** `internal/bench/results/latest.json` is committed and
@@ -39,17 +39,17 @@ in the order they gated each other:
 
 1. **Static, decided.** It reads the app; it does not boot it.
 
-   Booting is the tempting option because it gives the resolved container, and it
-   is the wrong one. `AppFactory.create` instantiates every provider and awaits
-   every async factory before returning - that is the no-lazy-resolution decision -
-   so booting an app to answer "what routes exist" opens database connections,
-   starts queue workers, binds sockets and runs every `onInit`. An agent asking a
+   Booting is the tempting option because it gives the resolved container. It is
+   also the wrong one. `AppFactory.create` instantiates every provider and awaits
+   every async factory before returning: that is the no-lazy-resolution decision.
+   Booting an app just to answer "what routes exist" opens database connections,
+   starts queue workers, binds sockets, and runs every `onInit`. An agent asking a
    question about the code would be running the code, with side effects, against
    whatever environment happened to be configured.
 
-   Static costs nothing and needs nothing: `describeRoutes` walks prototypes with
-   `Object.create`, so no constructor runs, and it already works with no database
-   and no port, which `bunx dunx-openapi` is built on. It is also
+   Static costs nothing and needs nothing. `describeRoutes` walks prototypes with
+   `Object.create`, so no constructor runs. It already works with no database and
+   no port, the same property `bunx dunx-openapi` is built on. It is also
    idempotent, which matters for a tool an agent calls repeatedly.
 
    The provider graph is reachable statically too, from the module records plus
@@ -57,24 +57,23 @@ in the order they gated each other:
 
    What static cannot give is runtime state: the actual value of a config field,
    whether the database is reachable. An agent should not be asking a
-   code-inspection tool those. If one is ever genuinely needed, add it as a
-   separately named tool whose description says it boots the app, so the cost is
-   visible at the call site rather than hidden in every answer.
+   code-inspection tool for those. If one is ever genuinely needed, add it as a
+   separately named tool whose description says it boots the app. That keeps the
+   cost visible at the call site rather than hidden in every answer.
 
 2. **Transport.** stdio is the obvious default for a local agent.
 3. **Where does the app's root module come from?** The same question
    `scripts/gen-openapi.ts` in `dunx-template` runs into: a tool cannot guess an
    app's module factory or its config source. Probably a path argument plus a
-   convention, and whatever is decided here should settle that script too.
-4. **Does it ship?** A published `@dunx/mcp` would let any dunx app wire it up,
-   the version with real value - but it inverts the "tools are private"
+   convention. Whatever is decided here should settle that script too.
+4. **Does it ship?** A published `@dunx/mcp` would let any dunx app wire it up:
+   the version with real value. But it inverts the "tools are private"
    rule, so it is a decision to record rather than assume.
 
 ## Constraints it inherits
 
 - The dependency rules still apply to anything published. An MCP server over
-  `Bun.serve` and
-  stdio needs no dependency; a framework SDK would need justifying.
+  `Bun.serve` and stdio needs no dependency. A framework SDK would need justifying.
 - If it stays in `tools/`, it may depend on anything, as `internal/bench`
   depending on express is allowed for.
 
@@ -83,43 +82,44 @@ in the order they gated each other:
 1. **Static, decided** - and it held. Every tool reads the graph and constructs
    nothing. `discoverRoutes` and `discoverGateway` both take an instance, and
    `Object.create(Class.prototype)` satisfies them: `instance.constructor` still
-   resolves to the class and every method is still reachable, so no constructor - or
-   dependency of one - has to exist.
+   resolves to the class, and every method is still reachable. So no constructor,
+   or dependency of one, has to exist.
 
 What made this cheaper than expected is that **nothing had to be reimplemented
 to get it**. The graph comes from `collectModules`, `readControllers`,
-`readDeps` and `describeToken`; the routes and gateways from http's own
+`readDeps`, and `describeToken`. The routes and gateways come from http's own
 discovery.
 
-The last three were internal to their packages and are now exported, which is
+The last three were internal to their packages and are now exported. That is
 the honest fix: a second reader of `Symbol.for('dunx.deps')` has to restate the
-prototype-chain lookup, the lazy thunk call and the shape of an `unresolved`
-entry, and silently drops any field that shape later gains. The first version
-of this package did restate them, and rendered a `token()` binding as `[object
-Object]` as a result.
+prototype-chain lookup, the lazy thunk call, and the shape of an `unresolved`
+entry, and it silently drops any field that shape later gains. The first
+version of this package did restate them. It rendered a `token()` binding as
+`[object Object]` as a result.
 
 2. **Transport: stdio**, as expected, and Bun-native throughout - `Bun.stdin.stream()`
    in, a `Bun.stdout.writer()` `FileSink` out, flushed per message. `Bun.resolveSync`
    locates the entry, which matters more than it sounds: it is the runtime's own
-   resolver, so every specifier `import` accepts works. It follows Node resolution, so
-   a bare _relative_ path throws - `src/app.module.ts` reads as a package named `src`
-   (measured) - and an unresolved specifier is retried as `./`-prefixed, as-is first
-   so a real package still wins.
+   resolver, so every specifier `import` accepts works. It follows Node resolution,
+   so a bare _relative_ path throws: `src/app.module.ts` reads as a package named
+   `src` (measured). An unresolved specifier is then retried as `./`-prefixed,
+   tried as-is first so a real package still wins.
 
 3. **Where the root module comes from**: a path argument plus the `default`/`root`
    convention, matching `bunx dunx-openapi`. `scripts/gen-openapi.ts` in the template
    should be settled the same way.
 
 4. **It ships**, as `@dunx/mcp`. That inverts the "tools are private" rule
-   knowingly: a published server is the version any dunx app can wire up, and a
+   knowingly. A published server is the version any dunx app can wire up. A
    private one under `tools/` would only ever serve this repo.
 
    **The OpenAPI document is in**, as `dunx_openapi`, with `@dunx/openapi` an
-   _optional_ peer reached by `await import()`, which lets the other five tools
-   work in an app with no OpenAPI setup, and it is why `dunx_routes` reports _which_
-   inputs a route validates rather than their schemas: converting a schema to JSON
-   Schema is zod-specific work `@dunx/openapi` already does, and a second, worse
-   generator here would be the "never invent what a mature library solves" failure.
+   _optional_ peer reached by `await import()`. That lets the other five tools
+   work in an app with no OpenAPI setup, and it also explains why `dunx_routes`
+   reports _which_ inputs a route validates rather than their schemas:
+   converting a schema to JSON Schema is zod-specific work `@dunx/openapi`
+   already does. A second, worse generator here would be the "never invent what
+   a mature library solves" failure.
 
    **The benchmark results are still out.** `internal/bench/results/latest.json`
    describes this repo rather than the app being read, so a tool exposing it would answer a

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -24,11 +24,10 @@ implementation for every package.
 workspaces are published too, and `bunx @dunx/create-app` is the point of them. The
 parent says what a workspace **is**, not whether it ships.
 
-`internal/*` is what sits outside all of this. Those workspaces are
-`"private": true`, never published, and build with whatever suits them -
-`internal/docs` is a React bundle, not a `Bun.build` package. The dependency rules
-constrain what dunx ships; they do not constrain what builds its website or measures
-it.
+`internal/*` sits outside all of this. Those workspaces are `"private": true`,
+never published, and build with whatever suits them - `internal/docs` is a React
+bundle, not a `Bun.build` package. The dependency rules constrain what dunx ships.
+They do not constrain what builds its website or measures it.
 
 ## Scaffolder (`create-app`)
 
@@ -60,10 +59,10 @@ untouched. With independent versions that produces:
 ```
 
 An app installing both gets **two copies of `@dunx/core`**. In this container a
-token _is_ a class object - `provide(Logger, …)` keys a `Map` by the class itself -
-so two copies means two distinct `Logger` classes, and `app.get(Logger)` misses the
-binding another package registered. It fails silently, at boot, with a message
-about a missing provider for a token the user can plainly see is bound.
+token _is_ a class object: `provide(Logger, …)` keys a `Map` by the class itself.
+So two copies means two distinct `Logger` classes, and `app.get(Logger)` misses
+the binding another package registered. It fails silently, at boot, with a
+message about a missing provider for a token the user can plainly see is bound.
 
 `Symbol.for('dunx.deps')` was already chosen so duplicate copies of core still agree
 on the deps key. Class identity cannot be made to agree, so the duplicate has to be
@@ -74,24 +73,24 @@ Two alternatives were considered and rejected:
 - **Caret ranges _instead of_ lockstep.** Pre-1.0 `^0.1.0` excludes `0.2.0`, so a
   minor bump of core still fragments the graph. `^` only helps within a patch series.
 
-Caret ranges **on top of** lockstep are a different question and are now what
-ships: `workspace:*` publishes as `^<version>`. Every internal range is a
-`peerDependency`, and an exact peer accepts exactly one version, so npm answers
-a consumer one patch ahead with an `ERESOLVE` failure and bun with a warning
-plus a nested copy.
+Caret ranges **on top of** lockstep are a different question, and they are now
+what ships: `workspace:*` publishes as `^<version>`. Every internal range is a
+`peerDependency`, and an exact peer accepts exactly one version. So npm answers
+a consumer one patch ahead with an `ERESOLVE` failure, and bun answers with a
+warning plus a nested copy.
 
 A caret is never worse than exact - exact excludes `0.2.1` too - and under
 lockstep it can never be stale, because every package in a release names the
 same version as the peer it declares. What the caret does _not_ do is survive
-independent versions, and lockstep stays for that reason.
+independent versions. Lockstep stays for that reason.
 
 - **`@dunx/core` as a `peerDependency`.** This was rejected here and has since been
-  **adopted** - the entry stays because the reason it was rejected is the useful
-  part. Peers are the textbook answer and they resolve to one copy, but
+  **adopted**; the entry stays because the reason it was rejected is the useful
+  part. Peers are the textbook answer, and they resolve to one copy. But
   `bun run --filter '*' build` orders builds by `dependencies` alone, so moving
   core to a peer raced `tsc` against core's own `.d.ts` emit and failed with
-  `TS7016`. The
-  fix was a topological build rather than a different dependency shape.
+  `TS7016`. The fix was a topological build rather than a different dependency
+  shape.
 
 `scripts/build-all.ts` now orders by `dependencies`, `peerDependencies` and
 `devDependencies`, and `@dunx/core` and `@dunx/http` are peers with a matching
@@ -109,16 +108,16 @@ pre-1.0 framework whose packages move together anyway that is a feature: one num
 answers "which versions work together", the question a consumer of six
 packages actually has.
 
-**Decided: lockstep stays until `@dunx/core` reaches 1.0.0, and that release is
-the one trigger that reopens it.** Independent versions were held open pending
-a range policy, and there is no pre-1.0 range that works. A caret cannot span a
+**Decided: lockstep stays until `@dunx/core` reaches 1.0.0.** That release is
+the one trigger that reopens it. Independent versions were held open pending a
+range policy, and there is no pre-1.0 range that works. A caret cannot span a
 `0.x` minor, so `@dunx/http@0.3.0` naming `@dunx/core@^0.2.0` while
 `@dunx/infra@0.4.0` names `^0.3.0` is an unsatisfiable peer set - a hard
 install failure now that these are peers, rather than the silent duplication
 `dependencies` used to produce.
 
-`>=x.y.z` installs cleanly but promises compatibility across every future
-major, which is a promise a pre-1.0 framework cannot keep, and it would be
+`>=x.y.z` installs cleanly, but it promises compatibility across every future
+major. That is a promise a pre-1.0 framework cannot keep, and a break would be
 discovered as a runtime token mismatch rather than an install error. Waiting is
 not a deferral for want of an answer: post-1.0 a caret spans the whole major,
 the policy writes itself, and no work done now would survive the change anyway.
@@ -134,15 +133,14 @@ were not redesigned. What follows is the decisions that specification did not
 cover.
 
 **The substitution lives in `@dunx/core`, as `AppFactory.create(root, {
-overrides })`.** `createTestApp` cannot assemble the flat list itself:
-`Injector` and `readModule` are not exported, because exporting
-the container would freeze its shape as public API, and a testing package that
-duplicated the register-resolve- `onInit` loop would be a second container to
-keep in step with the first.
+overrides })`.** `createTestApp` cannot assemble the flat list itself: `Injector`
+and `readModule` are not exported. Exporting the container would freeze its shape
+as public API, and a testing package that duplicated the register-resolve-
+`onInit` loop would be a second container to keep in step with the first.
 
-So core grew the seam and `@dunx/testing` is a thin wrapper over it -
+So core grew the seam, and `@dunx/testing` is a thin wrapper over it:
 `substitute()` is fifteen lines on the path that was already assembling the
-list, and costs an empty `Map` lookup per registration when no overrides are
+list, and it costs an empty `Map` lookup per registration when no overrides are
 passed.
 
 The seam is `readonly Registration[]` rather than a test-shaped API: it is "compose this
@@ -152,8 +150,8 @@ without a second mechanism.
 
 **The always-bound defaults are substituted too.** `Logger` and `RequestContext`
 are offered by `registerDefault` after every module, so nothing in the module graph
-binds them in a typical app - and an override of `Logger` would therefore have been
-"nothing to override". They are now built as a `Registration[]` and run through the
+binds them in a typical app. An override of `Logger` would therefore have been
+"nothing to override." They are now built as a `Registration[]` and run through the
 same substitution, which makes silencing the logger in a test possible at
 all. The unmatched-override check runs after both stages.
 
@@ -163,16 +161,17 @@ is pure noise, and the alternative - every suite passing `requestLogging: false`
 is a default in the wrong place. Asserting on request logging means asking for it.
 
 **An omitted `middleware` warns rather than becoming a type error.** Every other
-`HttpOptions` field is absent unless passed, and for `middleware` and `onError` that
+`HttpOptions` field is absent unless passed. For `middleware` and `onError` that
 means a fixture with no global guards and the default error mapper: it boots, it
-answers 200 where the application answers 401, and it says nothing. Reported from a
-port of `nestjs-template` as a first integration run of 12 pass / 10 fail.
+answers 200 where the application answers 401, and it says nothing. This was
+reported from a port of `nestjs-template`, as a first integration run of 12 pass /
+10 fail.
 
 Three fixes were on the table. **Requiring the fields** (a present key that may
 be `undefined`, which `exactOptionalPropertyTypes` makes a real obligation) was
 rejected: it is loud in the right cases and noise in the majority, where an app
 has no globals at all, and it breaks every existing suite. **Documenting the
-shared `httpOptions(config)`** is done, in guide 10 - it is the actual fix,
+shared `httpOptions(config)`** is done, in guide 10. It is the actual fix,
 because one definition of the application cannot drift.
 
 **The warning** is the guard for the case where documentation was not read: a
@@ -180,43 +179,45 @@ class provider whose prototype has a `handle` method is a `Middleware`, and if
 no `@UseGuards` attaches it and no `middleware` was passed, `createTestServer`
 writes one `console.warn` naming it.
 
-Two details are deliberate. The exclusion of route-scoped guards means the warning
-has no false positive on the common `@UseGuards` case - those are in the route table
-and cost the omission nothing - and it costs a second `discoverRoutes` pass over the
-controllers at fixture boot, which is boot-time work in tests only. And it goes to
-`console.warn` rather than the bound `Logger`: a suite asserting `recording.entries` is
-empty must not find an entry the application never wrote. `middleware: []` is the
-opt-out, because "none, intentionally" is expressible and "forgot" is not.
+Two details matter here. First, excluding route-scoped guards means the warning
+has no false positive on the common `@UseGuards` case: those are in the route
+table and cost the omission nothing. It does cost a second `discoverRoutes` pass
+over the controllers at fixture boot, which is boot-time work in tests only.
+Second, it goes to `console.warn` rather than the bound `Logger`: a suite
+asserting `recording.entries` is empty must not find an entry the application
+never wrote. `middleware: []` is the opt-out, because "none, intentionally" is
+expressible and "forgot" is not.
 
 **`@dunx/core` and `@dunx/http` are `dependencies` at `workspace:^` - measured, not
-assumed.** Peers were the first choice and are the better contract: a second copy of
-core in a consumer's tree is a second `Logger` class and therefore a token that
-matches nothing, so overrides would silently replace nothing - exactly the failure
-the unmatched-override error exists to prevent. It did not survive the build **at the
-time**; the topological build fixed that and peers are now in use. The measurement
-below is kept because it is why the build had to change first.
+assumed.** Peers were the first choice and are the better contract: a second copy
+of core in a consumer's tree is a second `Logger` class, and therefore a token
+that matches nothing. Overrides would then silently replace nothing, exactly the
+failure the unmatched-override error exists to prevent. Peers did not survive the
+build **at the time**; the topological build fixed that, and peers are now in
+use. The measurement below is kept because it explains why the build had to
+change first.
 
 `bun run --filter '*' build` derives its ordering from **`dependencies` only**.
 Measured on Bun 1.3.14: with core in `devDependencies` and in `peerDependencies`
 (both tried, including a `workspace:` range in the peer field), `@dunx/testing`'s
-`tsc` ran concurrently with core's own build and failed with `TS7016: Could not find
-a declaration file for module '@dunx/core'` - `build-package.ts` deletes `dist/`
-before writing it. In CI, where no `dist` exists at all, that is not a race but a
-certainty.
+`tsc` ran concurrently with core's own build and failed with `TS7016: Could not
+find a declaration file for module '@dunx/core'`. `build-package.ts` deletes
+`dist/` before writing it, so in CI, where no `dist` exists at all, that is not a
+race but a certainty.
 
 Two consequences worth keeping:
 
-- The range publishes as a **caret** rather than an exact version. An exact pin makes
-  `@dunx/testing@0.4.0` demand `@dunx/core@0.4.0` and nothing else, so a consumer
-  on 0.4.1 gets a nested second copy - the duplication being avoided. **That pass
-  has since been taken for every package**: `workspace:*` no longer publishes as
-  the exact version, it publishes as `^<version>`, and the rule lives in one
-  place (`resolveWorkspaceRange` in `scripts/workspace-ranges.ts`) shared by
+- The range publishes as a **caret** rather than an exact version. An exact pin
+  makes `@dunx/testing@0.4.0` demand `@dunx/core@0.4.0` and nothing else, so a
+  consumer on 0.4.1 gets a nested second copy - the duplication being avoided.
+  **That pass has since been taken for every package**: `workspace:*` no longer
+  publishes as the exact version, it publishes as `^<version>`. The rule lives in
+  one place (`resolveWorkspaceRange` in `scripts/workspace-ranges.ts`), shared by
   `version.ts` and `first-publish.ts`.
 
-The source form stayed `workspace:*` everywhere, which
-`scripts/manifests.test.ts` asserts and what keeps a concrete version from
-being left behind by an aborted publish.
+The source form stayed `workspace:*` everywhere. `scripts/manifests.test.ts`
+asserts that, and it is what keeps a concrete version from being left behind by
+an aborted publish.
 
 While dunx is pre-1.0 this is a partial fix rather than a complete one: `^0.4.0` is
 `>=0.4.0 <0.5.0`, and `version.ts` only republishes packages whose own `src`
@@ -225,14 +226,14 @@ changed. A core-only **minor** bump therefore leaves a published
 core reaches `1.x`, a minor bump of `@dunx/core` or `@dunx/http` wants
 `@dunx/testing` republished with it.
 
-- **A published package's tests cannot import a workspace package that is not one of
-  its runtime dependencies.** The first draft converted
-  `packages/openapi/src/module.test.ts` to the harness. A package's build typechecks
-  its own tests, so that made openapi's build race `@dunx/testing`'s, and putting
-  `@dunx/testing` in openapi's `dependencies` would ship a test package to
-  production. Reverted. `examples/*` have no such limit - nothing builds in parallel
-  with them, so `examples/full/src/service.test.ts` is where the
-  harness is exercised against a real app.
+- **A published package's tests cannot import a workspace package that is not one
+  of its runtime dependencies.** The first draft converted
+  `packages/openapi/src/module.test.ts` to the harness. A package's build
+  typechecks its own tests, so that made openapi's build race `@dunx/testing`'s.
+  Putting `@dunx/testing` in openapi's `dependencies` would have shipped a test
+  package to production, so this was reverted. `examples/*` have no such limit:
+  nothing builds in parallel with them, so `examples/full/src/service.test.ts` is
+  where the harness is exercised against a real app.
 
 `@dunx/http` is therefore not optional, and `createTestServer` imports it normally.
 

--- a/docs/architecture/packaging.md
+++ b/docs/architecture/packaging.md
@@ -188,14 +188,14 @@ asserting `recording.entries` is empty must not find an entry the application
 never wrote. `middleware: []` is the opt-out, because "none, intentionally" is
 expressible and "forgot" is not.
 
-**`@dunx/core` and `@dunx/http` are `dependencies` at `workspace:^` - measured, not
-assumed.** Peers were the first choice and are the better contract: a second copy
-of core in a consumer's tree is a second `Logger` class, and therefore a token
-that matches nothing. Overrides would then silently replace nothing, exactly the
-failure the unmatched-override error exists to prevent. Peers did not survive the
-build **at the time**; the topological build fixed that, and peers are now in
-use. The measurement below is kept because it explains why the build had to
-change first.
+**`@dunx/core` and `@dunx/http` were initially `dependencies` at `workspace:^`
+rather than peers - measured, not assumed.** Peers are the better contract: a
+second copy of core in a consumer's tree is a second `Logger` class, and
+therefore a token that matches nothing. Overrides would then silently replace
+nothing, exactly the failure the unmatched-override error exists to prevent.
+Peers did not survive the build at the time; the topological build fixed that,
+and **peers are now in use**. The measurement below is kept because it explains
+why the build had to change first.
 
 `bun run --filter '*' build` derives its ordering from **`dependencies` only**.
 Measured on Bun 1.3.14: with core in `devDependencies` and in `peerDependencies`
@@ -209,7 +209,8 @@ Two consequences worth keeping:
 
 - The range publishes as a **caret** rather than an exact version. An exact pin
   makes `@dunx/testing@0.4.0` demand `@dunx/core@0.4.0` and nothing else, so a
-  consumer on 0.4.1 gets a nested second copy - the duplication being avoided.
+  consumer on 0.4.1 gets a nested second copy (Bun warns and installs it;
+  npm fails with ERESOLVE) - the duplication being avoided.
   **That pass has since been taken for every package**: `workspace:*` no longer
   publishes as the exact version, it publishes as `^<version>`. The rule lives in
   one place (`resolveWorkspaceRange` in `scripts/workspace-ranges.ts`), shared by

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -273,8 +273,8 @@ after    parent pid 1148355  COLOURED   Started [background] worker for queue: .
 variable both checks read and the only thing that crosses a fork. Nothing is
 added when `NO_COLOR` or `FORCE_COLOR` is already set: it crosses in
 `process.env` unchanged, and it is the consumer's answer rather than a terminal
-check. Nothing is added either when the consumer passed `workerForkOptions` of
-their own, which would have to be merged into.
+check. Nothing is added when the consumer passed `workerForkOptions` of their own,
+since dunx's defaults would have to be merged into the consumer's options.
 
 `isolation: 'thread'` needs none of this: Bun ignores the `stdout`/`stderr` options
 bullmq passes `new Worker`, so a thread writes to the process's real stdout.

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -4,13 +4,12 @@ bullmq over `Bun.RedisClient`, and how the ioredis question resolved by measurin
 
 ## Queues (`@dunx/infra/queue`)
 
-**bullmq is the queue.** Never invent what a mature library solves, again: retries,
-backoff,
-priorities, rate limiting, delayed jobs, schedulers and stall recovery are bullmq's,
-and a dunx implementation of any of them would be a worse one. `bullmq` is an
-optional `peerDependency`. What the area contributes is the four things bullmq has
-no opinion about - where a handler lives, how it is found, how it is injected, and
-when it stops.
+**bullmq is the queue.** Never invent what a mature library already solves:
+retries, backoff, priorities, rate limiting, delayed jobs, schedulers and stall
+recovery are already bullmq's, and a dunx implementation of any of them would be
+a worse one. `bullmq` is an optional `peerDependency`. What this area contributes
+is the four things bullmq has no opinion about: where a handler lives, how it is
+found, how it is injected, and when it stops.
 
 ### The ioredis boundary, as it actually resolved
 
@@ -84,26 +83,25 @@ happen. It is not applied, and the advice is removed from the guide and from
 
 What the error actually reports is **ioredis absent**, which is not fixable from
 this side. `bullmq/dist/{cjs,esm}/classes/queue.js` both fail without it, because
-everything routes through `utils/index`; only `classes/bun-redis-client.js` loads
-standalone, and it is useless without `Queue` and `Worker`. So the barrel is not at
-fault and there is no deep-import escape - **`/queue` cannot be imported without
-ioredis, and cannot be made to be.**
+everything routes through `utils/index`. Only `classes/bun-redis-client.js` loads
+standalone, and it is useless without `Queue` and `Worker`. So the barrel is not
+at fault, and there is no deep-import escape: **`/queue` cannot be imported
+without ioredis, and cannot be made to be.**
 
-`ioredis` nonetheless stays an **optional** peer, because it is optional in exactly
-the sense `bullmq` is: needed if and only if `/queue` is used. Requiring it would
-put ioredis in the install of every consumer of `/db`, `/files`, `/images`,
-`/logger` and `/redis`, the outcome the ban exists to prevent. npm cannot
-express "optional, but in lockstep with bullmq", so `packages/infra/src/index.test.ts`
-does: one test asserts both peers carry `optional: true`, and guide 14 says
-`bun add bullmq ioredis`.
+`ioredis` nonetheless stays an **optional** peer, because it is optional in
+exactly the sense `bullmq` is: needed if and only if `/queue` is used. Requiring
+it would put ioredis in the install of every consumer of `/db`, `/files`,
+`/images`, `/logger` and `/redis`, the outcome the ban exists to prevent. npm
+cannot express "optional, but in lockstep with bullmq." `packages/infra/src/index.test.ts`
+does that instead: one test asserts both peers carry `optional: true`, and guide
+14 says `bun add bullmq ioredis`.
 
 The range is **bullmq's rather than dunx's**. dunx never imports ioredis, so it
-has no opinion that could be better informed than the library that does, and
-the peer therefore mirrors bullmq's own `>=5.0.0` rather than narrowing to the
-major CI happens to resolve. The second test in that file asserts the two
-ranges are equal, so bullmq changing its requirement fails here instead of
-leaving dunx advertising a stale one - the same guard shape as the `LOG_LEVELS`
-test.
+has no opinion that could be better informed than the library that does. The
+peer therefore mirrors bullmq's own `>=5.0.0` rather than narrowing to the major
+CI happens to resolve. The second test in that file asserts the two ranges are
+equal, so bullmq changing its requirement fails here instead of leaving dunx
+advertising a stale one, the same guard shape as the `LOG_LEVELS` test.
 
 The `devDependency` was `^6.0.0` against a `>=5.0.0` peer; it now matches the
 peer, as `bullmq`'s and `drizzle-orm`'s already did.
@@ -114,11 +112,11 @@ Rails 8 moved its queue, cache and websocket fan-out onto the application's own
 database and dropped Redis. The question that raises here is whether
 `@dunx/infra/queue` should have a second backend needing no broker.
 
-**pg-boss is the library, on the rule that made bullmq the queue.** Retries, backoff,
-cron, singleton queues, dead letters and archival are already its, and building them
-over `Bun.SQL` is the failure Rule 1's second half names. graphile-worker is the
-other candidate and was not measured; pg-boss took the first look for publishing a
-`Db` interface aimed at this case.
+**pg-boss is the library, on the rule that made bullmq the queue.** Retries,
+backoff, cron, singleton queues, dead letters and archival are already its, and
+building them over `Bun.SQL` is the failure Rule 1's second half names.
+graphile-worker is the other candidate and was not measured. pg-boss took the
+first look, for publishing a `Db` interface aimed at this case.
 
 pg-boss 12.28.1 takes a `db` implementing `executeSql(text, values)`, and its types
 say a custom adapter may also implement `listen` to enable `useListenNotify`.
@@ -163,11 +161,12 @@ Two costs stand against adopting this, and the measurement settles neither:
 
 Both figures above are PostgreSQL 17 through `Bun.SQL`'s Postgres adapter, and
 nothing else was measured. pg-boss carries four other backend profiles, and the
-latency does not carry to them, because the only thing separating 10 ms from 2012 ms
-is whether a notification arrives: `cockroachdb` sets `noListenNotify` and polls,
+latency does not carry to them: the only thing separating 10 ms from 2012 ms is
+whether a notification arrives. `cockroachdb` sets `noListenNotify` and polls,
 `yugabytedb` has it early-access behind `ysql_yb_enable_listen_notify` and off by
-default, `citus` and `pglite` have it. Their other flags, `noAdvisoryLocks` and
-`noTablePartitioning`, bear on migration and table layout rather than on dispatch.
+default, and `citus` and `pglite` have it. Their other flags, `noAdvisoryLocks`
+and `noTablePartitioning`, bear on migration and table layout rather than on
+dispatch.
 
 SQLite and MySQL are not pg-boss backends at all, and `Bun.SQL` answers
 `LISTEN`/`NOTIFY` on the Postgres adapter alone, so an app on either has no candidate
@@ -185,21 +184,21 @@ ordering dependence and no cross-file leak. `WorkerFactory` walks
 `Object.getPrototypeOf` from the prototype of each class the modules already declare
 in `providers`/`controllers`, exactly as `discoverGateways` does.
 
-What that buys, and it is the same list routes get: no second registration key, no
+What that buys is the same list routes get: no second registration key, no
 `@Processor` class decorator, an abstract base's handlers inherited by every
-subclass, an undecorated override still dispatched to because the handler is bound
-off the instance, and a duplicate `(queue, name)` as a boot error naming both
-methods rather than traffic silently split between them.
+subclass, an undecorated override still dispatched to because the handler is
+bound off the instance, and a duplicate `(queue, name)` as a boot error naming
+both methods rather than traffic silently split between them.
 
 One asymmetry with gateways is deliberate. `discoverGateways` throws when a class
 declares a handler but is not marked `@Gateway`, because such a handler could never
 receive a frame. There is no class-level marker here, so there is no such orphan
 state and no such error.
 
-A factory- or value-provided instance is **not** scanned. There is no class to read a
-prototype chain from until it has been built, and building every factory provider to
-find out whether it was worth building is the ordering trap the marker technique
-exists to avoid.
+A factory- or value-provided instance is **not** scanned. There is no class to
+read a prototype chain from until it has been built. Building every factory
+provider just to find out whether it was worth building is the ordering trap the
+marker technique exists to avoid.
 
 ### Publish and consume are different processes, so they are different objects
 
@@ -210,18 +209,18 @@ exists to avoid.
 discover by inspection, validate eagerly, and return an object wrapping `App` whose
 `shutdown()` sequences its own resource ahead of the container's.
 
-`create` discovers and validates; `start()` opens connections. That split is what
-makes a wiring mistake - no `QueueModule`, no handlers, a misspelled name in
-`queues` - fail before anything consumes, and what lets `worker.jobs` be asserted in
+`create` discovers and validates; `start()` opens connections. That split makes a
+wiring mistake - no `QueueModule`, no handlers, a misspelled name in `queues` -
+fail before anything consumes. It is also what lets `worker.jobs` be asserted in
 a test with no server running.
 
-The "no `QueueModule`" check reads the **module graph** rather than the container, and the
-reason generalises past queues: **every class self-binds, so a class whose
-constructor arguments are all optional resolves successfully when nothing bound it.**
-`app.get(QueueOptions)` on a container with no `QueueModule` returns defaults - a
-worker silently pointed at `localhost` - rather than throwing. Any presence check for
-a class-shaped token has the same hole; `collectModules(root)` and a token comparison
-do not.
+The "no `QueueModule`" check reads the **module graph** rather than the
+container. The reason generalises past queues: **every class self-binds, so a
+class whose constructor arguments are all optional resolves successfully when
+nothing bound it.** `app.get(QueueOptions)` on a container with no `QueueModule`
+returns defaults - a worker silently pointed at `localhost` - rather than
+throwing. Any presence check for a class-shaped token has the same hole;
+`collectModules(root)` and a token comparison do not.
 
 `JobPublisher` returns bullmq's own `Queue` and `Job` rather than wrappers, for the
 same reason `/db` returns drizzle's database class: the library is the interface, and
@@ -229,11 +228,11 @@ a wrapper would be a surface to outgrow.
 
 ### The one behaviour that is dunx's rather than bullmq's
 
-`jobTimeoutMs`. bullmq has `lockDuration` and stall detection, which answer _did the
-worker die_ rather than _is this handler stuck_ - a handler hung on an external call renews
-its lock and never finishes. The dispatcher races the handler against a timer and
-clears it in a `finally`, since an uncleared timer would hold the loop open for its
-full duration after a fast job. Off by default.
+`jobTimeoutMs`. bullmq has `lockDuration` and stall detection, which answer _did
+the worker die_ rather than _is this handler stuck_: a handler hung on an
+external call renews its lock and never finishes. The dispatcher races the
+handler against a timer and clears it in a `finally`, since an uncleared timer
+would hold the loop open for its full duration after a fast job. Off by default.
 
 ### Shutdown ordering
 
@@ -252,7 +251,7 @@ plus zero open sockets afterwards.
 ### A forked child's colour, which is the parent's question
 
 bullmq forks a sandboxed processor with `stdio: 'pipe'` and pipes the child's
-stdout into the parent's (`classes/child.js`), so the child's stdout is a pipe and
+stdout into the parent's (`classes/child.js`). The child's stdout is a pipe, and
 the terminal the lines actually reach belongs to the parent. Everything on the
 colour path asks the child's own stream: `Bun.enableANSIColors`, which
 `LoggerModule` defaults `isDevelopment` from, and `@arkv/colors`' `isColorSupported`,
@@ -269,13 +268,13 @@ after    parent pid 1148355  COLOURED   Started [background] worker for queue: .
          child  pid 1148371  COLOURED   Sandboxed worker ready, 1 handler(s)
 ```
 
-`childColourEnv` in `worker.ts` is the fix: `FORCE_COLOR=1` in `workerForkOptions.env`
-when this process has colour, since that is the one variable both checks read and
-the only thing that crosses a fork. Nothing is added when `NO_COLOR` or
-`FORCE_COLOR` is already set - it crosses in `process.env` unchanged and is the
-consumer's answer rather than a terminal check - and nothing is added when the
-consumer passed `workerForkOptions` of their own, which would have to be merged
-into.
+`childColourEnv` in `worker.ts` is the fix: `FORCE_COLOR=1` in
+`workerForkOptions.env` when this process has colour, since that is the one
+variable both checks read and the only thing that crosses a fork. Nothing is
+added when `NO_COLOR` or `FORCE_COLOR` is already set: it crosses in
+`process.env` unchanged, and it is the consumer's answer rather than a terminal
+check. Nothing is added either when the consumer passed `workerForkOptions` of
+their own, which would have to be merged into.
 
 `isolation: 'thread'` needs none of this: Bun ignores the `stdout`/`stderr` options
 bullmq passes `new Worker`, so a thread writes to the process's real stdout.

--- a/docs/architecture/tooling.md
+++ b/docs/architecture/tooling.md
@@ -309,7 +309,8 @@ the immutable header, and the page requests nothing off-origin.
 
 The docs site measured Vite at 1.7 s against `bun build ./index.html` at 41 ms
 and took Bun's ~25 % larger output, which was right for a site. Both numbers have
-since been re-measured and reversed - see "Documentation site" above. The
+since been re-measured. The speed gap narrowed but Bun.build remains faster,
+while the bundle-size result reversed - see "Documentation site" above. The
 dashboard bundle is inlined into a page a backend serves, so Rollup's
 tree-shaking wins there, and the ~1.5 s is paid once per package build.
 

--- a/docs/architecture/tooling.md
+++ b/docs/architecture/tooling.md
@@ -10,9 +10,9 @@ coverage report as the Pages root; coverage is now a page inside it.
 
 **The bundler was `Bun.build` and was moved back to Vite, by measuring rather than
 by preference.** The original swap traded ~25% more gzipped JS for a 41 ms build
-against Vite 5's 1.7 s. Vite 8 ships Rolldown, which removed the speed argument,
-and the size argument had grown as Mantine and `@mantine/charts`/recharts entered
-the graph. Same site, same content, both bundlers, gzip -9:
+against Vite 5's 1.7 s. Vite 8 ships Rolldown, which removed the speed argument.
+The size argument had also grown, as Mantine and `@mantine/charts`/recharts
+entered the graph. Same site, same content, both bundlers, gzip -9:
 
 | Bundler           | JS raw    | JS gzip      | CSS raw  | CSS gzip | Build   |
 | ----------------- | --------- | ------------ | -------- | -------- | ------- |
@@ -30,17 +30,17 @@ it is ever reversed:
 - `public/` copying and the `dist/` clean are Vite's; `scripts/build.ts` is gone.
 
 **Every `@mantine/*` is on one major, and it is 8.** `@mantine/charts` had
-drifted to 9.5.0 against core 8.3.18, which its own `peerDependencies` forbids
-(it pins `@mantine/core` and `@mantine/hooks` to an exact version). The fix was
-pinning `charts` back to `^8.3.6` rather than moving the whole site to Mantine
-9, and the reason it works is that `charts@8.3.18` peers `recharts` at
-`>=2.13.3`, so the installed recharts 3.10.1 satisfies both majors.
+drifted to 9.5.0 against core 8.3.18, which its own `peerDependencies` forbids:
+it pins `@mantine/core` and `@mantine/hooks` to an exact version. The fix was
+pinning `charts` back to `^8.3.6` rather than moving the whole site to Mantine 9.
+That works because `charts@8.3.18` peers `recharts` at `>=2.13.3`, so the
+installed recharts 3.10.1 satisfies both majors.
 
-`BarChart` in 8 carries every prop `BenchChart.tsx` passes, and a
-headless-Chrome render of `#/benchmarks` produced 5 recharts surfaces with 55
-bars and the focus colour on `@dunx/http`, so this is verified rather than
-assumed. `@mantine/code-highlight` went with it: highlighting happens at
-generate time now, and nothing under `internal/docs` imported it.
+`BarChart` in 8 carries every prop `BenchChart.tsx` passes. A headless-Chrome
+render of `#/benchmarks` produced 5 recharts surfaces with 55 bars and the focus
+colour on `@dunx/http`, so this is verified rather than assumed.
+`@mantine/code-highlight` went with it: highlighting happens at generate time
+now, and nothing under `internal/docs` imported it.
 
 **The model is one file per route, and the landing page carries none of them.**
 `site.json` was imported into the entry chunk, so `#/` downloaded all 21 guide
@@ -82,10 +82,10 @@ the site's shape, and a field surviving the projection means something renders i
 **A README is rendered minus its repo-plumbing sections.** A package page
 showed `## Install`, `## License` and the monorepo's own build instructions,
 which are for someone working in this repository and not for someone reading
-the docs. `siteMarkdown` in `scripts/content.ts` drops a `##` section whose
-slug matches `EXCLUDED_SECTIONS` with a `-` word boundary - so `## Install it
-as a devDependency` goes with `## Install` - plus the centered title-and-badges
-block every README opens with.
+the docs. `siteMarkdown` in `scripts/content.ts` drops a `##` section whose slug
+matches `EXCLUDED_SECTIONS` with a `-` word boundary, so `## Install it as a
+devDependency` goes with `## Install`. It also drops the centered
+title-and-badges block every README opens with.
 
 The list is published in `internal/docs/README.md`, and an author decides which
 side a section falls on by naming it. Guides under `docs/` are exempt: they
@@ -246,10 +246,10 @@ decision rather than a footnote to it. Two things follow, and both are in the co
 - **It is an optional peer, resolved on the first request for the page.** An app
   serving only `/openapi.json` neither installs nor loads it.
 
-Two measurements from the explorer era that are still the reason things are shaped
-as they are: **per-component Mantine CSS** beat the `styles.css` barrel 381 KiB to
-517 KiB, and dropping `Tooltip` and `ScrollArea` for `title=` and `overflow: auto`
-took 490 KiB to 434 KiB because `Tooltip` drags in floating-ui. Both applied to
+Two measurements from the explorer era still shape things as they are:
+**per-component Mantine CSS** beat the `styles.css` barrel 381 KiB to 517 KiB, and
+dropping `Tooltip` and `ScrollArea` for `title=` and `overflow: auto` took 490 KiB
+to 434 KiB, because `Tooltip` drags in floating-ui. Both applied to
 `internal/dashboard-ui`, which still exists and still follows them.
 
 ### `splitting: true`, which outlived the thing that needed it
@@ -292,7 +292,7 @@ being reachable and guarded the same way, and the server already has the bytes.
 
 ### The no-external-requests guarantee narrowed, and the test says so
 
-The old page fetched nothing at all, and the assertion had already had to move once
+The old page fetched nothing at all, and the assertion had already had to move once:
 
 - `expect(page).not.toContain('src=')` is sound over hand-written HTML and
   meaningless over a minified React bundle that contains `.src=`, `href="` and the
@@ -307,11 +307,11 @@ the immutable header, and the page requests nothing off-origin.
 
 ### Vite in `internal/dashboard-ui`, `bun build` in `internal/docs`
 
-The docs site measured Vite at 1.7 s against `bun build ./index.html` at 41 ms and
-took Bun's ~25 % larger output, which is right for a site. Both numbers have since
-been re-measured and reversed - see "Documentation site" above. The dashboard bundle
-is inlined into a page a backend serves, so Rollup's tree-shaking wins there and the
-~1.5 s is paid once per package build.
+The docs site measured Vite at 1.7 s against `bun build ./index.html` at 41 ms
+and took Bun's ~25 % larger output, which was right for a site. Both numbers have
+since been re-measured and reversed - see "Documentation site" above. The
+dashboard bundle is inlined into a page a backend serves, so Rollup's
+tree-shaking wins there, and the ~1.5 s is paid once per package build.
 
 ## Why `openapi.config.ts` stays
 

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -65,9 +65,10 @@ Use the links in the table to jump to the associated documentation.
 
 ## Re-probed on Bun 1.4.0 (rev 34cbb9a40)
 
-Everything below this heading was first measured on 1.3.14. Re-running the probes on
-1.4 moved five entries and added three; the rest still reproduce. **Fixed** means the
-probe that used to fail now passes, not that the note was wrong.
+Everything below this heading was first measured on Bun 1.3.14. Re-running the probes
+on 1.4 moved five entries and added three; the rest still reproduce. **Fixed** here
+means the probe that used to fail now passes. It does not mean the earlier note was
+wrong.
 
 | Finding                                                           | On 1.4                                                            |
 | ----------------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -185,27 +186,27 @@ wrong. Same process each time - construct, attempt one operation, tear down, the
 
 The black-holed row is Bun's, and is the "connect that never completes" entry in the
 table above - no framework involved. The refused row is bullmq's: its adapter runs a
-`setTimeout` reconnect chain, and both `disconnect()` and `quit()` return early when
-`closed` is already `true`, which is exactly when a reconnect is pending. Nothing on
+`setTimeout` reconnect chain. Both `disconnect()` and `quit()` return early when
+`closed` is already `true`, which is when a reconnect is pending, and nothing on
 `IRedisClient` can cancel it. Reproductions for both, ready to file, are in
 internal/notes/roadmap/queue-shutdown-sigterm.md.
 
-The healthy row is clean at every layer, which is why no normal deployment sees this.
-Consequence: a container that touched a Redis it could not reach will not exit on
-`SIGTERM` and will be `SIGKILL`ed. It serves correctly throughout - the route answers
-503 in single-digit milliseconds - so this is a shutdown defect, not an availability
-one.
+The healthy row is clean at every layer, so no normal deployment sees this. The
+consequence: a container that touched a Redis it could not reach will not exit on
+`SIGTERM`, and gets `SIGKILL`ed instead. It serves correctly throughout - the route
+answers 503 in single-digit milliseconds. This is a shutdown defect, not an
+availability one.
 
-Two neighbouring leaks in `Bun.RedisClient` itself, both fixed in
+Two neighbouring leaks live in `Bun.RedisClient` itself, and both are fixed in
 `@dunx/infra/redis`: a client that entered subscriber mode needs `unsubscribe()`
 before `close()`, and a `subscribe()` that failed to connect needs `connect()` first.
-`bun test` cannot observe either, because the runner exits the process itself - they
-need a spawned process to catch, which is what `@dunx/infra/redis` now has.
+`bun test` cannot observe either, because the runner exits the process itself.
+Catching them needs a spawned process, and `@dunx/infra/redis` now has one.
 
 **bullmq 6.0.5 has no `exports` map and no `"type": "module"`, so Bun resolves it to
-`main` - the CJS build.** The imported namespace carries `__esModule` and a `default`
-holding `Queue`, which is how you tell. This matters because a previous note here
-claimed the ESM build was the safe one: both builds statically import `ioredis` and
+`main`, the CJS build.** The imported namespace carries `__esModule` and a `default`
+holding `Queue`; that is how you can tell. A previous note here claimed the ESM build
+was the safe one. It was not: both builds statically import `ioredis` and
 `ioredis/built/utils`, ioredis 6.0.0 still ships that path, and no pin is needed.
 Full measurement in architecture/queues.md, "Not pinning ioredis 5".
 
@@ -225,26 +226,28 @@ Measured on `internal/bench`'s validation harness (`bun run validation`), four r
 | `POST` + `await req.json()`              |  12.14 | +3.10 µs |
 | `POST` + `req.json()` + zod              |  13.09 | +0.94 µs |
 
-**Putting a body on the wire is near-free; reading it is not, and reading it costs
+**Putting a body on the wire is near-free. Reading it is not, and reading it costs
 ~3.3x what validating it costs.** So the framework-level advice - "pick a faster
 validator" - is aimed at the smaller half. Every validator measured (zod, Valibot,
 ArkType, TypeBox's compiled checker, ajv) lands between 0.0 µs and 0.94 µs, all of
 them under the parse.
 
 **The primitive Bun is missing is a validating parser.** `req.json()` allocates a
-full JavaScript object graph which the validator then walks a second time, and
-Bun ships nothing that fuses the two: no `Bun.JSON` with a schema, no JSON Schema
-validator, no way to validate the body bytes without materialising them first.
-`Bun.TOML` and `Bun.markdown` exist; a `Bun.json(bytes, schema)` that answered from
-one pass over the buffer would remove most of what a validated POST costs today, and
-it is the kind of thing only the runtime can do - a userland library cannot avoid
-the intermediate object.
+full JavaScript object graph, and the validator then walks that same graph a second
+time. Bun ships nothing that fuses the two steps: no `Bun.JSON` with a schema, no
+JSON Schema validator, no way to validate the body bytes without materialising them
+first.
 
-Until then this is a floor, not a dunx cost, and **dunx must not try to fill it**:
-Not inventing what a mature library solves rules out writing a validator, and a
-hand-rolled JSON parser
-would be a JavaScript reimplementation of a JSC primitive, which the first half
-rules out. Recorded here so the ceiling is known rather than rediscovered.
+`Bun.TOML` and `Bun.markdown` exist, so the gap is not that Bun avoids parsers. A
+`Bun.json(bytes, schema)` that answered from one pass over the buffer would remove
+most of what a validated POST costs today. It is also the kind of thing only the
+runtime can do: a userland library cannot avoid building the intermediate object.
+
+Until then this is a floor, not a dunx cost. **dunx must not try to fill it**: not
+inventing what a mature library already solves rules out writing a validator, and a
+hand-rolled JSON parser would be a JavaScript reimplementation of a JSC primitive,
+which the first half of Rule 1 already rules out. Recorded here so the ceiling is
+known rather than rediscovered.
 
 ### `Bun.cron` - 1.4 honours `{ tz }` and changed the default zone
 
@@ -303,7 +306,7 @@ Three things it does not do, and the first is the one that decides an adoption:
 | **Every HTTP method is served**               | `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `PATCH` and `OPTIONS` all return **200 with the file body**. So `DELETE /assets/app.js` answers with the script, and `OPTIONS` cannot carry CORS preflight headers.       |
 | No `x-content-type-options: nosniff`          | Not set, and not settable for the same reason as `cache-control`.                                                                                                                                                 |
 
-One more shape worth knowing: `index` is **half-implemented**. It is type-checked at
+One more shape to flag: `index` is **half-implemented**. It is type-checked at
 `Bun.serve` (`index: false` throws `The "index" property must be of type string`),
 undeclared in `bun-types`, and then ignored - `{ dir, index: 'a.txt' }` still serves
 `index.html`. A validated-but-inert option is worse than an unknown one, which Bun
@@ -444,7 +447,7 @@ Fully typed in `bun-types` (`bun.d.ts` ~8180-8408), just undocumented on the sit
   `.resize(10,10).resize(20,20)` yields 20×20. Execution order is fixed at
   `autoOrient → rotate → flip/flop → resize → modulate` regardless of call order.
   A shared instance therefore lets one caller silently reconfigure another's
-  transform, which is why a wrapper should be immutable.
+  transform, so a wrapper should be immutable.
 - **`metadata()` ignores the chain** and only reads the header, so it reports the
   _source_ dimensions and format. It also succeeds on a truncated file - it is
   **not** a validity check.
@@ -573,10 +576,10 @@ names nothing. The explicit argument loses to the ambient variable.
 | `MYSQL_URL`                 | ok → `adapter: mysql`              |
 
 Three forms are unaffected, all verified: `new Bun.SQL(urlString)`,
-`new Bun.SQL(new URL(url))`, and `new Bun.SQL({ url, adapter: 'mysql' })`. Note
-that `@dunx/infra/db`'s `SqlOptions` uses the options-object form - harmless there,
-because that backend is Postgres by construction, but any non-Postgres backend
-built on `Bun.SQL` must name its `adapter`.
+`new Bun.SQL(new URL(url))`, and `new Bun.SQL({ url, adapter: 'mysql' })`.
+`@dunx/infra/db`'s `SqlOptions` uses the options-object form, which is harmless
+there because that backend is Postgres by construction. Any non-Postgres backend
+built on `Bun.SQL` must name its `adapter` explicitly.
 
 #### `LISTEN`/`NOTIFY` on the Postgres adapter, and the 7999-byte cap
 
@@ -665,7 +668,8 @@ MySQL URL through it emits `$1` placeholders and double-quoted identifiers) and
 `bun-sqlite`. Its MySQL drivers are `mysql2` and `mysql-proxy`.
 
 `drizzle-orm/mysql-proxy` over `Bun.SQL` works and keeps the split: drizzle owns the
-dialect, Bun owns the socket, `mysql2` is never installed. Verified against MySQL 8 inserts, selects, `where`, ordering, updates, deletes, aggregates,
+dialect, Bun owns the socket, and `mysql2` is never installed. Verified against
+MySQL 8: inserts, selects, `where`, ordering, updates, deletes, aggregates,
 `$returningId()` single and multi-row, inner and left joins, `placeholder()`
 prepared statements, and the `mysql-proxy` migrator.
 
@@ -761,10 +765,11 @@ iterator's `return()`, and the three explicit calls do the same job by hand.
 
 **A piped test never sees this.** `printf 'notes\n' | bun cli.ts` closes stdin
 straight away, the iteration ends on EOF, and the process exits. The hang needs
-something holding the other end open, which is every real terminal. That is how it
-reached a release: `bunx @dunx/create-app my-api` wrote the app, printed its next
-steps and then sat there until the user pressed Ctrl+C, reported from a real run
-after the piped CLI suite had been green for weeks.
+something holding the other end open, and every real terminal does.
+
+That is how it reached a release: `bunx @dunx/create-app my-api` wrote the app,
+printed its next steps, and then sat there until the user pressed Ctrl+C. It was
+reported from a real run, after the piped CLI suite had been green for weeks.
 
 The line read is gone - `@dunx/create-app` reads keys in raw mode now, and
 `ProcessTty.close()` in `tools/create-app/src/tty.ts` is the same release by hand,
@@ -788,12 +793,12 @@ write('a\nb\n') while raw            arrives as a<CR><LF>b<CR><LF>
 
 - **`setRawMode` is absent, not failing, on a pipe.** Checking `isTTY` on both
   streams is the capability test; there is nothing to catch.
-- **An escape sequence arrives whole.** Three bytes in one read, which is what lets
-  a decoder treat a chunk holding nothing but `0x1b` as the Escape key rather than
+- **An escape sequence arrives whole.** Three bytes arrive in one read, so a decoder
+  can treat a chunk holding nothing but `0x1b` as the Escape key rather than
   waiting on a timer.
 - **`ISIG` is off, so Ctrl+C is a byte.** A `SIGINT` handler installed alongside
-  never ran. Nothing ends the process unless the reader does, which is why the
-  cancel path exits 130 itself.
+  never ran. Nothing ends the process unless the reader does, so the cancel path
+  exits 130 itself.
 - **Restoring is enough to exit.** No `process.exit`, no `unref`.
 - **`OPOST` and `ONLCR` survive raw mode**, so a frame written with `\n` still
   returns the carriage. Node's `setRawMode` only clears input and local flags.
@@ -852,15 +857,15 @@ Three things about the shape of it:
 - Nothing to do with `@dunx/transform`. Reproduced in `/tmp` with no preload, no
   `bunfig.toml` and a two-line local decorator.
 
-This one is worth knowing rather than filing and forgetting, because dunx makes it
-easy to hit: **every controller, gateway, `@JobHandler` and scheduled service is a
-decorated class**, and `#count++` is the obvious way to keep a counter in one.
+dunx makes this easy to hit: **every controller, gateway, `@JobHandler` and
+scheduled service is a decorated class**, and `#count++` is the obvious way to keep
+a counter in one.
 
-It also sits under an idiom already in shipped code. `this.#x ??= ...` is how six
+It also sits under an idiom already in shipped code: `this.#x ??= ...` is how six
 classes do lazy init - `DashboardMiddleware`, `RedisRelay`, `QueueProcessor`,
 `QueueWorker`, `Workspace`, `Application`. None of them is decorated today, so none
-is broken; adding one decorator to any of them turns the file into a parse error
-with a message that names neither the field nor the decorator.
+is broken. Adding one decorator to any of them would turn the file into a parse
+error, with a message that names neither the field nor the decorator.
 
 Found while writing `examples/full/src/schedule/maintenance.service.ts`, whose
 `@Cron`/`@Interval`/`@OnceOnBoot` handlers each incremented a private counter.
@@ -938,10 +943,12 @@ N defaulting to the core count.
 Two behaviours change with it.
 
 **A `?raw` import suffix does not survive a worker.** `internal/docs/src/data.ts`
-has `import indexRaw from './generated/index.json?raw'`. In one process that is the
-file's text. In a `--parallel` worker it is the parsed object, so `JSON.parse` on it
-throws `SyntaxError: JSON Parse error: Unexpected identifier "object"` and 7 of the
-suite's 10 files bail: **91 tests sequentially against 30 passing and 7 failing**.
+has `import indexRaw from './generated/index.json?raw'`. In one process that import
+is the file's text. In a `--parallel` worker it is the parsed object instead, so
+`JSON.parse` on it throws `SyntaxError: JSON Parse error: Unexpected identifier
+"object"`, and 7 of the suite's 10 files bail: **91 tests sequentially against 30
+passing and 7 failing**.
+
 It fails loudly, so opting in per workspace is safe. `internal/docs` is the one
 exclusion, in the `docs` phase of `scripts/ci.ts`.
 
@@ -966,7 +973,7 @@ suite's 17.4s**, with the other nine files summing to 4.3s.
 `bun-types` declares every matcher `: void` and `rejects: Matchers<unknown>`, and the
 runtime agrees: `expect(Promise.reject(x)).rejects.toThrow()` evaluates to
 `undefined`, not a promise. `await expect(...).rejects.toThrow()` therefore awaits
-nothing, which is what `typescript/await-thenable` fires on at 19 sites here.
+nothing; `typescript/await-thenable` fires on that at 19 sites here.
 
 The assertion holds without the `await`. Probed all four combinations, settled or
 pending promise against correct or wrong expectation, awaited or not: Bun tracks the
@@ -1023,13 +1030,14 @@ default (remap to source)       28   11    39.3%
 coverageIgnoreSourcemaps = true 17   15    88.2%
 ```
 
-The 17 lines Bun cannot reach in the first column are the `import` statement,
-the interface members and the abstract member signatures: none of them emit
-anything, so they are unhittable by construction. `packages/core/src/logger/context.ts`
-was the live case, `DA:1,0` through `DA:46,0` over its imports and its two
-interfaces, reading as 32.35% for a file whose class is exercised on every boot.
-Repo-wide the remapping costs about 1.8 points of line coverage: 93.55% against
-95.33%.
+The 17 lines Bun cannot reach in the first column are the `import` statement, the
+interface members and the abstract member signatures. None of them emit anything,
+so they are unhittable by construction.
+
+`packages/core/src/logger/context.ts` was the live case: `DA:1,0` through `DA:46,0`
+over its imports and its two interfaces, reading as 32.35% for a file whose class
+is exercised on every boot. Repo-wide the remapping costs about 1.8 points of line
+coverage: 93.55% against 95.33%.
 
 `coverageIgnoreSourcemaps = true` is **not** set here. It fixes the ratio and
 breaks the thing the ratio is for: the uncovered line ranges the coverage page
@@ -1065,9 +1073,10 @@ rarely declare a constructor.
 That is as far as it can be pinned down, and not far enough to correct for. The
 counts do not add up at scale: `@dunx/core` has 15 unhit functions against roughly
 43 classes with no explicit constructor, so something else marks most of them hit.
-**Do not try to subtract this from the denominator** - a correction built on a rule
+
+**Do not try to subtract this from the denominator.** A correction built on a rule
 this shaky would be wrong in a way that is harder to notice than the artifact it
-replaces, and it would be baked into the gate.
+replaces, and it would get baked into the gate.
 
 Two other things no test can reach, for the same tally: `di/scope.ts:289` is a
 throw its own comment calls unreachable by construction, and
@@ -1100,11 +1109,13 @@ route reads as an empty document.
 Neither obvious escape works. `bun test -c other-bunfig.toml` still ran the
 preload (probed both ways: happy-dom reported `isRegistered` either way), and
 `GlobalRegistrator.unregister()` in a `beforeAll` does not hand the native
-`Response` back. What does work is **a `bunfig.toml` next to the working
-directory**: Bun picks the config beside the cwd, so the suite lives in
-`browser/` with an empty `[test]` there and its script does `cd browser && bun test`.
-Then `Response` is `function Response() { [native code] }`, `document` is
-undefined, and the server serves.
+`Response` back.
+
+What does work is **a `bunfig.toml` next to the working directory**: Bun picks the
+config beside the cwd, so the suite lives in `browser/` with an empty `[test]`
+there, and its script does `cd browser && bun test`. Then `Response` is
+`function Response() { [native code] }`, `document` is undefined, and the server
+serves.
 
 **`Bun.WebView` has no `colorScheme` or `deviceScaleFactor` option.**
 `ConstructorOptions` is `width`, `height`, `headless`, `backend`, `url`,
@@ -1125,11 +1136,11 @@ await view.cdp('Emulation.setDeviceMetricsOverride', {
 
 Verified against the built site: the body background goes `rgb(255, 255, 255)` to
 `rgb(36, 36, 36)`, `devicePixelRatio` reads 2, and the PNG comes out 2880x1800 for
-a 1440x900 viewport. The `console` option is a
-`(type, ...args) => void` callback, which is how the suite catches a page-side
-error no happy-dom test can see. 29 tests over 7 routes, 2 viewports and 2 schemes,
-writing 28 PNGs as they go, take 15.4s against a playwright install that was 150 MB
-of browser for the same work.
+a 1440x900 viewport. The `console` option is a `(type, ...args) => void` callback,
+and that is how the suite catches a page-side error no happy-dom test can see.
+
+29 tests over 7 routes, 2 viewports and 2 schemes, writing 28 PNGs as they go, take
+15.4s, against a playwright install that was 150 MB of browser for the same work.
 
 Both emulations are per-target and survive a navigation, so re-applying the one
 already in force is worth skipping: `setEmulatedMedia` needs a repaint wait, and 28
@@ -1138,15 +1149,16 @@ shots would otherwise spend 4.2s re-setting what was already set.
 ### `render()` has no auto-cleanup under `bun test`
 
 `@testing-library/react` registers its own `afterEach(cleanup)` only when it finds
-Jest's globals, and it does not find them here. Nothing in `internal/docs` called
-`cleanup`, so no `render` was ever unmounted, and `useRoute`'s `hashchange`
-listener outlived the test that created it. `mount()` sets `window.location.hash`
-first thing, so each new test re-rendered every detached tree every earlier file
-had left behind.
+Jest's globals, and it does not find them here.
+
+Nothing in `internal/docs` called `cleanup`, so no `render` was ever unmounted, and
+`useRoute`'s `hashchange` listener outlived the test that created it. `mount()`
+sets `window.location.hash` first thing, so each new test re-rendered every
+detached tree every earlier file had left behind.
 
 The cost was quadratic and hidden in one file: `symbol-anchor.test.tsx` measured
 **1.7s alone and 12.5s behind the other nine**. Pairs of files never reproduced it,
-which is what made it look like a slow test rather than a leak.
+so it looked like a slow test rather than a leak.
 
 `afterEach(cleanup)` registered from the **preload** fixes it for every file, and a
 preload-registered hook does run for every test in every file (probed). The whole
@@ -1173,9 +1185,10 @@ produced it. `scripts/ci.ts` drains both pipes into one buffer as the chunks arr
 
 Pointing the live `@dunx/infra/files` suite at MinIO by exporting `S3_ENDPOINT`
 broke two tests that had nothing to do with it. `S3StorageOptions` passes its
-options straight through, and anything omitted falls back to the environment, so
-the offline `presign` suite - which sets explicit fake credentials and region but
-no endpoint - started signing URLs against `localhost:9000` and failed its
+options straight through, and anything omitted falls back to the environment.
+
+The offline `presign` suite sets explicit fake credentials and region but no
+endpoint, so it started signing URLs against `localhost:9000` and failed its
 assertions on `s3.eu-west-1.amazonaws.com`.
 
 The live block takes `DUNX_S3_TEST_ENDPOINT` instead and passes it explicitly, so

--- a/docs/guide/01-introduction.md
+++ b/docs/guide/01-introduction.md
@@ -2,13 +2,11 @@
 
 dunx is a dependency injection framework for [Bun](https://bun.com). It gives you
 modules, constructor injection, class-based controllers, lifecycle hooks and
-guards, and it serves HTTP through `Bun.serve` rather than through a server it
-wrote itself.
+guards. HTTP is served through `Bun.serve`, not through a server dunx wrote.
 
-The architecture is the one Spring and Angular established: inversion of control
-with a container that owns object lifetimes, declarative metadata instead of wiring
-code, and modules that draw domain boundaries. If you have worked in either, the
-shape will be familiar within a minute:
+The architecture follows the pattern Spring and Angular established. A container
+owns object lifetimes. Metadata replaces wiring code. Modules draw domain
+boundaries. If you have worked with either framework, the shape is familiar:
 
 ```ts
 import { Module } from '@dunx/core';
@@ -52,19 +50,19 @@ cannot be recovered.
 ## What it is built on
 
 **Bun does the I/O.** `Bun.serve({ routes })` matches paths, dispatches per method
-and answers a method miss, in native Zig, so dunx ships no router: it builds the
-routes object at boot and hands it over. The same goes for SQLite, Postgres, Redis,
-S3, image resizing, password hashing and `.env` loading, each of which Bun already
-does. `ConfigModule` has no loader because Bun reads `.env` itself.
+and answers a method miss, in native Zig. dunx builds the routes object at boot
+and hands it over. The same goes for SQLite, Postgres, Redis, S3, image resizing,
+password hashing and `.env` loading: Bun already does each of those.
+`ConfigModule` has no loader because Bun reads `.env` itself.
 
 You can see where the line falls in the dependency tree: `@dunx/core` has **zero
 dependencies**, and nothing in dunx pulls in express, `ws`, ioredis, pg, sharp or
 dotenv.
 
-One exception, and it is the parser. Bun cannot tell you a TypeScript
-constructor's parameter types, so `@dunx/transform` reads them with
+The one exception is the parser. Bun cannot tell you a TypeScript constructor's
+parameter types, so `@dunx/transform` reads them with
 [oxc-parser](https://github.com/oxc-project/oxc), a Rust parser over N-API. It is
-build-time only and ships as its own package, so a production deploy carries no
+build-time only and ships as its own package. A production deploy carries no
 parser.
 
 **Libraries do the hard parts.** Where Bun has no primitive, dunx integrates
@@ -86,39 +84,35 @@ property works, a hand-written object included. TypeBox and ajv do not ship one,
 each took about ten lines to bridge in the benchmark harness without touching
 `@dunx/http`.
 
-## What it does not have
+## Design decisions
 
-Decisions rather than gaps.
+**TC39 decorators only.** The standard has no parameter decorators, so there is no
+`@Inject()`. `inject()` in a field initializer covers what a constructor parameter
+cannot express. No `@Injectable()` either: listing a class in `providers` is enough.
 
-**No `@Injectable()`, no `@Inject()`.** TC39 decorators have no parameter
-decorators, so `@Inject()` has nowhere to come from. `inject()` in a field
-initializer covers what a constructor parameter cannot express.
+**Module scoping replaces globals and path matching.** Each module is a scope,
+`exports` is its public surface, and `global: true` publishes one app-wide. These
+are fields on the one options object. A module's `middleware` covers the routes
+its own controllers declare. See [Modules](./04-modules.md).
 
-**No `@Global()` decorator, no `forRoutes()`.** Modules do encapsulate - each is a
-scope, `exports` is its public surface, and `global: true` publishes one app-wide -
-but each of those is a field on the one options object rather than a second
-spelling. A module's `middleware` covers the routes its own controllers declare, so
-there is no path-matching language and no ancestor layer. See
-[Modules](./04-modules.md).
+**Circular imports work.** Dependencies are recorded as a thunk and read at
+resolution, so a class declared later in the file, or across a circular import,
+resolves without `forwardRef`.
 
-**No `forwardRef`.** Dependencies are recorded as a thunk and read at resolution, so
-a class declared later in the file, or across a circular import, resolves anyway.
+**Singleton providers only.** Every provider lives for the container's lifetime.
+Per-request state is an argument. Per-request correlation is `AsyncLocalStorage`
+through `RequestContext`, which never touches the container.
 
-**No request-scoped DI.** Every provider is a singleton. Per-request state is an
-argument, and per-request correlation is `AsyncLocalStorage` through
-`RequestContext`, which never touches the container.
+**Eager resolution.** `AppFactory.create()` builds every provider and awaits every
+async factory before the server binds. A wiring mistake fails at boot, not on the
+first request that hits it. This costs boot time, measured below.
 
-**No lazy resolution.** `AppFactory.create()` builds every provider and awaits every
-async factory before the server binds, so a wiring mistake fails at boot instead of
-on the first request that hits it. It costs boot time, measured below.
-
-**No CommonJS and no Node.** ESM only, Bun only.
+**ESM only, Bun only.** No CommonJS build, no Node compatibility layer.
 
 ## The measured position
 
-`@dunx/http` sits on `Bun.serve`. The single most useful number the benchmark
-harness produces is the gap between the two, because that gap is dunx's own
-overhead and nothing else.
+`@dunx/http` sits on `Bun.serve`. The most useful number the benchmark harness
+produces is the gap between the two: that gap is dunx's own overhead.
 
 Run on an AMD Ryzen 9 5950X with 32 logical cores, Bun 1.4.0, oha 1.15.0, 64
 connections, 3 s warmup, 5 measured rounds of 5 s, dated 2026-08-22:
@@ -130,13 +124,12 @@ connections, 3 s warmup, 5 measured rounds of 5 s, dated 2026-08-22:
 | `params`    |   122,963 req/s |      115,506 |    93.9% | 119,472 (97.2%) |
 | `validate`  |    85,605 req/s |       79,596 |    93.0% |  75,330 (88.0%) |
 
-So **dunx costs 1% to 7%** against the API it dispatches through, and is level with
-Elysia. Read a ratio as plus or minus one point and anything under three points as a
-tie: two full runs of the same code disagreed by a median of 0.6 points, which is
-what the harness's measured reproducibility works out to.
+**dunx costs 1% to 7%** against the API it dispatches through, and is level with
+Elysia. Read a ratio as plus or minus one point. Anything under three points is a
+tie: two full runs of the same code disagreed by a median of 0.6 points.
 
-A figure at or above 100% would be noise, not a win: dunx dispatches through
-`Bun.serve` and cannot serve a request faster than the API it calls.
+A figure at or above 100% would be noise: dunx dispatches through `Bun.serve` and
+cannot serve a request faster than the API it calls.
 
 Startup is the clearest loss, and it is a real one:
 
@@ -150,15 +143,13 @@ Startup is the clearest loss, and it is a real one:
 | Fastify          |                                         150.8 ms |
 | NestJS (Express) |                                         273.7 ms |
 
-Both Bun figures roughly halved on Bun 1.4, from 54.8 ms and 28.7 ms, while every
-Node subject in the table stayed within 1% of its previous number. The ratio is what
-has not changed: dunx boots in about twice raw `Bun.serve`'s time, for the compiler's
-parse plus eager resolution of the whole graph.
+Both Bun figures roughly halved on Bun 1.4, from 54.8 ms and 28.7 ms. Every Node
+subject in the table stayed within 1% of its previous number. The ratio has not
+changed: dunx boots in about twice raw `Bun.serve`'s time, for the `oxc-parser`
+preload plus eager DI resolution and route discovery.
 
-Roughly twice raw `Bun.serve`, from the `oxc-parser` preload plus eager DI
-resolution and route discovery. That is the trade this architecture makes on
-purpose: paid once at boot, never per request. It is a real cost on a short-lived
-process.
+That cost is paid once at boot, never per request. It is a real cost on a
+short-lived process.
 
 Two more numbers worth having before you commit to anything:
 
@@ -183,7 +174,7 @@ API, error quality and ecosystem.
 The harness does not measure absolute capacity, concurrency beyond one process,
 anything with I/O, memory, behaviour under sustained load, TLS, HTTP/2, websockets
 or streaming. In an application that talks to Postgres, every difference in the
-table above is rounding error next to one query. That is the honest framing.
+table above is rounding error next to one query.
 
 ## When not to use dunx
 

--- a/docs/guide/02-first-steps.md
+++ b/docs/guide/02-first-steps.md
@@ -9,8 +9,8 @@ route, a service and a test. It assumes Bun 1.4 or newer and nothing else.
 bunx @dunx/create-app my-api
 ```
 
-It asks what the app should do, and nothing about that is a flag. Enter on an
-empty selection gives the minimal template:
+It asks what the app should do. Enter on an empty selection gives the minimal
+template:
 
 ```
 ✓ Features  none, the minimal template
@@ -94,18 +94,18 @@ The set:
 | `jobs`       | bullmq queues and a job processor, over `Bun.RedisClient`        | `images`                     |
 | `health`     | Liveness and readiness probes, and which parts are degraded      | `cache`, `database`, `files` |
 
-Requirements come along automatically - the list marks them `◈` while you choose,
-and the order they are imported in is construction order, so a database is built before the feature that reads it and torn
-down after it. `cache`, `websockets` and `jobs` want a Redis or Valkey; each reports
-itself degraded rather than failing the boot, so the app still starts without one.
+Requirements come along automatically. The list marks them `◈` while you choose.
+Import order is construction order, so a database is built before the feature that
+reads it and torn down after it. `cache`, `websockets` and `jobs` want a Redis or
+Valkey. Each reports itself degraded rather than failing the boot, so the app still
+starts without one.
 
 ### Where the code comes from
 
 Every feature directory is copied out of dunx's own
-[`examples/full`](https://github.com/petarzarkov/dunx/tree/main/examples/full) - the
-service CI builds, typechecks, tests and tours on every push. Starter code nobody
-runs rots, so a byte-for-byte parity test fails the moment a copy drifts from the
-example.
+[`examples/full`](https://github.com/petarzarkov/dunx/tree/main/examples/full).
+CI builds, typechecks, tests and tours that service on every push. A byte-for-byte
+parity test fails the moment a copy drifts from the example.
 
 The wiring cannot be copied. `app.module.ts`, `config.ts` and `main.ts` name every
 feature at once in the full example, so those three are **generated** for the
@@ -174,11 +174,11 @@ There are two `preload` entries because Bun's test runner reads its own. The
 top-level one covers `bun run start` and `bun src/main.ts`; the `[test]` one
 covers `bun test`. Miss the second and your app runs but your suite does not.
 
-**What breaks without it.** Not a silent `undefined`. The container compares the
-recorded dependency count against `Function.prototype.length`, which still reports
-the declared parameter count after TypeScript's parameter properties are compiled
-away. Zero recorded dependencies plus a non-zero arity can only mean the plugin
-never saw the file, so boot fails carrying the fix:
+**What breaks without it.** The container compares the recorded dependency count
+against `Function.prototype.length`, which still reports the declared parameter
+count after TypeScript's parameter properties are compiled away. Zero recorded
+dependencies plus a non-zero arity can only mean the plugin never saw the file.
+Boot fails with a clear message carrying the fix:
 
 ```
 GreetingsService declares 1 constructor parameter(s) but no dependencies were
@@ -192,11 +192,10 @@ the plugin, then retry:
   preload = ["@dunx/transform/preload"]
 ```
 
-There are no false positives here. A constructor whose parameters all have
-defaults has `length === 0` and is genuinely callable with no arguments; a class
-bound with `useValue` is never constructed; and the transform only ever writes a
-record whose length equals the parameter count, so a present record is never
-empty.
+There are no false positives. A constructor whose parameters all have defaults
+has `length === 0` and is genuinely callable with no arguments. A class bound
+with `useValue` is never constructed. The transform only writes a record whose
+length equals the parameter count, so a present record is never empty.
 
 `@dunx/core` does not register the plugin on import, for two reasons, both fatal.
 
@@ -258,10 +257,10 @@ without it `verbatimModuleSyntax` raises `TS1287` against ESM syntax.
 preload runs when you run the app. If you compile ahead of time with
 `Bun.build({ plugins: [depsPlugin] })`, it becomes build-time only and can move.
 
-`@dunx/testing` is a dev dependency and is what `src/app.test.ts` uses.
+`@dunx/testing` is a dev dependency. It is what `src/app.test.ts` uses.
 
 `dev` is `--watch`, which restarts the process on a change. `--hot` swaps modules
-in place, and a container is built once at boot, so the old providers would still
+in place, but a container is built once at boot. The old providers would still
 hold the socket the new ones are trying to bind.
 
 ### Keep every `@dunx/*` on the same version
@@ -282,10 +281,10 @@ That happens when a lockfile already has an entry satisfying your range. Adding
 rest at 0.2.0, and `@dunx/auth@0.2.5` peers on `@dunx/http@^0.2.5`.
 
 The warning is the good case. The bad one is **two copies of `@dunx/core` in one
-tree, which breaks dependency injection outright**: a token _is_ a class object, so
-two copies are two different classes, and a provider bound against one is invisible
-to a resolution against the other. The error you get says nothing is bound, from
-somewhere unrelated to the version mismatch.
+tree**, which breaks dependency injection. A token _is_ a class object, so two
+copies are two different classes. A provider bound against one is invisible to a
+resolution against the other. The error says nothing is bound, from somewhere
+unrelated to the version mismatch.
 
 So when you add a package, match the version to the ones already installed:
 
@@ -322,11 +321,11 @@ Or edit the manifest so every `@dunx/*` range reads the same, and reinstall.
 **Do not enable `experimentalDecorators` or `emitDecoratorMetadata`.** dunx uses
 TC39 standard decorators, and those flags change decorator semantics under you.
 
-`moduleResolution: nodenext` is why relative imports in the generated source carry
-a `.js` extension: `import { AppModule } from './app.module.js'`. The file on disk
-is `.ts`; the specifier is what the emitted declaration would carry, and an
-extensionless one fails to resolve for consumers on `node16` or `nodenext`. Under
-this setting it is a compile error rather than someone else's problem.
+`moduleResolution: nodenext` is why relative imports carry a `.js` extension:
+`import { AppModule } from './app.module.js'`. The file on disk is `.ts`. The
+specifier is what the emitted declaration would carry, and an extensionless one
+fails to resolve for consumers on `node16` or `nodenext`. Under this setting it
+is a compile error.
 
 `verbatimModuleSyntax` is why type-only imports must say so: `import type { Input }`.
 It is also, indirectly, a DI hazard, and [Providers](./03-providers.md) covers
@@ -353,8 +352,8 @@ Four lines of real work.
 `HttpFactory.create(AppModule)` builds the container from the root module's import
 graph, resolves every provider, awaits every async factory, runs every `onInit`,
 then discovers each controller's routes and rejects any collision. It does not
-bind a port. There is no separate `init()` step, because resolution is eager: an
-app that exists is an app that booted.
+bind a port. There is no separate `init()` step: resolution is eager, so an app
+that exists is an app that booted.
 
 `app.enableShutdownHooks()` registers `SIGTERM` and `SIGINT` handlers. Pass your
 own list to change that. On a signal, the server stops first, then every provider
@@ -420,9 +419,9 @@ A plain class. No decorator, no registration boilerplate. Listing it in a module
 `providers` is what makes it injectable.
 
 `Logger` in the constructor is the entire dependency injection story. Nothing in
-this app bound `Logger` and it still resolves: `AppFactory.create` offers a
-default binding for `Logger` and `RequestContext` after every module's, so a
-module that binds either one wins and an app that binds neither still gets one.
+this app bound `Logger` and it still resolves. `AppFactory.create` offers a
+default binding for `Logger` and `RequestContext` after every module's. A module
+that binds either one wins, and an app that binds neither still gets one.
 
 The default is `ConsoleLogger`, which writes one JSON line per entry and reaches
 for no dependency. It performs no sanitizing, masking or rotation, so swapping in

--- a/docs/guide/03-providers.md
+++ b/docs/guide/03-providers.md
@@ -11,8 +11,7 @@ export class UsersService {
 }
 ```
 
-No `@Injectable()`. No `@Inject()`. No `reflect-metadata`. This page explains how
-that works, where it stops working, and what to do at each of those edges.
+No `@Injectable()`. No `@Inject()`. No `reflect-metadata`.
 
 ## How constructor injection works
 
@@ -74,10 +73,9 @@ export class UsersRepository extends Repository {
 A subclass that _does_ declare a constructor gets its own record from the
 transform, which shadows the base's.
 
-This is the opposite of the rule `@Module` uses, and the difference is
-deliberate. Module options are read with `Object.hasOwn`, so subclassing a module
-does not silently inherit its bindings. Constructors are inherited by the language
-and dependencies follow them; module options are not.
+`@Module` uses the opposite rule. Module options are read with `Object.hasOwn`,
+so subclassing a module does not silently inherit its bindings. Constructors are
+inherited by the language and dependencies follow them. Module options are not.
 
 ## When the type cannot be recovered
 
@@ -103,12 +101,12 @@ Six cases are detected this way:
 | a class type parameter     | `class Box<T> { constructor(x: T) {} }` erases `T` |
 | a primitive or a union     | `number`, `string`, `A \| B` are not tokens        |
 
-Measured against `emitDecoratorMetadata`: given
-`constructor(db: Db, cache: Cache, n: number)` the legacy metadata table yields
-`["Db", "Object", "Number"]`. An interface degrades to `Object` and a primitive
-to `Number`, indistinguishably, so a metadata-driven container needs
-`@Inject(TOKEN)` for everything that is not a class. The transform reads the
-difference from source and names the parameter.
+For comparison, `emitDecoratorMetadata` given
+`constructor(db: Db, cache: Cache, n: number)` yields `["Db", "Object", "Number"]`.
+An interface degrades to `Object` and a primitive to `Number`, indistinguishably.
+A metadata-driven container then needs `@Inject(TOKEN)` for everything that is
+not a class. The dunx transform reads the difference from source and names the
+parameter.
 
 The fix is one of two things. If the erased type is a contract implemented
 elsewhere, make it an `abstract class`, which is a runtime value and therefore a
@@ -165,9 +163,9 @@ export class BuildInfo implements OnInit {
 ```
 
 Both mechanisms may appear in one class. Use `inject()` when there is no
-constructor parameter for the value to hang off, which in practice means a
-`Token<T>`: a token is a value rather than a type, so it cannot be written as a
-parameter type and the transform has nothing to record.
+constructor parameter for the value to hang off. In practice that means a
+`Token<T>`: a token is a value rather than a type, so it cannot be a parameter
+type and the transform has nothing to record.
 
 The window is narrow. Constructor arguments resolve _before_ the injector is
 made ambient, since argument resolution recurses back through `get()` and must

--- a/docs/guide/04-modules.md
+++ b/docs/guide/04-modules.md
@@ -1,8 +1,7 @@
 # Modules
 
 A module is a **scope**: a named set of registrations that are private to it, plus a
-list of tokens it makes visible to whoever imports it. That sentence is the whole
-model.
+list of tokens it makes visible to whoever imports it.
 
 ```ts
 import { Module } from '@dunx/core';
@@ -16,15 +15,15 @@ import { Module } from '@dunx/core';
 export class UsersModule {}
 ```
 
-`UsersRepository` is not on the `exports` line, so nothing outside `UsersModule` can
-resolve it. That is the boundary, and everything else on this page follows from it.
+`UsersRepository` is not on the `exports` line, so nothing outside `UsersModule`
+can resolve it.
 
 ## `@Module` is a marker
 
 The decorator writes its options onto the class as a
 `Symbol.for('dunx.module')` property and returns the class. The class is never
 instantiated. It has no constructor to inject into, no lifecycle hooks, and no
-runtime behaviour at all. It exists to give a module a name for error messages.
+runtime behaviour. It exists to give a module a name for error messages.
 
 A class handed to `AppFactory.create` or to `imports` without the decorator is a
 boot error:

--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -40,11 +40,10 @@ last one answers 201.
 ## Bun does the routing
 
 `Bun.serve({ routes })` handles path parameters, per-method dispatch, static
-`Response` values and 404-on-method-miss in native Zig. dunx does not ship a
-router, and writing one is a standing prohibition rather than a backlog item.
-`@dunx/http`'s job is to build the `routes` object at boot and hand it to Bun.
+`Response` values and 404-on-method-miss in native Zig. dunx ships no router.
+`@dunx/http` builds the `routes` object at boot and hands it to Bun.
 
-Four consequences you will actually notice.
+Four consequences worth knowing about.
 
 **An unmatched method returns 404 where most frameworks return 405.** Bun answers a
 method miss natively only when nothing else can claim the request. dunx always
@@ -63,9 +62,9 @@ The status is 404 either way; what differs is that your middleware sees it, so
 request logging, throttling and CORS all get a look at a method miss.
 
 **Paths are matched exactly, so a trailing slash is a different path.** `GET /t`
-is a 200 and `GET /t/` is a 404, and the same goes for `/t/sub/` and `POST /t/`.
-Most frameworks normalise this, so it is the common break in a ported client, and
-it breaks as a 404 that reads like a missing route.
+is a 200 and `GET /t/` is a 404. The same goes for `/t/sub/` and `POST /t/`.
+Most frameworks normalise this, so it is the common break in a ported client. It
+shows up as a 404 that reads like a missing route.
 
 The declared side is already normalised: `@Get('/')` inside `@Controller('t')` is
 `/t`, never `/t/`, so both spellings are never live at once. Route discovery

--- a/docs/guide/06-validation.md
+++ b/docs/guide/06-validation.md
@@ -1,6 +1,6 @@
 # Validation
 
-A route declares the shape of what it accepts on the decorator itself, and the
+A route declares the shape of what it accepts on the decorator itself. The
 framework parses, validates and types the request before the handler runs.
 
 ```ts
@@ -27,17 +27,18 @@ export class UsersController {
 }
 ```
 
-No `await req.json()`, no `Response.json()`, no status: the body arrives parsed
-and validated, `input.body.name` is a `string`, and a POST answers 201. A request
-that fails the schema never reaches the handler.
+The body arrives parsed and validated: `input.body.name` is already a `string`,
+and a POST answers 201, all without writing `await req.json()`, `Response.json()`
+or a status code by hand. A request that fails the schema never reaches the
+handler.
 
 ## Standard Schema is the contract
 
-`@dunx/http` has **no validator dependency**. Its `peerDependencies` are
-`@dunx/core` and (optionally) `@types/bun`, and the list ends there. What a
-route's `body`, `query` and `params` accept is anything implementing
+What a route's `body`, `query` and `params` accept is anything implementing
 [Standard Schema v1](https://standardschema.dev): an object carrying a
-`~standard` property.
+`~standard` property. `@dunx/http` needs no validator dependency to enforce
+that. Its `peerDependencies` are `@dunx/core` and (optionally) `@types/bun`,
+and the list ends there.
 
 ```ts
 export interface StandardSchemaV1<In = unknown, Out = In> {
@@ -52,10 +53,11 @@ export interface StandardSchemaV1<In = unknown, Out = In> {
 }
 ```
 
-That interface is **restated** by `@dunx/http` rather than imported. The spec is an interface and nothing else: `@standard-schema/spec` ships
-declarations with no runtime, so restating it costs one file and adds no dependency
-to the package. zod 4, Valibot and ArkType already satisfy the shape, so all
-three drop straight into a route's options with nothing adapting anything:
+That interface is restated in `@dunx/http` rather than imported. The spec is
+only an interface: `@standard-schema/spec` ships type declarations with no
+runtime code, so restating it costs one file and adds no dependency to the
+package. zod 4, Valibot and ArkType already satisfy the shape, so all three
+drop straight into a route's options with no adapter needed:
 
 ```ts
 import { z } from 'zod';
@@ -72,8 +74,8 @@ does not know or care which library produced the object.
 
 ### Sync and async validators
 
-`~standard.validate` is _permitted_ to return a promise. zod, Valibot and ArkType
-never do, and the input reader is built around that: it checks
+`~standard.validate` is permitted to return a promise, though zod, Valibot and
+ArkType never do. The input reader is built around that difference: it checks
 `result instanceof Promise` and only allocates a promise link when it gets one.
 A validator that really is asynchronous still works and is awaited correctly; it
 just costs an async frame that the synchronous ones do not.
@@ -250,8 +252,8 @@ value, and only the validator knows that.
 
 ## `Input<typeof schema>` and why it must be written out
 
-The annotation on the handler parameter is not optional, and it is not a wart the
-framework can remove.
+The annotation on the handler parameter carries the type the schema infers. It is
+not optional, and not a wart the framework could remove if it tried.
 
 A TC39 standard method decorator is
 `(value: V, context: ClassMethodDecoratorContext) => V | void`. It receives the
@@ -347,7 +349,7 @@ Replace all of it by passing `onError` to `HttpFactory.create`; see
 
 ## Vendor-specific features sit behind a vendor check
 
-Standard Schema **validates**, and says nothing about describing, serialising or
+Standard Schema validates. It says nothing about describing, serialising or
 converting a schema, so there is no vendor-neutral way to turn one into JSON
 Schema. `@dunx/openapi` needs exactly that, and resolves it with the one
 piece of vendor information the interface does carry:
@@ -381,7 +383,8 @@ loudly.
 
 ## What validation costs
 
-This repo publishes its losses, and here the loss is not where most people expect.
+This repo measures its own losses rather than guessing at them. Here, the loss
+sits somewhere most people would not expect.
 
 Four raw `Bun.serve` routes, each doing exactly one thing more than the one above
 it, all answering the same bytes, all against a 69 byte three-field payload:

--- a/docs/guide/07-lifecycle.md
+++ b/docs/guide/07-lifecycle.md
@@ -26,9 +26,9 @@ per scope. [Modules](./04-modules.md) covers when that is what you want.
 
 ### Per-request state
 
-Request-scoped DI was measured and turned down: it is a container's largest
-source of per-request cost and complexity. Two replacements cover what it was
-used for.
+Request-scoped DI was measured and turned down. It is a container's largest
+source of per-request cost and complexity, and two replacements cover what it
+was used for.
 
 **Correlation data** goes through `RequestContext`, an `AsyncLocalStorage` that
 never touches the container:
@@ -159,18 +159,19 @@ export class Readiness implements OnBeforeShutdown {
 }
 ```
 
-`onShutdown` is too late for anything that has to be observable from outside.
-`@dunx/http` stops the server before tearing providers down, so a hook that flips a
-readiness probe there answers on a closed port: a load balancer is still routing when
-the socket goes away.
+`onShutdown` runs too late for anything that has to be observable from outside.
+`@dunx/http` stops the server before tearing providers down. A readiness probe
+flipped inside `onShutdown` would answer on an already-closed port, while a load
+balancer is still routing traffic to it.
 
 So `app.drain()` runs every `onBeforeShutdown` first, then the port closes, then
 `onShutdown` tears down. `shutdown()` calls the drain itself, which is what makes a
 process with no server drain at all.
 
 Every `onBeforeShutdown` runs **concurrently**, unlike `onShutdown`. These are
-independent waits and the phase should cost the slowest rather than their sum, where
-teardown follows dependencies and has to be sequential.
+independent waits, so the phase costs as much as the slowest one rather than
+their sum. Teardown, in contrast, follows dependencies and has to run
+sequentially.
 
 `@dunx/http`'s `HealthModule` is built on this, and its `drainDelayMs` is the window
 above. A queue consumer that must stop accepting jobs before its database closes
@@ -189,9 +190,9 @@ app.enableShutdownHooks(['SIGTERM'], { exitAfterMs: false });
 
 **This ends the process.** After the drain completes, an `unref()`d timer gives
 the runtime 1000 ms to exit on its own, then calls `process.exit`. A process
-with nothing pending exits in about 1 ms and the timer never fires; it fires
-only when a handle outside the container is still holding the loop open, and it
-logs a warning naming that case before exiting.
+with nothing pending exits in about 1 ms and the timer never fires. It fires
+only when a handle outside the container is still holding the loop open, and
+when that happens it logs a warning naming the case before exiting.
 
 Pass `exitAfterMs: false` when the app does not own its process, and in any test
 that fires a signal at its own runner. A programmatic `app.shutdown()` never
@@ -199,9 +200,9 @@ exits the process at any setting.
 
 ## Circular dependencies
 
-There is no `forwardRef`. `@dunx/transform` records constructor dependencies as
-a **thunk** evaluated at resolution time, so a class declared later in the file,
-or reached across a circular import, resolves normally.
+`@dunx/transform` records constructor dependencies as a **thunk** evaluated at
+resolution time, so a class declared later in the file, or reached across a
+circular import, resolves normally. There is no `forwardRef` to reach for.
 
 A genuine cycle throws `CircularDependencyError` at boot, carrying the full path:
 
@@ -239,7 +240,9 @@ it.
 
 ## Overrides in tests
 
-`createTestApp` replaces a binding **in place**, in every scope that holds one:
+A test wants the same container with one binding swapped, not a second boot
+path built to route around it. `createTestApp` replaces a binding **in place**,
+in every scope that holds one:
 
 ```ts
 const app = await createTestApp({
@@ -251,25 +254,28 @@ const app = await createTestApp({
 The discarded provider is never constructed, so an async `useFactory` that would
 have opened the real database does not run.
 
-An override naming a non-class token nothing binds throws. A silent no-op there
-produces a test asserting against the provider it believed it had swapped. A class
-token nobody bound is accepted instead, and bound lazily, because a class self-binds
-on demand anyway.
+Overriding a token that nothing binds throws, unless the token is a class. A
+silent no-op there would produce a test asserting against a provider it
+believed it had swapped. A class token nobody bound is accepted instead and
+bound lazily, because a class self-binds on demand anyway.
 
 Full harness, including `createTestServer` and `RecordingLogger`:
 [Testing](./11-testing.md).
 
 ## Reaching the container
 
+The container itself is reachable too, for wiring and debugging code that sits
+outside constructor injection:
+
 ```ts
 app.get(UsersService); // root scope view, then any single declarer
 app.get(UsersService, OrdersModule); // prefers OrdersModule's view
 ```
 
-`app.get` is more permissive than constructor injection, being a wiring and
-debugging call. With a module argument it prefers that module's view, then falls back
-to the root scope's, then to the single module that declares the token, and finally
-self-binds a class into the module named. Two scopes binding the token differently is
-an error rather than a guess, and a module that is not in the graph at all throws.
+`app.get` is more permissive than constructor injection. With a module argument
+it prefers that module's view. Failing that, it falls back to the root scope's
+view, then to the single module that declares the token, and finally self-binds
+a class into the module named. Two scopes binding the token differently is an
+error rather than a guess, and a module that is not in the graph at all throws.
 
 `AppRef` is the injectable form, and is dunx's `ModuleRef`.

--- a/docs/guide/08-middleware-and-guards.md
+++ b/docs/guide/08-middleware-and-guards.md
@@ -73,9 +73,9 @@ could not take effect.
 belongs to one feature goes on that feature's module instead - see
 [Module middleware](#module-middleware) below.
 
-Both resolve as your root module sees them, which for a middleware class means
-"the single module that declares it". Listing a guard here does not oblige your
-root to import or re-export the feature module that provides it.
+Both resolve the way your root module sees them: for a middleware class, that
+means the single module that declares it. Listing a guard here does not oblige
+your root to import or re-export the feature module that provides it.
 
 ## `next()` is a function you call
 
@@ -179,9 +179,9 @@ export const compose = (
 ```
 
 One `reduceRight` per route at `listen()`, after which a request is a call into a
-closure. No array iteration, no metadata lookup, no container access on the
-request path, so a guard costs a `Map` lookup where Nest's `Reflector` costs a
-per-request reflection call.
+closure. A guard costs a `Map` lookup where Nest's `Reflector` costs a
+per-request reflection call, because there is no array iteration, no metadata
+lookup and no container access left on the request path.
 
 A route with **no middleware and no CORS** skips even that, taking a direct
 dispatch path that allocates no async frame unless something genuinely has to be
@@ -193,8 +193,9 @@ middleware. Install the middleware you need.
 
 ## `RouteContext`
 
-The second argument tells a middleware which route it is running for and what that
-route's decorators declared:
+Every middleware in that chain runs against one fixed route. The second
+argument tells it which route that is, and what that route's decorators
+declared:
 
 ```ts
 export interface RouteContext {
@@ -261,8 +262,8 @@ export class RolesGuard implements Middleware {
 }
 ```
 
-Refusing a request is `throw`. Allowing it is `return next()`. Against a
-boolean-returning guard that buys two things: the guard says _why_ in the same
+Refusing a request is `throw`. Allowing it is `return next()`. Compared to a
+boolean-returning guard, this buys two things: the guard says _why_ in the same
 statement that rejects, and the rejection travels the ordinary error path, so the
 mapper, the logger and CORS all treat it like any other failure. A `403` from a
 guard is `{"error":"Requires one of: admin","status":403}`.
@@ -367,7 +368,7 @@ export class ReportsModule {}
 for these routes, built from providers only these routes can see - is the reason
 module scoping exists.
 
-Three things module middleware does not have:
+Module middleware differs from Nest's `configure(consumer)` in three ways:
 
 **No `forRoutes()`.** Nest needs a path-matching mini-language because
 `configure(consumer)` registers middleware against paths. A dunx module already owns
@@ -389,7 +390,8 @@ A guard that genuinely applies everywhere stays global. `@dunx/auth`'s
 
 ## The error mapper
 
-One function, for the whole app:
+A guard's `throw` needs somewhere to land as a response. The error mapper is
+that place: one function, for the whole app:
 
 ```ts
 export type ErrorMapper = (error: unknown, req: Request) => Response;
@@ -495,10 +497,10 @@ response.
 
 ### `ErrorFilter`, when the mapper needs dependencies
 
-A mapper is a function, so it cannot inject - and the interesting ones need the
-app's config to decide how much of an error to reveal, or its `Logger` to record the
+A mapper is a function, so it cannot inject. The interesting ones need the app's
+config to decide how much of an error to reveal, or its `Logger` to record the
 ones that became a 500. dunx's own default proves it: `errorMapper(logger)` is
-curried because currying was the only way to hand a function a dependency.
+curried, because currying was the only way to hand a function a dependency.
 
 `onError` also takes a **class**, resolved from the container like any middleware:
 
@@ -536,8 +538,8 @@ structural, so any class with a matching `catch` is accepted. The method is name
 
 ### Scoping one, without a second concept
 
-There is no `@Catch`, no per-controller filter and no per-route filter, because
-middleware already is one:
+Middleware already is a scoped filter, so there is no separate `@Catch`, no
+per-controller filter and no per-route filter:
 
 ```ts
 export class ReportErrors implements Middleware {

--- a/docs/guide/09-websockets.md
+++ b/docs/guide/09-websockets.md
@@ -118,8 +118,8 @@ opened(socket: Socket<{ nickname: string }>): void {
 ```
 
 Returning a `Response` refuses the upgrade, and it is the only place a connection
-can be refused. There is no `@UseGuards` for a gateway: the request has not become
-a socket yet, so the thing to run is a plain function call in `@OnUpgrade`.
+can be refused. A gateway has no `@UseGuards`: the request has not become a
+socket yet, so the thing to run is a plain function call inside `@OnUpgrade`.
 
 ## `Socket`
 
@@ -279,9 +279,9 @@ The return types are `unknown` because the implementations disagree: Bun's
 in-memory bus resolves nothing at all. A returned promise is awaited by `subscribe` and watched for rejection by
 `publish`; anything else is taken as having succeeded.
 
-`close?` is optional, and omitting it is how a relay says the connections are not
-its to close. A relay that is the application's own shared `RedisConnection` must
-leave that to the container.
+`close?` is optional. Omitting it is how a relay says it does not own the
+connections and should not close them: a relay built on the application's own
+shared `RedisConnection` must leave that to the container.
 
 ### The batteries-included one
 
@@ -350,15 +350,15 @@ WsRelayModule.forPostgresAsync({
 
 The factory changes with the method: `PostgresRelayOptions` is `url` and `max`, so
 Redis-only settings like `connectionTimeout` do not carry across. The injection site
-does not change, because both relays are bound under `WsRelay`. Which method you call is the choice: a binding is fixed when the
-module graph is built, so it cannot be read from config the container resolves
-later.
+does not change, because both relays are bound under `WsRelay`. Which method you
+call has to be decided up front, though: a binding is fixed once the module graph
+is built, so it cannot be read from config the container resolves later.
 
-Two differences from Redis are worth knowing before you switch. **A frame over
-about 7.9 KB does not cross**, because Postgres caps a `NOTIFY` payload at 7999
-bytes and the envelope adds a topic and an origin id to it; `PubSub` logs one
-warning and fan-out stays local for that message. And `LISTEN`/`NOTIFY` is Postgres
-only, so `Bun.SQL`'s SQLite and MySQL adapters reject it.
+Switching from Redis changes two things. **A frame over about 7.9 KB does not
+cross**, because Postgres caps a `NOTIFY` payload at 7999 bytes and the envelope
+adds a topic and an origin id to it; `PubSub` logs one warning and fan-out stays
+local for that message. And `LISTEN`/`NOTIFY` is Postgres only, so `Bun.SQL`'s
+SQLite and MySQL adapters reject it.
 
 `RedisRelay` is built on `Bun.RedisClient`, a Bun global, so the relay itself costs
 `@dunx/http` **no new dependency**. The package's one runtime dependency is
@@ -510,8 +510,8 @@ with gateways force-stops:
 await this.#server?.stop(this.#websocket !== undefined);
 ```
 
-Those clients observe close code **1006**. There is no way around it that does not
-hang, and an app that hangs on `SIGTERM` gets `SIGKILL` anyway.
+Those clients observe close code **1006**. There is no way around it without
+hanging, and an app that hangs on `SIGTERM` gets `SIGKILL` anyway.
 
 `PubSub.close()` runs **before** the container tears down. A relay this app owns
 holds two Redis sockets and, with `maxRetries: 0`, nothing else would ever close

--- a/docs/guide/10-openapi.md
+++ b/docs/guide/10-openapi.md
@@ -79,12 +79,13 @@ is actually served. From each route it reads:
 - `meta` and `classMeta` - whatever `@Public`, `@Roles` and `@ApiDoc` wrote.
 - the path and the method, from the verb decorator.
 
-It constructs nothing. `discoverRoutes` walks an instance's prototype chain
-looking for marked methods, and `Object.create(Controller.prototype)` is that
-chain with nothing behind it: `instance.constructor` still resolves to the class,
-every method is still reachable, and no constructor, or dependency of one, has to
-exist. So a document can be written to a file from a script with no container and
-no server:
+A document can be written to a file from a script with no container and no
+server, because `describeRoutes` never constructs a controller.
+
+`discoverRoutes` walks an instance's prototype chain looking for marked
+methods, and `Object.create(Controller.prototype)` is that chain with nothing
+behind it: `instance.constructor` still resolves to the class, every method is
+still reachable, and no constructor, or dependency of one, has to exist:
 
 ```ts
 import { describeRoutes, generateDocument } from '@dunx/openapi';
@@ -151,10 +152,10 @@ export const oneUser = {
 } as const satisfies RouteSchemas;
 ```
 
-One contract for both directions, so a named response schema hoists into
+One contract covers both directions: a named response schema hoists into
 `components/schemas` and the operation `$ref`s it exactly as a request body does.
-That is what the document needs for client codegen, and what gives
-`.meta({ id })` on a response-only schema its meaning.
+That gives `.meta({ id })` on a response-only schema its meaning, and gives the
+document what it needs for client codegen.
 
 Two consequences of it being the same contract rather than a second channel:
 
@@ -177,7 +178,7 @@ declared success status keeps its own description and gains the `content`.
 A hoisted schema gets a `title` equal to its `components/schemas` key, unless it
 declared one of its own.
 
-That is what an explorer labels a **nested** schema by. Swagger UI renders a model as
+An explorer labels a **nested** schema by that title. Swagger UI renders a model as
 `title || displayName || name`: a `$ref` at the root of a response supplies those
 fallbacks from the ref, but the same `$ref` inside `items` supplies neither, so
 `array<User>` read as `array<object>` before the title was there.
@@ -246,7 +247,7 @@ It works at class scope and at method scope, and the two **compose per field**.
 The operation above is tagged and described from the class, then summarised and
 deprecated from the method; the method wins only on a field they both set.
 
-Class tags plus per-method summaries therefore needs no repetition, and dropping
+Class tags plus per-method summaries therefore need no repetition, and dropping
 the class `tags` from a method does not silently fall back to the class-name
 default.
 
@@ -263,8 +264,9 @@ the merged `meta`.
 
 ## Security comes from the guards' own metadata
 
-There is no `@ApiBearerAuth`. The document reads the same `@Public()` and
-`@Roles()` that the guards read at runtime, so the two cannot drift:
+The document reads the same `@Public()` and `@Roles()` that the guards read at
+runtime, so the two cannot drift. There is no separate `@ApiBearerAuth`
+decorator to keep in sync:
 
 | Route declares     | Operation gets                                                  |
 | ------------------ | --------------------------------------------------------------- |

--- a/docs/guide/11-testing.md
+++ b/docs/guide/11-testing.md
@@ -1,8 +1,8 @@
 # Testing
 
 `@dunx/testing` is two functions and a logger. It builds the container your
-application would have, with the bindings you name replaced, and optionally binds
-a real `Bun.serve` in front of it.
+application would have, with the bindings you name replaced, and it can put a
+real `Bun.serve` in front of that container too.
 
 ```ts
 import {
@@ -52,30 +52,31 @@ describe('createTestApp', () => {
 });
 ```
 
-`modules` takes one module ref or several; they become the `imports` of one
+`modules` takes one module ref or several. They become the `imports` of one
 synthetic root, so no fixture module has to be written by hand. What comes back is
 a plain `App`: `get`, `shutdown`, `closed`, `enableShutdownHooks`. Providers are
-resolved eagerly and `onInit` has already run by the time the promise settles,
+resolved eagerly, and `onInit` has already run by the time the promise settles,
 exactly as in production.
 
-The fake above is a class the test wrote. There is no mocking framework, no
-interface, and no `jest.mock`. A subclass with an `override` is enough, and it
-typechecks against the real thing, which a hand-built object literal would not.
+The fake above is a class the test wrote: a subclass with an `override`, nothing
+more. It typechecks against the real thing. A hand-built object literal would
+not, and there is no mocking framework, interface, or `jest.mock` involved either.
 
 ### Overrides replace in place
 
-This is the part worth understanding, because it is what makes the harness safe.
+`AppFactory.create` builds the scope graph it always would, then substitutes by
+token **in every scope that binds it**, before anything resolves. That reach is
+what makes the harness safe to use: a test that stubs `Logger` never has to know
+how many modules bind it.
 
 An override is **not** an extra module appended at the end that wins. A module
-appended at the end would be its own scope, invisible to everything already wired,
-so it would win nothing. Instead, `AppFactory.create` builds the scope graph it
-always does and substitutes by token **in every scope that binds it**, before
-anything resolves.
+appended at the end would be its own scope, invisible to everything already
+wired, so it would win nothing.
 
-Every scope, so a test that stubs `Logger` never has to know how many modules
-bind it; making it name a scope would push container topology into every suite.
-Where two scopes genuinely bind a token differently and only one is meant,
-resolve through the module that matters instead of overriding.
+Naming a scope for the override would push container topology into every suite,
+so the substitution runs across every scope instead. Where two scopes genuinely
+bind a token differently and only one is meant, resolve through the module that
+matters rather than overriding.
 
 The consequence that matters:
 
@@ -106,16 +107,17 @@ test('the discarded provider is never constructed', async () => {
 });
 ```
 
-Because the replacement happens before anything resolves, the discarded provider's
-constructor never runs, its `useFactory` never runs, and its `onInit` never fires.
-That is the guarantee a hand-rolled fixture usually misses: with an "append and
-win" model, the real database provider is still in the list, still gets
-instantiated, and still opens a connection that nothing under test uses.
+Because the replacement happens before anything resolves, the discarded
+provider's constructor never runs. Its `useFactory` never runs, and its
+`onInit` never fires. That is the guarantee a hand-rolled fixture usually
+misses: with an "append and win" model, the real database provider is still in
+the list, still gets instantiated, and still opens a connection that nothing
+under test uses.
 
-The seam lives in `@dunx/core` as `AppFactory.create(root, { overrides })` rather
-than in the testing package, and it is not a test-shaped API. It says "compose
-this graph with these bindings replaced", which is also how a deployment variant
-would be expressed. `HttpOptions extends AppOptions`, so
+The seam lives in `@dunx/core`, as `AppFactory.create(root, { overrides })`,
+rather than in the testing package. It is not a test-shaped API: it says
+"compose this graph with these bindings replaced", the same statement a
+deployment variant would make. `HttpOptions extends AppOptions`, so
 `HttpFactory.create` inherits it without a second mechanism.
 
 ### An unmatched override is an error - unless it is a class
@@ -143,20 +145,20 @@ The full message, and the second clause is the important one:
 > cannot add one, because a token nobody bound is a token nothing under test
 > resolves.
 
-A silent no-op here is the worst possible failure, because it leaves a suite
-asserting against the real provider it believed it had swapped, and it passes. The
-check names **every** unmatched token rather than the first, so a renamed token does
-not turn into three rounds of the same error.
+A silent no-op here is the worst possible failure. It leaves a suite asserting
+against the real provider it believed it had swapped, and the suite passes. The
+check names **every** unmatched token rather than the first, so a renamed token
+does not turn into three rounds of the same error.
 
-**A class is deliberately exempt, and that is a real gap in the safety net.** A class
-self-binds: it needs no declaration to be resolvable, so an override for one is
-replacing the binding that _would_ have happened on demand, and registering it
-eagerly would construct a stub for a collaborator the graph under test never reaches.
-That is why `Injector.registerLazy` exists.
+**A class is exempt from that check, and that is a real gap in the safety net.**
+A class self-binds: it needs no declaration to be resolvable. An override for one
+replaces the binding that _would_ have happened on demand, so registering it
+eagerly would construct a stub for a collaborator the graph under test never
+reaches. `Injector.registerLazy` exists to avoid exactly that.
 
-The cost is that a **typo'd class override is accepted in silence** - there is no
-binding for it to fail to match, and nothing under test asks for it, so it simply
-never fires. Measured:
+The cost is that a **typo'd class override is accepted in silence**: there is no
+binding for it to fail to match, and nothing under test asks for it, so it
+simply never fires. Measured:
 
 ```
 override a declared class      -> resolves, replacement used
@@ -265,8 +267,8 @@ decide what the application _is_: `middleware` holds the global guards, `onError
 the error mapper.
 
 A suite that forgets them gets a server with no global guards and the default
-mapper. It boots fine and answers 200 where production answers 401, which is a
-fixture quietly testing a different application.
+mapper. It boots fine and answers 200 where production answers 401. That fixture
+is quietly testing a different application.
 
 So define the options once, export them, and give the same function to `main.ts`
 and to every suite:
@@ -386,10 +388,10 @@ const server = await createTestServer({
 ## Testing a guard through the real request path
 
 A guard is worth testing through the server rather than by calling
-`guard.handle()` directly, because what it reads is route metadata that only
-exists once routes have been discovered. `ctx.get(PUBLIC)` has no meaning outside
-a built route table, and a hand-constructed `RouteContext` would be testing your
-construction of it.
+`guard.handle()` directly. What it reads is route metadata that only exists once
+routes have been discovered: `ctx.get(PUBLIC)` has no meaning outside a built
+route table, and a hand-constructed `RouteContext` would be testing your
+construction of it rather than the guard.
 
 ```ts
 class KnownKeys extends ApiKeys {
@@ -457,14 +459,10 @@ const url = await app.listen(0);
 `testClient(url)` is exported too, so the same `request`/`json` pair can be
 pointed at an app booted any other way.
 
-## There is no `providers` option
+## `{ modules, overrides }`, and nothing more
 
-`{ modules, overrides }` is the documented shape and stays that shape.
-
-A `providers` list would let the harness assemble graphs that do not exist in the
-application, which is how a suite ends up asserting against a container the
-production app never builds. A fixture class that needs binding goes in a two-line
-`@Module`, where it would live if it were real:
+A fixture class that needs binding goes in a two-line `@Module`, exactly where
+it would live if it were real:
 
 ```ts
 @Module({
@@ -474,6 +472,11 @@ class FixedTime {}
 
 const app = await createTestApp({ modules: [BillingModule, FixedTime] });
 ```
+
+That two-line module is also why the harness has no `providers` option: the
+documented shape stays `{ modules, overrides }`. A `providers` list would let it
+assemble graphs that do not exist in the application, and a suite would end up
+asserting against a container the production app never builds.
 
 ## Sharp edges
 

--- a/docs/guide/12-configuration.md
+++ b/docs/guide/12-configuration.md
@@ -164,10 +164,10 @@ export class Notifier {
   or `null` at run time. It throws `ConfigError` naming the whole path.
 - `values` is the whole validated object, for destructuring or passing on.
 
-Paths stop at three segments, and `config.values.a.b.c.d` is what reaches past
-them. Each depth is a separate overload rather than one recursive type: a
-conditional type over `T` anywhere on this class makes its variance unmeasurable,
-and `app.get(ConfigService)` then stops compiling. A top-level key that itself
+Paths stop at three segments. `config.values.a.b.c.d` is what reaches past them.
+Each depth is a separate overload rather than one recursive type: a conditional
+type over `T` anywhere on this class makes its variance unmeasurable, and
+`app.get(ConfigService)` then stops compiling. A top-level key that itself
 contains a dot is read whole, so it keeps winning over a path that spells it.
 
 ## Why `as` exists
@@ -185,9 +185,9 @@ bare type name of a constructor parameter and discards the type argument, so
 `constructor(private readonly config: ConfigService<AppConfig>)` resolves the
 `ConfigService` token while the annotation keeps the precise type.
 
-It breaks in a **factory's `inject` array**, which is why `as` is on the API at
-all. `inject: [ConfigService]` resolves to
-`ConfigService<Record<string, unknown>>`, the token being a plain runtime value
+It breaks in a **factory's `inject` array**, and `as` exists on the API because
+of that gap. `inject: [ConfigService]` resolves to
+`ConfigService<Record<string, unknown>>`: the token is a plain runtime value,
 carrying no type argument to recover.
 
 A factory annotating its parameter as `ConfigService<AppConfig>` is then
@@ -212,9 +212,9 @@ LoggerModule.forRootAsync({
 });
 ```
 
-A subclass serves as both a precise token and a usable annotation, which is what
-the factory case needs. Every `forRootAsync` in dunx exists so options can be read
-off config, so `as` comes up almost immediately.
+A subclass serves as both a precise token and a usable annotation - exactly what
+the factory case needs. Every `forRootAsync` in dunx exists so options can be
+read off config, so `as` comes up almost immediately.
 
 `ConfigService` stays bound to the same instance when `as` is used, so either name
 injects. That matters for library code, which only knows the base contract.
@@ -251,18 +251,18 @@ The raw source is bound too, under the `ConfigInput` token, but it is **not**
 exported: `validate` is what reads it, and everything downstream reads the shaped
 object instead.
 
-## Two things that are absent
+## No `isGlobal`, no `forRootAsync`
 
-**No `isGlobal`.** `ConfigModule.forRoot` is already `global: true`, and exports
-`ConfigService` plus whatever `as` names. Configuration is the one thing every
-module reads, so a flag to turn that on would only ever be turned on. `ConfigInput`
-stays private: it is the raw environment, and nothing outside the module should read
+`ConfigModule.forRoot` is already `global: true`, and exports `ConfigService`
+plus whatever `as` names. Configuration is the one thing every module reads, so
+a flag to turn that on would only ever be turned on. `ConfigInput` stays
+private: it is the raw environment, and nothing outside the module should read
 it.
 
-**No `forRootAsync`.** Every other module has one; `ConfigModule` needs none.
-`validate` may already return a promise, and the container settles every factory
-before the first constructor runs, so an async validation has finished by the
-time anything can read it.
+Every other module offers `forRootAsync`; `ConfigModule` needs none. `validate`
+may already return a promise, and the container settles every factory before the
+first constructor runs, so an async validation has finished by the time anything
+can read it.
 
 `forRootAsync` exists elsewhere to let a factory **inject**, the one thing a
 zero-argument function cannot do. `validate` runs before everything and has

--- a/docs/guide/13-logging.md
+++ b/docs/guide/13-logging.md
@@ -1,9 +1,8 @@
 # Logging
 
 dunx logs every HTTP request by default, in an app that imported no logging
-module at all, and it does that without `@dunx/core` taking a single dependency.
-This page explains how, what it costs, and what you get by swapping the default
-out.
+module at all, and it does that without `@dunx/core` taking a single
+dependency.
 
 ## The contract lives in core
 
@@ -22,10 +21,10 @@ export abstract class Logger {
 }
 ```
 
-An abstract class rather than an `interface`, because `@dunx/transform` records
-constructor parameter **types**, and an interface has no runtime value to record.
-An interface here would be a boot error at every injection site. That is the same
-trick `RequestContext`, `Storage`, `DbOptions` and `Auth` all use.
+An abstract class rather than an `interface`: `@dunx/transform` records
+constructor parameter **types**, and an interface has no runtime value to
+record. An interface here would be a boot error at every injection site. That is
+the same trick `RequestContext`, `Storage`, `DbOptions` and `Auth` all use.
 
 Inject it like anything else:
 
@@ -117,14 +116,14 @@ That missing list is what `@dunx/infra/logger` buys.
 
 `ConsoleLogger` **batches `info` and below into one write per event-loop turn.**
 
-A `console.log` per entry is a `write(2)` per entry, and measured, that was the
+A `console.log` per entry is a `write(2)` per entry. Measured, that was the
 largest single component of request logging: **1.84 µs**, more than the
-`JSON.stringify` that produced the line. Concatenating into one string and writing it once per
-event-loop turn costs **0.27 µs**.
+`JSON.stringify` that produced the line. Concatenating into one string and
+writing it once per event-loop turn costs **0.27 µs**.
 
-The trade is real and worth stating plainly: **a line still sitting in the buffer
-is lost if the process dies without unwinding** - a `SIGKILL`, an OOM kill, a
-segfault - which is exactly when the log matters most.
+The trade matters: **a line still sitting in the buffer is lost if the process
+dies without unwinding** - a `SIGKILL`, an OOM kill, a segfault - and a crash is
+when the log is needed most.
 
 Three things bound it:
 
@@ -318,7 +317,7 @@ worse are never sampled, and every discard is announced in the stream rather tha
 being silent.
 
 `logger.stats()` on the `BackingLogger` token reports what each transport is
-holding and what it has dropped, which is what an alert on "we are losing logs"
+holding and what it has dropped - the numbers an alert on "we are losing logs"
 reads.
 
 ### Output formats
@@ -365,11 +364,11 @@ final path and every gateway with the messages it claims:
 }
 ```
 
-This is the answer to "is my route registered", and a service that logs nothing at
-boot cannot answer it from production. Nest emits a line per controller and a line
-per route to say the same thing; one structured entry is the same content in the
-shape a collector wants, and it is what `WorkerFactory` already does for the
-consuming side with `Consuming N job(s) on M queue(s)`.
+This is the answer to "is my route registered"; a service that logs nothing at
+boot cannot answer it from production. Nest emits a line per controller and a
+line per route to say the same thing. One structured entry carries the same
+content in the shape a collector wants, and it is what `WorkerFactory` already
+does for the consuming side, with `Consuming N job(s) on M queue(s)`.
 
 It is at `listen()` rather than `create()` because `setGlobalPrefix` runs in between,
 and a table listing unprefixed paths would name routes that do not exist.
@@ -388,10 +387,10 @@ what an import already exports to it, or imports one token from two modules that
 disagree, is legal and warned.
 
 They used to sit on `app.warnings` and be logged by nobody, on the reasoning that
-core had no logger. It has one, `Logger` is always bound, and the reference app
-never read the property, so a shadowed binding would have been silent in the app
-most likely to hit one. The list is still public for an app that would rather
-fail boot on it.
+core had no logger. It has one now: `Logger` is always bound, and the reference
+app never read the property, so a shadowed binding would have been silent in the
+app most likely to hit one. The list is still public for an app that would
+rather fail boot on it.
 
 ## Request logging
 
@@ -428,11 +427,12 @@ The entry carries the request and its response together:
 }
 ```
 
-A framework whose middleware cannot see the response needs a middleware for the inbound half and an interceptor for the outbound
-one, because they are different classes and the interceptor cannot see what the
-middleware saw. dunx does not, because middleware wraps `next()` and both halves
-are the same closure. There is no pair to correlate by `requestId` just to find out
-how a call ended.
+dunx writes both halves from one middleware, because middleware wraps `next()`
+and both halves are the same closure. A framework whose middleware cannot see
+the response needs a middleware for the inbound half and an interceptor for the
+outbound one instead: different classes, and the interceptor cannot see what
+the middleware saw. There is no pair to correlate by `requestId` just to find
+out how a call ended.
 
 - A **4xx** is the same line at `warn`.
 - A **5xx** is the same line at `error`.

--- a/docs/guide/14-database.md
+++ b/docs/guide/14-database.md
@@ -1,11 +1,9 @@
 # Database
 
-`@dunx/infra/db` is **drizzle**, wired into the container. It adds no query
-abstraction, no entity decorators, and no repository base class. drizzle is the
-interface.
-
-What it does add is the four things a drizzle handle does not have: a lifecycle,
-module wiring, an async-safe transaction, and data seeding.
+`@dunx/infra/db` is **drizzle**, wired into the container. What it adds is what
+a drizzle handle does not have on its own: a lifecycle, module wiring, an
+async-safe transaction, and data seeding. It adds no query abstraction, no
+entity decorators, and no repository base class. drizzle is the interface.
 
 ```bash
 bun add drizzle-orm
@@ -53,10 +51,10 @@ export class Widgets {
 }
 ```
 
-There is no wrapper in that constructor. `BunSQLiteDatabase` and `BunSQLDatabase`
-are real runtime classes, so a class is usable as a token directly, and
-`@dunx/transform` records the bare type name while ignoring the type argument. One
-erased class is the token; the schema types stay on the annotation.
+`BunSQLiteDatabase` and `BunSQLDatabase` are real runtime classes, so a class is
+usable as a token directly: `@dunx/transform` records the bare type name while
+ignoring the type argument. One erased class is the token; the schema types
+stay on the annotation. There is no wrapper in that constructor.
 
 `schema` is required for that reason: it is the type argument that reaches
 `BunSQLiteDatabase<typeof schema>` at every injection site. Pass `{}` if you only
@@ -160,10 +158,10 @@ The handshake is awaited inside `open()` rather than deferred to the first query
 query.
 
 `create: false` behaves differently across Bun versions. On 1.4 it throws
-`bad parameter or other API misuse` when the file is missing, which is what the
-option is for. On 1.3.14 it created the file anyway. `readOnly` refuses a missing
-file on both, with `unable to open database file`, so it is the portable way to
-require an existing database.
+`bad parameter or other API misuse` when the file is missing - the behaviour
+the option is for. On 1.3.14 it created the file anyway. `readOnly` refuses a
+missing file on both, with `unable to open database file`, so it is the
+portable way to require an existing database.
 
 `strict: true` is this package's default and the driver's is not. Strict mode
 turns an unsupported binding into a `TypeError` instead of a silent `NULL`. It is also why `SqliteOptions` opens the `bun:sqlite` handle itself instead
@@ -303,11 +301,10 @@ So:
 - **Pick `SyncSqliteOptions`** if SQLite is the decision for good and you want a
   request path with no promise in it at all. Sync mode is SQLite forever.
 
-There is **no `SyncSqlOptions`, and there will not be one.**
 `Bun.SQL` talks to a server over a socket, and no amount of API design makes a
-Postgres query return a row instead of a promise. The asymmetry is structural:
-`SqlOptions` simply has no sync sibling, and `transactionSync` does not accept a
-`BunSQLDatabase`.
+Postgres query return a row instead of a promise. That asymmetry is structural:
+`SqlOptions` has no sync sibling, and `transactionSync` does not accept a
+`BunSQLDatabase`. There is **no `SyncSqlOptions`, and there will not be one.**
 
 ## Querying
 

--- a/docs/guide/15-queues.md
+++ b/docs/guide/15-queues.md
@@ -1,12 +1,10 @@
 # Queues
 
-**bullmq is the queue.** dunx adds no retry policy, no backoff, no rate limiter and
-no scheduler: those are bullmq's, and a second implementation of them would be a
-worse one.
-
-What `@dunx/infra/queue` contributes is the four things bullmq has no opinion
-about: where a handler lives, how it is found, how it is injected, and when it
-stops.
+**bullmq is the queue.** What `@dunx/infra/queue` contributes is the four things
+bullmq has no opinion about: where a handler lives, how it is found, how it is
+injected, and when it stops. dunx adds no retry policy, no backoff, no rate
+limiter and no scheduler: those are bullmq's, and a second implementation of
+them would be a worse one.
 
 ```bash
 bun add bullmq ioredis
@@ -195,8 +193,8 @@ client.
 
 `QueueModule.forRoot()` exports three tokens: `QueueOptions`, `QueueConnection` and
 `JobPublisher`. That is the **publish** side, which is all a web process needs. It
-also binds a fourth provider it does not export, `QueueRunner`, which is what opens
-workers when you ask it to.
+also binds a fourth provider it does not export, `QueueRunner` - the piece that
+opens workers when you ask it to.
 
 **By default it consumes nothing.** `consume` is `false`, so a web process that
 publishes never starts a worker by accident. There are three ways to consume, and
@@ -238,8 +236,8 @@ lands several commits before the first handler. Two handlers claiming one
 
 `@JobHandler({ queue, name, background })` marks one handler. `background: true`
 makes bullmq fork the file named by `QueueModule.forRoot({ processor })` instead of
-calling a function in this process, which is what keeps a CPU-bound handler off the
-loop serving requests.
+calling a function in this process - the switch that keeps a CPU-bound handler off
+the loop serving requests.
 
 Two things about it are easy to get wrong.
 
@@ -400,8 +398,6 @@ own it.
 
 ### Stop the consumer before you shut the app down
 
-This is the sharp edge, and it deserves saying plainly.
-
 ```ts
 await consumer.stop();
 await app.shutdown();
@@ -443,9 +439,9 @@ by default.
 ## Shutdown
 
 `worker.shutdown()` closes every bullmq `Worker` **before** the container tears
-down. That order is the point: `close()` without `force` stops fetching and waits
-for what is already running, so an in-flight job finishes while the database
-connection it is using is still open.
+down, so an in-flight job finishes while the database connection it is using is
+still open. `close()` without `force` stops fetching and waits for what is
+already running.
 
 The container's own reverse-construction-order teardown then closes the
 publisher's queues, and last of all the sockets. `QueueConnection` is constructed
@@ -570,7 +566,7 @@ even while workers drained jobs.
 
 `QueueConnection` wrapped `duplicate` and called it with no arguments, dropping
 the `{ connectionName }` bullmq's Bun adapter names a connection through. One
-line, fixed; `CLIENT SETNAME` runs and the worker appears..
+line, fixed; `CLIENT SETNAME` runs and the worker appears.
 
 ## Related
 

--- a/docs/guide/16-scheduling.md
+++ b/docs/guide/16-scheduling.md
@@ -93,8 +93,8 @@ and logged at `warn` with the name and how long that run has been going.
 
 `Overlap.CONCURRENT` starts the new run anyway.
 
-There is no queue mode. An overrun that must not be dropped is a job, which is
-`@JobHandler` and [queues](./15-queues.md).
+An overrun that must not be dropped is a job, which is `@JobHandler` and
+[queues](./15-queues.md). There is no queue mode here.
 
 A throwing handler is reported and never rethrown, so one bad run does not disarm the
 schedule. Its message lands on the entry's `lastError`.

--- a/docs/guide/18-files-and-images.md
+++ b/docs/guide/18-files-and-images.md
@@ -136,7 +136,7 @@ Details:
 S3 signs; a local disk cannot. `LocalStorage.presign()` throws
 `UnsupportedOperationError`, naming the key and what to do instead:
 
-```
+```text
 LocalStorage does not support presign(). Nothing signs "report.pdf" on a local
 disk. Configure S3StorageOptions, or serve the bytes through your own route.
 ```
@@ -252,8 +252,8 @@ nothing extra:
 ImagesModule.forRoot(async () => ({ quality: await settings.imageQuality() }));
 ```
 
-`forRootAsync` is for the one thing that cannot do: **injecting** a dependency
-into the factory.
+`forRootAsync` is for the one thing `forRoot` cannot do: **injecting** a
+dependency into the factory.
 
 ```ts
 ImagesModule.forRootAsync({
@@ -454,16 +454,16 @@ Bun's own codes pass through unchanged. Two are added here:
 `ERR_IMAGE_UNREADABLE_SOURCE` for a source that could not be read at all, and
 `ERR_IMAGE_FORMAT_NOT_ALLOWED` for one excluded by `allowedFormats`.
 
-| Condition                                    | Type        | `code`                          |
-| -------------------------------------------- | ----------- | ------------------------------- |
-| No container signature matched               | `Error`     | `ERR_IMAGE_UNKNOWN_FORMAT`      |
-| Header valid, pixels truncated or corrupt    | `Error`     | `ERR_IMAGE_DECODE_FAILED`       |
-| HEIC/AVIF/TIFF with no OS codec              | `Error`     | `ERR_IMAGE_FORMAT_UNSUPPORTED`  |
-| Over `maxPixels` (raised even by `metadata`) | `Error`     | `ERR_IMAGE_TOO_MANY_PIXELS`     |
-| Rotation not a multiple of 90                | `TypeError` | `ERR_INVALID_ARG_TYPE`          |
-| Unknown resize `filter`                      | `TypeError` | `ERR_INVALID_ARG_TYPE`          |
-| Input is a `Response`/`ReadableStream`       | `TypeError` | `ERR_INVALID_ARG_TYPE`          |
-| Missing path or directory                    | `Error`     | raw syscall: `ENOENT`, `ENODEV` |
+| Condition                                    | Cause         | `code`                         |
+| -------------------------------------------- | ------------- | ------------------------------ |
+| No container signature matched               | `Error`       | `ERR_IMAGE_UNKNOWN_FORMAT`     |
+| Header valid, pixels truncated or corrupt    | `Error`       | `ERR_IMAGE_DECODE_FAILED`      |
+| HEIC/AVIF/TIFF with no OS codec              | `Error`       | `ERR_IMAGE_FORMAT_UNSUPPORTED` |
+| Over `maxPixels` (raised even by `metadata`) | `Error`       | `ERR_IMAGE_TOO_MANY_PIXELS`    |
+| Rotation not a multiple of 90                | `TypeError`   | `ERR_INVALID_ARG_TYPE`         |
+| Unknown resize `filter`                      | `TypeError`   | `ERR_INVALID_ARG_TYPE`         |
+| Input is a `Response`/`ReadableStream`       | `TypeError`   | `ERR_INVALID_ARG_TYPE`         |
+| Missing path or directory                    | syscall error | `ERR_IMAGE_UNREADABLE_SOURCE`  |
 
 `ERR_IMAGE_ENCODE_FAILED` and `ERR_INVALID_STATE` are declared in Bun's types but
 were not reachable in probing.

--- a/docs/guide/18-files-and-images.md
+++ b/docs/guide/18-files-and-images.md
@@ -1,10 +1,10 @@
 # Files and images
 
-Two subpaths, both built entirely on Bun primitives. `@dunx/infra/files` is one
+Two subpaths, both built on Bun primitives. `@dunx/infra/files` is one
 storage contract over `Bun.file`, `Bun.write`, `Bun.Glob` and `Bun.S3Client`.
-`@dunx/infra/images` is decode, inspect and transform on `Bun.Image`.
+`@dunx/infra/images` decodes, inspects and transforms images on `Bun.Image`.
 
-Neither needs an install. No `@aws-sdk/*`, no `sharp`, no `jimp`, no
+Both work with no extra install: no `@aws-sdk/*`, no `sharp`, no `jimp`, no
 `image-size`, no native module to compile.
 
 ## Storage
@@ -22,8 +22,8 @@ export class Uploads {
 ```
 
 `Storage` is an abstract class, so it is both the injectable contract and the
-token. Whether the bytes land on a disk or in a bucket is decided in one `forRoot`
-call, and nothing above changes.
+token. Which backend gets used, disk or bucket, is decided in one `forRoot`
+call. The code above stays the same either way.
 
 ### Setup
 
@@ -53,12 +53,12 @@ FilesModule.forRoot(
 
 Anything omitted from the client options falls back to the environment:
 `S3_BUCKET` or `AWS_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-`AWS_REGION`, `AWS_ENDPOINT`. That is `Bun.S3Client`'s own resolution, and this
+`AWS_REGION`, `AWS_ENDPOINT`. That is `Bun.S3Client`'s own resolution; this
 package adds none of its own.
 
-`forRootAsync` when the configuration has to be loaded, or injected. The root
-existing before `LocalStorageOptions` names it is a real case, and creating it is
-async, so the factory may await:
+Use `forRootAsync` when the configuration has to be loaded or injected first.
+Creating the storage root before `LocalStorageOptions` can name it is a real
+case, and that setup can be async, so the factory may await it:
 
 ```ts
 FilesModule.forRootAsync({
@@ -69,14 +69,14 @@ FilesModule.forRootAsync({
 ```
 
 Both bind the same two tokens: `Storage`, and the `StorageOptions` that selected
-it. The module never branches on the backend, because the backend is whichever
-`StorageOptions` subclass got configured and `options.create()` is what builds it.
+it. The module never branches on the backend: the backend is whichever
+`StorageOptions` subclass got configured, and `options.create()` builds it.
 Adding a backend means writing a subclass.
 
 ### `LocalStorageOptions`
 
 The constructor is `(root: string, createPath = true)`. `root` is resolved to an
-absolute path, every key is resolved against it and may not escape it, and
+absolute path, and every key is resolved against it and may not escape it.
 `createPath` creates missing parent directories on write.
 
 ### The contract
@@ -102,16 +102,7 @@ key that was never there is not an error. A missing key raises
 
 Keys are always relative to the storage root: the configured directory locally,
 the configured prefix on S3. What `write` takes is what `list` and `stat` give
-back, so putting a bucket behind a prefix does not ripple into call sites.
-
-### Errors
-
-| Class                       | When                                       |
-| --------------------------- | ------------------------------------------ |
-| `FileNotFoundError`         | A backend-neutral ENOENT, mapped from both |
-| `PathTraversalError`        | A key that escapes the storage root        |
-| `UnsupportedOperationError` | `presign()` on a local disk                |
-| `StorageError`              | The base for all three                     |
+back. Putting a bucket behind a prefix does not ripple into call sites.
 
 ### Listing
 
@@ -143,17 +134,16 @@ Details:
 ### presign
 
 S3 signs; a local disk cannot. `LocalStorage.presign()` throws
-`UnsupportedOperationError` naming the key and what to do instead, rather than
-returning a URL that does not work:
+`UnsupportedOperationError`, naming the key and what to do instead:
 
 ```
 LocalStorage does not support presign(). Nothing signs "report.pdf" on a local
 disk. Configure S3StorageOptions, or serve the bytes through your own route.
 ```
 
-Signing is HMAC over the canonical request, so `S3Storage.presign()` is
-**synchronous and never touches the network**, returning a `string` rather than
-a promise.
+Signing is HMAC over the canonical request. `S3Storage.presign()` is
+**synchronous and never touches the network**, so it returns a `string` rather
+than a promise:
 
 ```ts
 const url = storage.presign('invoices/2026-01.pdf', {
@@ -163,9 +153,49 @@ const url = storage.presign('invoices/2026-01.pdf', {
 });
 ```
 
+### Streaming stays streaming
+
+Nothing here buffers a whole file to satisfy the contract. `readStream` returns
+`Bun.file().stream()`, or the S3 `GET` body, unread. A `ReadableStream` passed to
+`write` is pumped chunk by chunk into a sink: a `FileSink` locally, a multipart
+`NetworkSink` on S3. A file larger than memory transfers either way.
+
+The sink exists because of two `Bun.write` behaviours, both measured on Bun
+1.3.14:
+
+- **`Bun.write(path, stream)` silently writes the wrong bytes.** It matches no
+  overload, so the stream is stringified and the file contains the 23 bytes
+  `[object ReadableStream]`. No error, no warning.
+- **`Bun.write(path, new Response(stream))` never settles** when the response body
+  is itself a stream. `new Response('string')` settles normally.
+
+A third behaviour forces a streaming local write to do an empty `Bun.write` first:
+**`Bun.file(path).writer()` does not truncate and does not create parent
+directories.** Writing `"bb"` over a 20-byte file leaves
+`bbAAAAAAAAAAAAAAAAAA`. The empty write handles truncation and directory
+creation, then the sink streams in over the top.
+
+Two places where a call costs more than it looks:
+
+- **`readStream` does one `exists()` first**, so a missing key rejects the promise
+  instead of handing back a stream that fails on the consumer's first `read()`.
+  On S3 that is one extra `HEAD`. The `GET` has not started; the returned stream
+  is still lazy.
+- `Bun.file().stream()` is itself lazy, opening on the first read, which the
+  `exists()` check compensates for.
+
+### Errors
+
+| Class                       | When                                       |
+| --------------------------- | ------------------------------------------ |
+| `FileNotFoundError`         | A backend-neutral ENOENT, mapped from both |
+| `PathTraversalError`        | A key that escapes the storage root        |
+| `UnsupportedOperationError` | `presign()` on a local disk                |
+| `StorageError`              | The base for all three                     |
+
 ### Path traversal is rejected rather than sanitised
 
-Every key is resolved against the configured root, and one that lands outside it
+Every key is resolved against the configured root. One that lands outside it
 raises `PathTraversalError` **before any syscall**:
 
 ```ts
@@ -179,7 +209,7 @@ Two checks run, and the order matters. A key is accepted or refused
 **identically on every platform**: `..\..\etc` is one legal filename to POSIX
 `resolve` but three segments to Windows, so `..` is checked as a segment on
 **both separators** before the path is resolved at all. The boundary check then
-catches what segments cannot, which is an absolute key or a root-relative one that
+catches what segments cannot: an absolute key, or a root-relative one that
 resolves out.
 
 S3 keys get the same treatment. A key is opaque to S3, so a `..` in one was meant
@@ -191,38 +221,9 @@ symlink **inside** the root pointing outside it is still followed. Detecting tha
 needs `realpath`, which cannot answer for a file that does not exist yet. Do not
 make the root writable by anything you would not trust with its contents.
 
-### Streaming stays streaming
-
-Nothing here buffers a whole file to satisfy the contract. `readStream` returns
-`Bun.file().stream()`, or the S3 `GET` body, unread. A `ReadableStream` passed to
-`write` is pumped chunk by chunk into a sink: a `FileSink` locally, a multipart
-`NetworkSink` on S3. A file larger than memory transfers either way.
-
-The sink is not a stylistic choice. Two `Bun.write` behaviours forced it, both
-measured on Bun 1.3.14:
-
-- **`Bun.write(path, stream)` silently writes the wrong bytes.** It matches no
-  overload, so the stream is stringified and the file contains the 23 bytes
-  `[object ReadableStream]`. No error, no warning.
-- **`Bun.write(path, new Response(stream))` never settles** when the response body
-  is itself a stream. `new Response('string')` settles normally.
-
-A third forces a streaming local write to do an empty `Bun.write` first:
-**`Bun.file(path).writer()` does not truncate and does not create parent
-directories.** Writing `"bb"` over a 20-byte file leaves
-`bbAAAAAAAAAAAAAAAAAA`. The empty write does both jobs, then the sink streams in
-over the top.
-
-Two places where a call costs more than it looks:
-
-- **`readStream` does one `exists()` first**, so a missing key rejects the promise
-  instead of handing back a stream that fails on the consumer's first `read()`.
-  On S3 that is one extra `HEAD`. The `GET` has not started; the returned stream
-  is still lazy.
-- `Bun.file().stream()` is itself lazy, opening on the first read, which the
-  `exists()` check compensates for.
-
 ## Images
+
+Storage moves bytes; the images subpath reads and transforms them.
 
 ```ts
 import { Images, ImagesModule, ImageFit } from '@dunx/infra/images';
@@ -251,7 +252,8 @@ nothing extra:
 ImagesModule.forRoot(async () => ({ quality: await settings.imageQuality() }));
 ```
 
-`forRootAsync` is for the one thing that cannot do, which is **injecting**:
+`forRootAsync` is for the one thing that cannot do: **injecting** a dependency
+into the factory.
 
 ```ts
 ImagesModule.forRootAsync({
@@ -282,9 +284,9 @@ unresolved. Inject it to read the effective configuration.
 | `maxWidth`       | `undefined`               | Clamps every requested resize width              |
 | `maxHeight`      | `undefined`               | Clamps every requested resize height             |
 
-`maxPixels` matches Bun's own default, and is checked after the header is parsed
-but **before any pixel buffer is allocated**, so a small file declaring an enormous
-canvas is rejected cheaply.
+`maxPixels` matches Bun's own default. It is checked after the header is parsed
+but **before any pixel buffer is allocated**, so a small file declaring an
+enormous canvas is rejected cheaply.
 
 `maxWidth` and `maxHeight` **clamp** rather than refuse, so a request larger than
 the ceiling is served smaller.
@@ -333,8 +335,9 @@ const hero = source.resize(1200); // and still 'source'
 This is the single most important difference between `ImagePipeline` and
 `Bun.Image` underneath it. **`Bun.Image` mutates and returns `this`**, so two
 callers holding one instance silently reconfigure each other's transform. An
-`ImagePipeline` returns a new value from every operation, can be shared and forked
-freely, and re-runs the whole recipe from the original bytes on each terminal.
+`ImagePipeline` returns a new value from every operation. It can be shared and
+forked freely, and re-runs the whole recipe from the original bytes on each
+terminal.
 
 **Operations:** `resize`, `rotate`, `flip`, `flop`, `modulate`, `to`.
 
@@ -390,6 +393,45 @@ A ThumbHash low-quality placeholder of the **source**, as a
 `data:image/png;base64,...` URL. Roughly 1.4 KB for a photo, at most 32px on the
 long edge.
 
+### What `Bun.Image` does that will surprise you
+
+`Bun.Image` is barely documented upstream. Everything here was measured on Bun
+1.3.14 and is pinned by tests in `@dunx/infra`.
+
+**Silent clamping, no throw.** `resize(0)`, `resize(-5)` and `resize(1.5)` all
+produce a 1x1 image. `quality: 0` behaves as the minimum and `quality: 101` as
+`100`. A bogus option **key** is ignored, but a bogus option **value** for
+`filter` throws.
+
+**Decode-only formats fall back to PNG.** Bun decodes `gif` (first frame), `bmp`
+and `tiff` but has no encoder for them. Bun's docs say a terminal with no format
+setter re-encodes in the source format; for those three it actually emits **PNG**,
+and `blob().type` reports `image/png`. `ImagePipeline.outputFormat` tells you this
+before you run anything.
+
+**`width`/`height` on a raw `Bun.Image` are `-1`** until a terminal has been
+awaited, and then hold whatever that terminal produced. `encode()` exists so you
+never have to reason about that.
+
+**Lazy and re-runnable.** The pipeline runs on a worker thread when a terminal is
+awaited, and awaiting a second terminal re-runs it rather than throwing. Parallel
+terminals via `Promise.all` are safe.
+
+**Platform.** `Bun.Image.backend` is `'bun'` on Linux and `'system'` on
+macOS/Windows. On Linux, **HEIC and AVIF encoding is unavailable**, `tiff` decode
+fails with `ERR_IMAGE_FORMAT_UNSUPPORTED`, and setting `backend = 'system'` does
+not change either. The clipboard statics are inert there too.
+
+`allowedFormats` defaults to every container Bun can identify, including HEIC and
+AVIF: a machine with the codec can use them, and the runtime's own
+`ERR_IMAGE_FORMAT_UNSUPPORTED` is the honest answer where it cannot. Narrow it if
+you want the refusal to be a policy decision instead.
+
+**Undocumented but present.** `Bun.file(path).image()` and `Blob.prototype.image()`
+both exist and return a `Bun.Image`. `linear` works as a resize filter, an alias
+for `bilinear`, even though it is missing from the error message listing the valid
+names.
+
 ### Errors
 
 Everything throws `ImageError extends AppError`, carrying a `code` and the
@@ -425,45 +467,6 @@ Bun's own codes pass through unchanged. Two are added here:
 
 `ERR_IMAGE_ENCODE_FAILED` and `ERR_INVALID_STATE` are declared in Bun's types but
 were not reachable in probing.
-
-### What `Bun.Image` does that will surprise you
-
-`Bun.Image` is barely documented upstream. Everything here was measured on Bun
-1.3.14 and is pinned by tests in `@dunx/infra`.
-
-**Silent clamping, no throw.** `resize(0)`, `resize(-5)` and `resize(1.5)` all
-produce a 1x1 image. `quality: 0` behaves as the minimum and `quality: 101` as
-`100`. A bogus option **key** is ignored, but a bogus option **value** for
-`filter` throws.
-
-**Decode-only formats fall back to PNG.** Bun decodes `gif` (first frame), `bmp`
-and `tiff` but has no encoder for them. Bun's docs say a terminal with no format
-setter re-encodes in the source format; for those three it actually emits **PNG**,
-and `blob().type` reports `image/png`. `ImagePipeline.outputFormat` tells you this
-before you run anything.
-
-**`width`/`height` on a raw `Bun.Image` are `-1`** until a terminal has been
-awaited, and then hold whatever that terminal produced. `encode()` exists so you
-never have to reason about that.
-
-**Lazy and re-runnable.** The pipeline runs on a worker thread when a terminal is
-awaited, and awaiting a second terminal re-runs it rather than throwing. Parallel
-terminals via `Promise.all` are safe.
-
-**Platform.** `Bun.Image.backend` is `'bun'` on Linux and `'system'` on
-macOS/Windows. On Linux, **HEIC and AVIF encoding is unavailable**, `tiff` decode
-fails with `ERR_IMAGE_FORMAT_UNSUPPORTED`, and setting `backend = 'system'` does
-not change either. The clipboard statics are inert there too.
-
-`allowedFormats` defaults to every container Bun can identify, including HEIC and
-AVIF, because a machine with the codec can use them and the runtime's own
-`ERR_IMAGE_FORMAT_UNSUPPORTED` is the honest answer where it cannot. Narrow it if
-you want the refusal to be a policy decision instead.
-
-**Undocumented but present.** `Bun.file(path).image()` and `Blob.prototype.image()`
-both exist and return a `Bun.Image`. `linear` works as a resize filter, an alias
-for `bilinear`, even though it is missing from the error message listing the valid
-names.
 
 ## Related
 

--- a/docs/guide/19-deployment.md
+++ b/docs/guide/19-deployment.md
@@ -1,8 +1,8 @@
 # Deployment
 
-A dunx app is a Bun process that calls `Bun.serve`. There is no adapter to pick,
-no build step that rewrites your code, and nothing that has to run before the
-process starts except the one preload line.
+A dunx app is a Bun process that calls `Bun.serve`. There is no adapter to pick
+and no build step that rewrites your code. Nothing has to run before the process
+starts except one preload line.
 
 ## The one thing that must survive to production
 
@@ -14,8 +14,8 @@ preload = ["@dunx/transform/preload"]
 `@dunx/transform` records each class's constructor parameter types when the file
 loads. Without it the container has no way to know what a constructor wants, and
 boot fails with an error naming the class rather than constructing it with
-`undefined` arguments. That is deliberate, and it means a deployment that loses
-`bunfig.toml` fails immediately and loudly rather than at the first request.
+`undefined` arguments. A deployment that loses `bunfig.toml` fails immediately
+and loudly rather than at the first request.
 
 Three ways to supply it, all equivalent:
 
@@ -37,7 +37,7 @@ bun src/main.ts
 
 That is the whole command. `HttpFactory.create` builds the container,
 `listen()` hands the route table to `Bun.serve`, and the server holds the
-process open. There is no cluster module to configure - see the note on
+process open. There is no cluster module to configure, see the note on
 horizontal scaling below.
 
 ## Shutting down cleanly
@@ -52,8 +52,8 @@ await app.closed;
 
 `enableShutdownHooks()` installs the signal handlers. On `SIGTERM` or `SIGINT`
 the graph is torn down in **reverse construction order**, so a repository is
-disposed before the database connection it holds, and `app.closed` resolves once
-that finishes. Anything implementing `OnShutdown` participates.
+disposed before the database connection it holds. `app.closed` resolves once
+that finishes, and anything implementing `OnShutdown` participates.
 
 This matters more than it looks under an orchestrator. Kubernetes sends
 `SIGTERM` and then waits `terminationGracePeriodSeconds` before `SIGKILL`; a
@@ -65,7 +65,7 @@ handle is often not yours.
 
 The real case is a Redis client. A `Bun.RedisClient` whose TCP connect never
 completed keeps a handle past `close()`, and bullmq's Bun adapter cannot cancel
-its own reconnect once the connection has dropped, so an app that touched an
+its own reconnect once the connection has dropped. An app that touched an
 unreachable broker used to drain perfectly and then hang.
 
 Both leaks are upstream and neither is reachable from userland. They are recorded
@@ -79,8 +79,8 @@ logs a line, since it means something leaked.
 
 You no longer need a short `terminationGracePeriodSeconds` to work around this.
 
-Pass `{ exitAfterMs: false }` to opt out, and pass it in **tests that fire a
-signal at their own process** - otherwise the forced exit lands in the middle of
+Pass `{ exitAfterMs: false }` to opt out. Pass it in **tests that fire a
+signal at their own process**, too, or the forced exit lands in the middle of
 your test run:
 
 ```ts
@@ -130,8 +130,6 @@ the image.
 ## Health checks
 
 `HealthModule` from `@dunx/http` serves `/api/health/live` and `/api/health/ready`.
-Do not hand-roll a controller for this; the part worth having is the drain, and a
-controller cannot express it.
 
 ```ts
 HealthModule.forRootAsync({
@@ -146,26 +144,30 @@ HealthModule.forRootAsync({
 });
 ```
 
-Two settings decide whether a rollout drops requests.
+Do not hand-roll a controller for this. The part worth having is the drain, and a
+plain controller cannot express it. Two settings decide whether a rollout drops
+requests; the full mechanics, including how to write your own indicator, are in
+[Health checks](./20-health-checks.md).
 
-**`critical`** is what separates readiness from liveness. A `critical: false`
-indicator reports `degraded` without failing the probe, so an absent Redis degrades a
-route rather than restarting the process. Be sparing with `critical: true`: it should
+**`critical`** separates readiness from liveness. A `critical: false` indicator
+reports `degraded` without failing the probe, so an absent Redis degrades a route
+rather than restarting the process. Be sparing with `critical: true`: it should
 name only what makes the process useless, which in most services is the database
-alone. A liveness probe that checks Redis will restart a healthy process on a cache
-blip.
+alone. A liveness probe that checks Redis will restart a healthy process on a
+cache blip.
 
 **`drainDelayMs`** holds readiness failing before the port closes.
-
 `Readiness` implements `OnBeforeShutdown`, which runs while the server is still
-accepting. The probe can therefore answer "not ready" on an open socket for as long as
+accepting, so the probe can answer "not ready" on an open socket for as long as
 the load balancer needs to notice. An `onShutdown` hook runs after the server has
-stopped, so a probe answering from there answers on a closed socket.
+stopped, so a probe answering from there answers on a closed socket already.
 
-Liveness keeps passing throughout: a pod that is shutting down does not need killing.
+Liveness keeps passing throughout: a pod that is shutting down does not need
+killing.
 
-Set `drainDelayMs` to at least your ingress's deregistration interval. The probes are
-hidden from the OpenAPI document, so they will not appear in a generated client.
+Set `drainDelayMs` to at least your ingress's deregistration interval. The probes
+are hidden from the OpenAPI document, so they will not appear in a generated
+client.
 
 ## Logging
 
@@ -196,7 +198,7 @@ balancer works with no changes. Two things need attention when you do:
 
 - **WebSocket fan-out is per process.** `socket.subscribe(topic)` joins a topic
   in the Bun runtime of that process only, so a publish reaches the clients
-  connected to that instance. Attach the Redis relay to fan out across nodes -
+  connected to that instance. Attach the Redis relay to fan out across nodes,
   see [WebSockets](./09-websockets.md).
 - **Queue workers are separate processes.** `QueueModule.forRoot` binds the
   publish side alone, so a web process that publishes never accidentally starts
@@ -211,6 +213,6 @@ watch. The current figures are on the
 [benchmarks page](https://petarzarkov.github.io/dunx/#/benchmarks), regenerated
 from a real run rather than written down.
 
-Eager resolution is a deliberate trade: every provider is constructed at boot, so
-a missing binding or a bad config is a failed start rather than a 500 on the
-first request that happens to need it.
+Eager resolution is a trade: every provider is constructed at boot, so a missing
+binding or a bad config is a failed start rather than a 500 on the first request
+that happens to need it.

--- a/docs/guide/20-health-checks.md
+++ b/docs/guide/20-health-checks.md
@@ -91,8 +91,8 @@ has stopped, so a probe answering from there answers on a socket that is already
 closed.
 
 `drainDelayMs` keeps readiness failing for that long before the socket closes. A
-load balancer notices a failing probe on its own schedule: at a 2 second interval
-and a 3 failure threshold, traffic can arrive for 6 seconds after the pod has
+load balancer notices a failing probe on its own schedule: at a 2-second interval
+and a 3-failure threshold, traffic can arrive for 6 seconds after the pod has
 decided to go. Set it to a few intervals.
 
 Liveness keeps passing throughout. A pod that is shutting down does not need

--- a/docs/guide/20-health-checks.md
+++ b/docs/guide/20-health-checks.md
@@ -61,11 +61,11 @@ costs the slowest check rather than their sum.
 
 ## Three states
 
-A check that throws is `down`, carrying its message. A check that outruns its budget
-is `unknown`.
+A check that throws is `down`, carrying its message. A check that outruns its
+budget is `unknown`.
 
-The difference matters. A probe that did not answer has told you nothing, which is not
-the same as telling you it is broken.
+The difference matters. A probe that did not answer has told you nothing, which
+is not the same as telling you it is broken.
 
 `unknown` on a critical check fails readiness. On a non-critical one it does not.
 
@@ -73,32 +73,36 @@ the same as telling you it is broken.
 
 `critical` defaults to `true`. A failure sheds traffic.
 
-`MemoryIndicator` and `DiskIndicator` ship as `critical: false`. A disk at 91 percent
-is worth seeing on the page, and pulling the pod out of rotation does not make it
-emptier, because no other pod's disk is.
+`MemoryIndicator` and `DiskIndicator` ship as `critical: false`. A disk at 91
+percent is worth seeing on the page. Pulling the pod out of rotation does not
+make it emptier, since no other pod's disk is either.
 
-A memory ceiling belongs on `liveness`, where the orchestrator restarts the process
-rather than routing around it.
+A memory ceiling belongs on `liveness`, where the orchestrator restarts the
+process rather than routing around it.
 
 ## Draining
 
-Readiness starts failing **before** the port closes. That ordering is the point.
+Readiness starts failing **before** the port closes.
 
-`Readiness` implements [`OnBeforeShutdown`](./07-lifecycle.md), which runs while the
-server is still accepting. Every `onShutdown` hook runs after the server has stopped,
-so a probe answering from there answers on a closed socket.
+`Readiness` implements [`OnBeforeShutdown`](./07-lifecycle.md), which runs while
+the server is still accepting, so the probe can answer "not ready" while the
+load balancer can still reach it. Every `onShutdown` hook runs after the server
+has stopped, so a probe answering from there answers on a socket that is already
+closed.
 
-`drainDelayMs` keeps readiness failing for that long before the socket closes. A load
-balancer notices a failing probe on its own schedule: at a 2 second interval and a 3
-failure threshold, traffic can arrive for 6 seconds after the pod has decided to go.
-Set it to a few intervals.
+`drainDelayMs` keeps readiness failing for that long before the socket closes. A
+load balancer notices a failing probe on its own schedule: at a 2 second interval
+and a 3 failure threshold, traffic can arrive for 6 seconds after the pod has
+decided to go. Set it to a few intervals.
 
 Liveness keeps passing throughout. A pod that is shutting down does not need
 restarting, and `down` there invites a SIGKILL mid-drain.
 
 ## Taking a pod out by hand
 
-`Readiness` is injectable, so a handler can do it for a migration.
+A drain does not always start with a signal. A migration needs the same
+"stop sending me traffic" behaviour on demand, and `Readiness` is injectable so
+a handler can trigger it directly.
 
 ```ts
 export class MaintenanceController {
@@ -120,7 +124,8 @@ export class MaintenanceController {
 
 ## Your own indicators
 
-Subclass `HealthIndicator`, or hand `HealthOptions` any object with the three members.
+Subclass `HealthIndicator`, or hand `HealthOptions` any object with the three
+members.
 
 ```ts
 import { HealthIndicator, type ProbeResult } from '@dunx/http';
@@ -143,14 +148,14 @@ Throwing is how a check reports `down`. The registry never lets one throw into a
 response.
 
 `DatabaseIndicator` needs a connection with `ping()`, which `DbConnection` from
-`@dunx/infra/db` has. A custom connection must implement it: the base throws with a
-message saying so, rather than reporting a database healthy without having asked it
-anything.
+`@dunx/infra/db` has. A custom connection must implement `ping()` too: the base
+throws a message naming what is missing, rather than reporting a database
+healthy without having asked it anything.
 
 ## No startup probe
 
-The port already answers that. `create()` finishes every `onInit` before `listen()`
-binds, so a refused connection is "not started yet".
+The port already answers that question. `create()` finishes every `onInit`
+before `listen()` binds, so a refused connection means "not started yet".
 
 ## Options
 
@@ -165,7 +170,7 @@ HealthModule.forRoot({
 });
 ```
 
-`routes: false` binds `HealthRegistry` and `Readiness` and mounts nothing, for an app
-that answers on its own paths.
+`routes: false` binds `HealthRegistry` and `Readiness` and mounts nothing, for an
+app that answers on its own paths.
 
 `documented: false` mounts the routes and hides them from `@dunx/openapi`.

--- a/docs/guide/21-agent-tooling.md
+++ b/docs/guide/21-agent-tooling.md
@@ -142,8 +142,8 @@ it writes the minimal template rather than blocking.
 
 ## It reads the app. It never boots it.
 
-`AppFactory.create()` instantiates every provider and awaits every async factory
-before it returns; dunx has no lazy resolution. Booting an app to answer "what
+`AppFactory.create()` instantiates every declared binding and awaits every async
+factory before it returns. Booting an app to answer "what
 routes exist" would open database connections, start queue workers, bind sockets
 and run every `onInit`. An agent asking a question about the code would end up
 running the code against whatever environment happened to be configured.

--- a/docs/guide/21-agent-tooling.md
+++ b/docs/guide/21-agent-tooling.md
@@ -24,10 +24,10 @@ bunx @dunx/mcp ./src/app.module.ts
 ```
 
 Point it at the file that declares your root module. No naming convention applies:
-`@Module` leaves a marker, so a module exported only by name is found on its own,
-which is what `bunx @dunx/create-app` scaffolds.
+`@Module` leaves a marker, so a module exported only by name is found on its own.
+`bunx @dunx/create-app` scaffolds a module exported exactly this way.
 
-`default` and `root` win if present, and `--export=<name>` settles a file that
+`default` and `root` win if present. `--export=<name>` settles a file that
 declares several. The path is resolved with `Bun.resolveSync`, so anything
 `import` accepts works: a relative path with or without `./`, an absolute one, an
 extensionless specifier, or a package name.
@@ -72,12 +72,12 @@ whether it would boot, without returning the graph:
 }
 ```
 
-`unresolvedDependencies` is listed rather than counted, because each entry is a boot
+`unresolvedDependencies` is listed rather than counted: each entry is a boot
 error naming a parameter. A constructor parameter whose type was erased - an
 interface, a primitive, a union, a type-only import - is recorded by
-`@dunx/transform` as `unresolved`. `emitDecoratorMetadata` has that wart and dunx
-does not. The `typeOnly` case is called out separately because it has a
-one-line fix:
+`@dunx/transform` as `unresolved`. That is the same wart `emitDecoratorMetadata`
+has; dunx's transform does not carry it. The `typeOnly` case gets its own field
+because it has a one-line fix:
 
 ```json
 {
@@ -112,9 +112,9 @@ Schema vendor. It does not report the schema:
 }
 ```
 
-Turning a schema into JSON Schema is zod-specific work `@dunx/openapi` already does
-properly, so `dunx_openapi` is where it lives - and that split is what keeps the
-other five tools working in an app with no OpenAPI setup. `@dunx/openapi` is an
+Turning a schema into JSON Schema is zod-specific work; `@dunx/openapi` already
+does it properly, so `dunx_openapi` is where it lives. That split keeps the other
+five tools working in an app with no OpenAPI setup at all. `@dunx/openapi` is an
 optional peer, loaded only when `dunx_openapi` is called.
 
 ## Starting a project with an agent
@@ -142,12 +142,10 @@ it writes the minimal template rather than blocking.
 
 ## It reads the app. It never boots it.
 
-This is the decision the package is built around.
-
 `AppFactory.create()` instantiates every provider and awaits every async factory
-before it returns, dunx having no lazy resolution. Booting an app to answer "what
+before it returns; dunx has no lazy resolution. Booting an app to answer "what
 routes exist" would open database connections, start queue workers, bind sockets
-and run every `onInit`, so an agent asking a question about the code would be
+and run every `onInit`. An agent asking a question about the code would end up
 running the code against whatever environment happened to be configured.
 
 Reading costs none of that. `discoverRoutes` and `discoverGateway` each walk a

--- a/docs/guide/22-upgrading.md
+++ b/docs/guide/22-upgrading.md
@@ -6,16 +6,16 @@ except the first, which changes a default.
 ## An unmatched path answers 404
 
 `HttpFactory.create` used to report a miss to global middleware with no route
-metadata, so a global guard refused it and a prober could not tell a 404 from a 401. That is now opt-in.
+metadata. A global guard refused it, and a prober could not tell a 404 from a 401. That is now opt-in.
 
 | Before                            | After                                    |
 | --------------------------------- | ---------------------------------------- |
 | a miss behind a global guard: 401 | a miss behind a global guard: 404        |
 | `notFound: 'public'` to get 404   | `notFound: 'guarded'` to get the old 401 |
 
-An app with no global authentication guard needs no change and now behaves the way
-every other framework does. An app that has one, and wants a miss to look like
-every other refused request, sets it back:
+An app with no global authentication guard needs no change. It now behaves the
+way every other framework does. An app that has one, and wants a miss to look
+like every other refused request, sets it back:
 
 ```ts
 await HttpFactory.create(AppModule, { notFound: 'guarded' });
@@ -61,9 +61,9 @@ export class HttpConfigModule {}
 | `app.set('trust proxy', true)`                   | `override readonly trustProxy`   |
 
 **Nothing is removed.** `setGlobalPrefix`, `enableCors`, `set` and
-`enableShutdownHooks` all still work, and a call to one wins over the provider,
-because it happens after construction. An argument to `create()` wins too, field by
-field, so a setting can move into the container one at a time.
+`enableShutdownHooks` all still work. A call to one wins over the provider,
+because it happens after construction. An argument to `create()` wins too, field
+by field, so a setting can move into the container one at a time.
 
 Override a field with a field and a getter with a getter: TypeScript rejects the
 other pairing with `TS2611` and `TS2610`. To derive a field from config, declare
@@ -71,7 +71,7 @@ other pairing with `TS2611` and `TS2610`. To derive a field from config, declare
 
 ## A named outbound client can be a class
 
-`httpClient(name)` returns a `Token`, and a token is not a class, so a named client
+`httpClient(name)` returns a `Token`, and a token is not a class. A named client
 could only be reached with `inject()` in a field initialiser.
 
 ```ts
@@ -90,8 +90,8 @@ client and any number of named ones coexist.
 
 ## A named Redis connection can be a class
 
-The same change, in `@dunx/infra/redis`. `redisConnection(name)` returns a `Token`,
-so a named connection could only be reached with `inject()` in a field.
+The same change, in `@dunx/infra/redis`. `redisConnection(name)` returns a
+`Token`, so a named connection could only be reached with `inject()` in a field.
 
 ```ts
 export class SessionsRedis extends Redis {}
@@ -106,12 +106,12 @@ RedisModule.forRootAsync({ useFactory, inject }, SessionsRedis);
 
 `Redis` is now exported for this: `RedisConnection` is the abstract contract and
 takes no options, so it cannot be the base a subclass extends. The string form
-still works, and a subclass does not claim `RedisConnection`.
+still works. A subclass does not claim `RedisConnection`.
 
 ## The websocket relay can be a provider
 
 `relay: new RedisRelay({...})` was an instance `main.ts` built and threaded into
-`HttpFactory.create`, which made it the one setting an options provider could not
+`HttpFactory.create`. That made it the one setting an options provider could not
 answer from config.
 
 | Before                                     | After                                        |
@@ -119,7 +119,7 @@ answer from config.
 | `new RedisRelay(...)` in `main.ts`         | `WsRelayModule.forRootAsync({ useFactory })` |
 | `relay:` and `relayChannel:` on `create()` | `override get relay()` on the provider       |
 
-The container closes it at shutdown, which `PubSub.close()` does not do for an app
+The container closes it at shutdown. `PubSub.close()` does not do that for an app
 that never opened a socket. Passing an instance to `create()` still works.
 
 ## Config takes a schema directly
@@ -173,19 +173,19 @@ try {
 }
 ```
 
-`toDatabaseError` returns a `ConstraintError` carrying a status - 409 for a unique
-or foreign key violation, 400 for not-null and check - and returns anything it does
-not recognise untouched. `@dunx/http` reads the status off it, so no error filter is
-involved. `transaction`, `transactionSync` and `runSeeds` already classify on the
-way out.
+`toDatabaseError` returns a `ConstraintError` carrying a status - 409 for a
+unique or foreign key violation, 400 for not-null and check. Anything it does
+not recognise passes through untouched. `@dunx/http` reads the status off it, so
+no error filter is involved. `transaction`, `transactionSync` and `runSeeds`
+already classify on the way out.
 
 The driver's own message stays on `cause` rather than in the response body, which
 would otherwise carry the table and column names.
 
 ## Four more `fetch` options
 
-`HttpClientOptionsInit` passes `compress`, `protocol` and `maxRedirects` through,
-and `proxy` widens to `string | URL | { url, headers }` - the object form sends
+`HttpClientOptionsInit` passes `compress`, `protocol` and `maxRedirects` through.
+`proxy` widens to `string | URL | { url, headers }`: the object form sends
 `Proxy-Authorization` to the proxy rather than to the target.
 
 `protocol: 'http2'` lets concurrent requests to one origin share a connection.

--- a/docs/logo/README.md
+++ b/docs/logo/README.md
@@ -21,24 +21,24 @@ looked nice.
 | [`logo-mark-color.svg`](../../internal/docs/public/logo/logo-mark-color.svg)           | Favicon, README, anywhere foreign | All gradient, adapts to nothing            |
 
 **The rule that decides between them:** an `<img>` element cannot inherit
-`currentColor` - the SVG loads as its own document and the keyword resolves against
-that document's root, which is black. So the `currentColor` cuts are only correct
-when the SVG is **inlined into the page**, and anything referenced by `src=` or
-pasted into a README must be `logo-mark-color.svg`.
+`currentColor`. The SVG loads as its own document, and the keyword resolves
+against that document's root, which is black. So the `currentColor` cuts are
+only correct when the SVG is **inlined into the page**. Anything referenced by
+`src=` or pasted into a README must be `logo-mark-color.svg`.
 
 So the docs site draws the paths in
 [`Logo.tsx`](../../internal/ui/src/components/Logo.tsx) instead of loading the files:
 the header has to follow the theme toggle. It reads `BOWL` and `CROSS` from
-[`logo.ts`](../../internal/ui/src/logo.ts), which is where the geometry is written;
-the three files above restate it and have to be edited alongside.
+[`logo.ts`](../../internal/ui/src/logo.ts), which is where the geometry is written.
+The three files above restate it and have to be edited alongside.
 
 ## Do not add a `prefers-color-scheme` block
 
 It was tried and removed. An `@media (prefers-color-scheme: dark)` rule **inside**
 the SVG is evaluated against the operating system, not against the page embedding
-it, and the SVG's own rule beats the host's theme. A dark-OS visitor reading the
+it. So the SVG's own rule beats the host's theme. A dark-OS visitor reading the
 site in light mode got a pale, near-invisible arch. The neutral cuts inherit and
-nothing else; opening one directly in a browser gives black on white, which is
+nothing else. Opening one directly in a browser gives black on white, which is
 correct.
 
 `logo-mark-color.svg` is all-gradient **on purpose**. A browser tab strip and
@@ -64,6 +64,6 @@ A mark that dies at favicon size is not a logo.
 
 A solid dome was also cut before the arch this was rotated from: it reads as a ghost
 or a "blocked" icon (`05-cuts-rejected.png`). What replaced it is hollow, open along
-one side and cool-toned, which is also what settles any question of it being derived
-from Bun's mark - that one is a solid, warm, faced shape, and this shares no fill, no
+one side and cool-toned. That also settles any question of it being derived from
+Bun's mark: that one is a solid, warm, faced shape, and this shares no fill, no
 palette and no closed silhouette with it.

--- a/examples/databases/README.md
+++ b/examples/databases/README.md
@@ -1,8 +1,8 @@
 # @dunx/example-databases
 
 Setting up `@dunx/infra/db` on **SQLite** (asynchronous *and* synchronous),
-**Postgres** and **MySQL** - the same three operations against each, so the parts
-that differ are the only parts on screen.
+**Postgres** and **MySQL**. The same three operations run against each, so the
+parts that differ are the only parts on screen.
 
 ```bash
 bun install
@@ -11,10 +11,10 @@ bun run --filter '@dunx/example-databases' start
 bun run --filter '@dunx/example-databases' dev
 ```
 
-With nothing installed that prints two SQLite results and says it is skipping
-Postgres and MySQL, and exits 0. There is no HTTP anywhere in this example: it
-uses `AppFactory`, not `HttpFactory`, so the database wiring is all there is to
-read.
+With nothing installed, running it prints two SQLite results, reports that it is
+skipping Postgres and MySQL, and exits 0. There is no HTTP anywhere in this
+example: it uses `AppFactory`, not `HttpFactory`, so the database wiring is all
+there is to read.
 
 ## One app, four configurations
 
@@ -25,9 +25,9 @@ read.
 | `PostgresModule.forUrl()`     | `drizzle-orm/bun-sql` over `Bun.SQL`        | `BunSQLDatabase`     |
 | `MysqlModule.forUrl()`        | `drizzle-orm/mysql-proxy` over `Bun.SQL`    | `MySqlRemoteDatabase` |
 
-Four containers rather than one, because the container is flat and each binds its
-own `DbConnection` - two backends in one app would be a duplicate token, which
-dunx rejects at boot naming both modules. Running one app per database is also
+Four containers rather than one. The container is flat and each one binds its own
+`DbConnection`, so two backends in one app would be a duplicate token: dunx
+rejects that at boot, naming both modules. Running one app per database is also
 what a real deployment does.
 
 ## SQLite, two modes
@@ -56,10 +56,10 @@ the move is a change to one module and to no repository. Compare
 [`postgres/widgets.service.ts`](./src/postgres/widgets.service.ts): the imports
 differ by two lines and the bodies are the same.
 
-The mode is not a runtime flag, and cannot be: it decides which class the drizzle
-handle is bound under, and `DbModule.forRoot` infers the injection
-token from. It is also enforced - a service annotating `SyncDatabase` will not
-resolve in an app that bound `BunSQLiteDatabase`.
+The mode is not a runtime flag, and cannot be. It decides which class the drizzle
+handle is bound under, and `DbModule.forRoot` infers the injection token from that
+class. It is also enforced: a service annotating `SyncDatabase` will not resolve
+in an app that bound `BunSQLiteDatabase`.
 
 ### Transactions differ, and the difference is the point
 
@@ -69,17 +69,17 @@ resolve in an app that bound `BunSQLiteDatabase`.
 | `transactionSync(db, fn)`  | **sync only**        | `T`          | savepoint   |
 
 `transaction()` on `bun:sqlite` issues `BEGIN`/`COMMIT`/`ROLLBACK` itself rather
-than delegating to drizzle, because drizzle delegates to `bun:sqlite`'s wrapper,
-which commits as soon as the callback *returns its promise* - so every statement
-after the first `await` runs in autocommit and a later throw rolls back nothing.
+than delegating to drizzle. drizzle delegates to `bun:sqlite`'s wrapper, which
+commits as soon as the callback *returns its promise*, so every statement after
+the first `await` runs in autocommit and a later throw rolls back nothing.
 
 `transactionSync()` **does** delegate, correctly: the whole failure is
 downstream of a callback that returns a promise, and this one cannot. An `async`
 callback is a compile error naming the constraint.
 
 One wart: `transactionSync`'s return type is constrained to
-"not a promise", and that constraint's object branch is a TypeScript *weak type* -
-so returning an object or an array from the callback is rejected even though it is
+"not a promise", and that constraint's object branch is a TypeScript *weak type*.
+Returning an object or an array from the callback is rejected, even though it is
 not thenable. Return a scalar, or use the async `transaction()`.
 
 ## Postgres
@@ -93,8 +93,8 @@ socket, the pool and the wire protocol. `SqlInit` extends `Bun.SQL`'s own option
 type rather than restating it, so `max`, `idleTimeout` and `tls` are all accepted.
 
 The dialect is resolved from the URL at construction, so a bad URL throws before
-any I/O. The handshake is awaited inside `open()`, and dunx settles every async
-factory before it constructs anything - so a repository can never be handed a
+any I/O. The handshake is awaited inside `open()`. dunx settles every async
+factory before it constructs anything, so a repository can never be handed a
 client that has not connected.
 
 ```bash
@@ -104,9 +104,9 @@ bun run --filter '@dunx/example-databases' start
 
 ## MySQL
 
-**There is no Bun-native drizzle driver for MySQL, and this example builds one in
-about forty lines.** [`mysql/driver.ts`](./src/mysql/driver.ts) is the whole of it,
-and `@dunx/infra` needed no change to accept it - `DbOptions.open()` is where a
+**There is no Bun-native drizzle driver for MySQL. This example builds one in
+about forty lines.** [`mysql/driver.ts`](./src/mysql/driver.ts) is the whole of it.
+`@dunx/infra` needed no change to accept it: `DbOptions.open()` is where a
 backend lives, so adding one is a new class rather than an edit to a dispatch table.
 
 The reasoning: drizzle 0.45.2's only Bun entrypoints are `bun-sql` (Postgres,
@@ -179,14 +179,14 @@ naming `adapter` explicitly. This example does the last two.
 nothing else pending exits **silently with code 0** in the middle of a query - no
 error, no rejection, no output. A server never notices because `Bun.serve` holds a
 reference; a CLI does. [`main.ts`](./src/main.ts) holds one `setInterval` for the
-duration for exactly this reason. Postgres and `bun:sqlite` are unaffected.
+duration for this reason. Postgres and `bun:sqlite` are unaffected.
 
 ## Migrations
 
 None of the three run migrations here. Schema changes are
-`drizzle-kit generate` plus the dialect's own migrator - which own the SQL, the
-journal and the snapshot folder - and a `:memory:` database has nowhere to keep any
-of that. Each service creates its table in `onInit` instead, which runs after the
+`drizzle-kit generate` plus the dialect's own migrator, which own the SQL, the
+journal and the snapshot folder. A `:memory:` database has nowhere to keep any of
+that, so each service creates its table in `onInit` instead, which runs after the
 graph is built and before the first caller.
 
 `runSeeds()` from `@dunx/infra/db` is the seeding half, and

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -6,7 +6,7 @@ and poke at it rather than read about it.
 **Start smaller if this is your first look.** [`examples/minimal`](../minimal) is
 five files and two minutes; [`examples/databases`](../databases) is database setup
 on four configurations; [`examples/testing`](../testing) is the test story. This one
-is the answer to "does it all actually compose?", and it is the only example where
+is the answer to "does it all actually compose?" It is the only example where
 that is visible.
 
 ```bash
@@ -38,7 +38,7 @@ services first, then the database and the temp directory they were using.
 | `bun run tour`  | boots the same app, narrates every package, shuts down, exits 0      |
 
 The tour is what CI runs. It is the end-to-end check that the whole DI graph builds
-and that every package still does what its comments claim - `bun start` cannot be
+and that every package still does what its comments claim. `bun start` cannot be
 that check, because a service never exits.
 
 ## What is mounted
@@ -101,8 +101,8 @@ starts answering `503` while the port is still open, waits `drainDelayMs`, and o
 then does the socket close. `/api/health/live` keeps answering `200` throughout, so
 nothing decides to restart a pod that is already leaving.
 
-`bun run tour` also boots a **second node** for `/chat` - a second `Bun.serve`
-and a second container in the same process - and relays a publish between the
+`bun run tour` also boots a **second node** for `/chat`: a second `Bun.serve`
+and a second container in the same process. It relays a publish between the
 two through Redis, asserting one delivery per client.
 
 Node A relays with `@dunx/http`'s `RedisRelay`; node B relays through the app's
@@ -114,8 +114,8 @@ With no Redis running it says it is skipping and the app still exits 0.
 ### Where a handler runs
 
 `bun start` works the queues as well as serving them. There is no second command,
-and **nothing in `main.ts` says so** - `JobsModule` sets `consume: true` on its
-`QueueModule`, and the container starts the workers at `onInit` and stops them at
+and **nothing in `main.ts` says so**: `JobsModule` sets `consume: true` on its
+`QueueModule`. The container starts the workers at `onInit` and stops them at
 `onShutdown`, before the database they use closes.
 
 A queue runs in a **forked child** when a handler asks for one:
@@ -234,8 +234,8 @@ exercises a 03:00 cron without waiting for 03:00.
 
 ## Logging
 
-`@dunx/http` writes the entry, and `requestLogging` in
-[src/main.ts](./src/main.ts) is all this app configures - the bodies come
+`@dunx/http` writes the entry. `requestLogging` in
+[src/main.ts](./src/main.ts) is all this app configures: the bodies come
 from `LOG_REQUEST_BODY` and `LOG_RESPONSE_BODY`, and `/api/_dunx` is skipped.
 Nothing here writes a request line by hand;
 [src/http/request-trail.ts](./src/http/request-trail.ts) is a middleware of the
@@ -270,7 +270,7 @@ Everything the *handler* logs in between still carries `requestId`, `method`,
 `AsyncLocalStorage`. An inbound `x-request-id` is honoured so a trace survives
 across services; otherwise one is minted and returned on the response.
 
-An unmatched path is logged too. Bun answers a miss itself and the middleware chain
-would never see it, so `@dunx/http` installs one `fetch` fallback that puts the
-global middleware in front of a `{"error":"NOT_FOUND","status":404}` - Bun is still
-the router.
+An unmatched path is logged too. Bun answers a miss itself, and the middleware
+chain would never see it, so `@dunx/http` installs one `fetch` fallback that puts
+the global middleware in front of a `{"error":"NOT_FOUND","status":404}`. Bun is
+still the router.

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -235,7 +235,8 @@ exercises a 03:00 cron without waiting for 03:00.
 ## Logging
 
 `@dunx/http` writes the entry. `requestLogging` in
-[src/main.ts](./src/main.ts) is all this app configures: the bodies come
+[src/http/http-options.ts](./src/http/http-options.ts) is all this app
+configures: the bodies come
 from `LOG_REQUEST_BODY` and `LOG_RESPONSE_BODY`, and `/api/_dunx` is skipped.
 Nothing here writes a request line by hand;
 [src/http/request-trail.ts](./src/http/request-trail.ts) is a middleware of the

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -34,9 +34,9 @@ Constructor injection needs no decorator and no `@Inject()`, because
 records them for the container. That preload is how it runs.
 
 Leave it out and boot fails with an error naming the class and telling you to add
-it - never a silent `undefined`. Same for a parameter whose type is erased (an
-interface, a primitive, a union): that is a boot error naming the parameter, which
-is the wart `emitDecoratorMetadata` has and dunx does not.
+it - never a silent `undefined`. The same is true for a parameter whose type is
+erased (an interface, a primitive, a union): that is a boot error naming the
+parameter. `emitDecoratorMetadata` has this wart; dunx does not.
 
 ## A provider
 
@@ -74,11 +74,11 @@ export class GreetingsController {
 }
 ```
 
-`Bun.serve` does the routing. dunx does not ship a JavaScript router - path
-params, per-method dispatch and method-miss 404s are Bun's, natively.
+`Bun.serve` does the routing, natively: path params, per-method dispatch and
+method-miss 404s are Bun's. dunx does not ship a JavaScript router.
 
-Without a `params` schema a path param arrives as a string on `input.req.params`.
-Declare one and it is validated and typed instead - see
+Declare a `params` schema and a path param is validated and typed; without one,
+it arrives as a plain string on `input.req.params`. See
 [`examples/full/src/users`](../full/src/users) for that.
 
 ## A module
@@ -101,8 +101,8 @@ await app.closed;
 ```
 
 `create()` builds the container and discovers routes. `listen()` builds the
-`Bun.serve` route table - everything between the two (`setGlobalPrefix`, `use`,
-`enableCors`) still gets to shape it, and after it every one of them throws.
+`Bun.serve` route table. Everything between the two (`setGlobalPrefix`, `use`,
+`enableCors`) still gets to shape it; after it, every one of them throws.
 
 You get request logging for free: one JSON line per request carrying the request
 and the response together, at `warn` for a 4xx and `error` for a 5xx.

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -1,7 +1,7 @@
 # @dunx/example-testing
 
 How you test a dunx app. A small service with one external collaborator and one
-guard, and the two test files that exercise them.
+guard, plus the two test files that exercise them.
 
 ```bash
 bun install
@@ -32,16 +32,16 @@ const app = await createTestApp({
 });
 ```
 
-No `IForecastClient`, no factory indirection, no mocking framework. dunx resolves
-by class, so binding a different class to the same token reaches every consumer.
-`bun test` already ships `mock()` and `spyOn()` if a single method on a returned
-instance is all you need.
+dunx resolves by class, so binding a different class to the same token reaches
+every consumer: no `IForecastClient`, no factory indirection, no mocking
+framework needed. `bun test` already ships `mock()` and `spyOn()` if a single
+method on a returned instance is all you need.
 
 ## Overrides replace; they never append
 
 This is the whole design, and it follows from the container being flat. `@dunx/core`
 collects every module's registrations into one list and **throws on a duplicate
-token** - so an override cannot be an extra module tacked on the end that wins,
+token**. An override cannot be an extra module tacked on the end that wins,
 because there is no "wins". Three consequences the tests assert:
 
 - **The discarded provider is never constructed.** Its constructor never runs, its
@@ -83,7 +83,7 @@ parts of the request path dunx wrote - not route matching, params, method dispat
 or upgrades, which are Bun's. Bun binds a socket in about a millisecond, so the
 real server is cheaper than the lie.
 
-Two differences from production, both deliberate: `port` is always 0, and
+Two differences from production, both intentional: `port` is always 0, and
 **`requestLogging` defaults to `false`** so a suite does not print one JSON line
 per assertion. Pass `requestLogging: true` to test the logging itself.
 
@@ -112,8 +112,8 @@ binds a key store with one known key.
 
 ## Websockets
 
-`@dunx/testing` ships no websocket client, because Bun implements `WebSocket`
-natively and wrapping it would add nothing:
+Bun implements `WebSocket` natively, and wrapping it would add nothing, so
+`@dunx/testing` ships no client of its own:
 
 ```ts
 const ws = new WebSocket(`${server.url.replace('http', 'ws')}chat`);

--- a/internal/bench/README.md
+++ b/internal/bench/README.md
@@ -4,8 +4,8 @@ A benchmark harness comparing `@dunx/http` with other backend frameworks and
 runtimes. Private workspace, never published.
 
 The point of this harness is not that dunx wins. The single most useful number it
-produces is the gap between `@dunx/http` and **raw `Bun.serve`**, because dunx is a
-layer on top of that exact API - the gap is dunx's own overhead and nothing else.
+produces is the gap between `@dunx/http` and **raw `Bun.serve`**. dunx is a layer
+on top of that exact API, so the gap is dunx's own overhead and nothing else.
 Everything below is written so that number, and the places dunx loses, are as hard
 to hide as the places it wins.
 
@@ -22,8 +22,8 @@ with the validator held constant. `validation` does the opposite: one framework 
 time, one step of work at a time, and every validator swapped through the same
 Standard Schema seam - which is how the `validate` scenario's cost gets split into
 parsing, the validator, and dunx. `db-modes` holds the framework, the SQL and the
-bytes on the wire constant and varies only whether the handler awaits its way to the
-row; it writes `results/db-modes.json`, and what it found is recorded in
+bytes on the wire constant, and varies only whether the handler awaits its way to
+the row. It writes `results/db-modes.json`, and what it found is recorded in
 `docs/architecture/constraints.md` under "Synchronous SQLite mode".
 
 ## What is measured
@@ -179,7 +179,7 @@ What the published run says: MVC costs **16% of `aspnet-minimal` on `plaintext`,
 20% on `json` and 31% on both `params` and `validate`**. Against the same figure
 for Nest on Fastify (12%, 14%, 18%, 15%) and for dunx on `Bun.serve` (2.0%, 4.5%,
 4.1%, 8.8%), MVC is the most expensive of the three programming models relative to
-its own floor - and still 2.4x NestJS-on-Fastify and 1.6x Spring in absolute
+its own floor. It is still 2.4x NestJS-on-Fastify and 1.6x Spring in absolute
 throughput, because the floor it is paying that tax on is a different height.
 `params` is where it costs most, which is route-value plus action-parameter model
 binding rather than dispatch.
@@ -191,9 +191,9 @@ startup number away and is what a .NET benchmark usually ships; it is not what
 either.
 
 Neither row logs. ASP.NET Core's hosting layer writes two Information entries per
-request out of the box, which is what the default template's `appsettings.json`
-turns off; both subjects do the same in the file you are reading, for the reason
-the `dunx` and `dunx-logging` split exists.
+request by default, which is what the default template's `appsettings.json` turns
+off. Both subjects do the same in the file you are reading, for the reason the
+`dunx` and `dunx-logging` split exists.
 
 #### Reading the Go, Rust, JVM and .NET rows fairly
 
@@ -221,8 +221,8 @@ so the pinning cannot be lost by launching the process another way.
 Without any of this a 32-core Go server would be measured against a
 single-threaded JavaScript one, which ranks the machine and not the framework.
 With them, the ranking is per-thread dispatch cost, which is the only thing the
-rest of this table has ever measured - and which is **not** what anyone deploying
-Go, Rust or .NET actually gets. Measured on the machine below at the same 64
+rest of this table has ever measured. It is **not** what anyone deploying Go, Rust
+or .NET actually gets. Measured on the machine below at the same 64
 connections: raw `net/http` goes from about 73k req/s at `GOMAXPROCS(1)` to about
 230k with all 32 cores, Axum from about 121k to about 503k, and `aspnet-minimal`
 from about 88k to about 377k. Neither Bun subject can move at all, because
@@ -238,13 +238,13 @@ for the JVM and .NET too - class or assembly loading and a JIT-free first reques
 are real costs both pay every boot, and they stay in the number.
 
 **JIT warmup.** Three seconds warms neither a JVM nor a .NET runtime, so `spring`,
-`aspnet-minimal` and `aspnet-mvc` get a 30-second unmeasured warmup instead,
-recorded per subject in the report and printed above the tables. Reporting a cold
-JVM would be exactly the kind of flattering measurement this file exists to avoid,
-pointed the other way, and .NET turned out to need it just as badly: measured,
-`aspnet-minimal` served 40k req/s on the `json` scenario after a 3-second warmup,
-was still climbing 20 seconds later and plateaued near 88k. Quoting the first
-number would have understated it by 2.2x.
+`aspnet-minimal` and `aspnet-mvc` get a 30-second unmeasured warmup instead. That
+figure is recorded per subject in the report and printed above the tables.
+Reporting a cold JVM would be exactly the kind of flattering measurement this file
+exists to avoid, pointed the other way. .NET turned out to need it just as badly:
+measured, `aspnet-minimal` served 40k req/s on the `json` scenario after a
+3-second warmup, was still climbing 20 seconds later and plateaued near 88k.
+Quoting the first number would have understated it by 2.2x.
 
 **The validator is not held constant across languages.** Inside JavaScript every
 subject validates with zod, which is what makes `validate` minus `json` readable.

--- a/internal/dashboard-ui/README.md
+++ b/internal/dashboard-ui/README.md
@@ -12,7 +12,7 @@ bun run typecheck
 
 This is a **real React + Mantine application** - the same one `internal/docs` and
 `internal/openapi-ui` are, sharing `@dunx/ui`'s theme and components. The backend
-package contains no React at all, and cannot: it is published as plain ESM plus
+package contains no React at all, and cannot. It is published as plain ESM plus
 `.d.ts`, and a consumer must not need React or a bundler installed to serve an
 HTML page.
 
@@ -24,10 +24,10 @@ egress. The UI therefore cannot be a dependency and cannot be an asset the brows
 requests. It is **text**, inlined into the HTML.
 
 `scripts/build.ts` runs the Vite build, folds any extracted CSS back into the
-JavaScript, escapes `</` so the string cannot close the `<script>` it lands in, and
-writes `packages/dashboard/src/ui-bundle.ts`. That file is **generated and
-committed**: `bun test` and `tsc --noEmit` have to work in a fresh clone without a
-Vite run, and the publish path must not depend on one. `packages/dashboard`'s
+JavaScript, and escapes `</` so the string cannot close the `<script>` it lands
+in. Then it writes `packages/dashboard/src/ui-bundle.ts`. That file is
+**generated and committed**: `bun test` and `tsc --noEmit` have to work in a
+fresh clone without a Vite run, and the publish path must not depend on one. `packages/dashboard`'s
 `build` script runs this first, so the committed copy cannot go stale.
 
 It is reached with `await import('./ui.js')` on the **first request for the page**,
@@ -40,7 +40,7 @@ importing it - importing it there would silently revert the split.
 Only the **meta** is embedded, in a
 `<script type="application/json" id="dunx-dashboard-meta">`: the mount path, the
 poll interval, whether commands are enabled, and where the API explorer lives.
-Everything else is fetched, which is the difference from the explorer's model - a
+Everything else is fetched, which is the difference from the explorer's model. A
 queue count embedded in HTML would be stale before it painted, and the JSON
 endpoints have to exist anyway so `curl` can reach them.
 
@@ -54,14 +54,15 @@ the two workspaces.
 cannot change while the process runs. `/api/runtime` and `/api/queues` are polled.
 
 `usePoll` schedules the next request when the last one **settles** rather than on a
-fixed interval, drops a response from a request that has been superseded, and keeps
-the previous data when a poll fails. All three showed up immediately: a five-second
-endpoint on a five-second poll otherwise opens a request per tick forever, switching
-queues repaints with the previous queue's jobs, and one failed poll blanks the page.
+fixed interval. It also drops a response from a request that has been superseded,
+and keeps the previous data when a poll fails. All three showed up immediately: a
+five-second endpoint on a five-second poll otherwise opens a request per tick
+forever, switching queues repaints with the previous queue's jobs, and one failed
+poll blanks the page.
 
 ## Keeping it small
 
 Every component costs bytes twice - once in JavaScript, once in the CSS file
-`src/styles.ts` has to import. Mantine ships one stylesheet per component and this
-imports only what it renders, so **adding a component means adding its CSS file**.
-A component that renders unstyled is almost always a missing line there.
+`src/styles.ts` has to import. Mantine ships one stylesheet per component, and
+this imports only what it renders. So **adding a component means adding its CSS
+file**. A component that renders unstyled is almost always a missing line there.

--- a/internal/docs/README.md
+++ b/internal/docs/README.md
@@ -3,8 +3,8 @@
 The documentation site for dunx: **React + Mantine over Vite**, built to static
 output and deployed to GitHub Pages at <https://petarzarkov.github.io/dunx>.
 
-Private, never published. Per CLAUDE.md, `tools/*` may depend on anything -
-The dependency rules govern what dunx _ships_, not what builds its website.
+Private, never published. Per CLAUDE.md, `tools/*` may depend on anything: the
+dependency rules govern what dunx _ships_, not what builds its website.
 
 ```bash
 bun run docs:dev      # extract, then serve with HMR
@@ -15,7 +15,7 @@ bun run docs:build    # extract, then build to internal/docs/dist
 
 It was `Bun.build` - `bun build ./index.html` did the same job in 41 ms against
 Vite 5's 1.7 s, at ~25% more gzipped JS. Vite 8 is Rolldown, which removed the
-speed argument, and Mantine plus `@mantine/charts`/recharts had grown the size
+speed argument. Mantine plus `@mantine/charts`/recharts had also grown the size
 one. Re-measured on this site, same content, `gzip -9`:
 
 | Bundler            | JS raw    | JS gzip      | CSS gzip | Build   |
@@ -26,8 +26,8 @@ one. Re-measured on this site, same content, `gzip -9`:
 83.5 KB less over the wire for 150 ms nobody waits on. Two consequences worth
 knowing before reversing it: text imports are Vite's `?raw` rather than
 `with { type: 'text' }` (typed by `src/env.d.ts`, taught to `bun test` by
-`happydom.ts`), and `public/` copying and the `dist/` clean are Vite's rather
-than a hand-written `scripts/build.ts`.
+`happydom.ts`). The other is that `public/` copying and the `dist/` clean are
+Vite's rather than a hand-written `scripts/build.ts`.
 
 ## What the site is made of
 
@@ -76,7 +76,7 @@ Measured, `gzip -9`, entry chunk only - which is all `#/` downloads:
 
 329.1 KB less on the landing page, 55% of it. The sum over *every* chunk goes the
 other way, 2529.9 KB to 2554.8 KB raw and 595.2 KB to 626.3 KB gzipped, because
-each chunk is compressed against its own dictionary - the trade is deliberate:
+each chunk is compressed against its own dictionary. The trade is deliberate:
 nobody downloads all 30.
 
 **`chunks.ts` is generated rather than a glob.** `import.meta.glob` is a Vite
@@ -106,13 +106,13 @@ is not the one on the docs site. `siteMarkdown` in `scripts/content.ts` drops:
   **Packages**
 
 Matching is on the heading's slug with a `-` word boundary, so
-`## Install it as a devDependency` goes with `## Install`, and `## Setup` - which
-is API documentation in `@dunx/transform` - stays. Nested `###` headings go with
+`## Install it as a devDependency` goes with `## Install`. `## Setup`, which is
+API documentation in `@dunx/transform`, stays. Nested `###` headings go with
 their parent `##`. Fenced code is tracked, so the `# bunfig.toml` inside
 `packages/transform/README.md`'s example is not mistaken for a heading.
 
 **Naming a section is how an author chooses.** Content worth keeping should not
-live under one of those headings; `@dunx/testing`'s single-copy-of-`@dunx/core`
+live under one of those headings. `@dunx/testing`'s single-copy-of-`@dunx/core`
 reasoning sits under `## Install it as a devDependency` and is therefore not on
 the site.
 

--- a/internal/notes/research/README.md
+++ b/internal/notes/research/README.md
@@ -37,11 +37,11 @@ verified facts alone, in the format
 [architecture/constraints.md](../../../docs/architecture/constraints.md) uses, ready to be
 appended there once the record is reviewed.
 
-All twelve records are in. Two of the six defects below have since been fixed and
-two of the verdicts have shipped; the rows say which. The serialization one carries the logger performance
-question, and it lands where
-[arkv-logger-transports](./arkv-logger-transports.md) pointed: the write is 4 to 9
-percent of a log call and entry assembly plus sanitization is the rest. A fused
+All twelve records are in. Two of the six defects below have since been fixed,
+and two of the verdicts have shipped; the rows say which. The serialization one
+carries the logger performance question, and it lands where
+[arkv-logger-transports](./arkv-logger-transports.md) pointed. The write is 4 to
+9 percent of a log call, and entry assembly plus sanitization is the rest. A fused
 walk that redacts while serializing is 3.09x on Bun and 1.69x on Node, 44 of 44
 corpus payloads byte-identical.
 
@@ -51,14 +51,14 @@ These are not features and do not wait on a roadmap decision.
 
 1. ~~**`ClientAddress` trusts the wrong end of `X-Forwarded-For`.**~~ **Fixed.**
    It took `.split(',')[0]`, the leftmost entry, which is the one a client
-   appends, so a caller could set its own address and bypass any IP-keyed limiter
-   by rotating one header. `ClientAddress` now counts trusted hops from the right,
+   appends. So a caller could set its own address and bypass any IP-keyed
+   limiter by rotating one header. `ClientAddress` now counts trusted hops from the right,
    `true` meaning one proxy, and clamps a count longer than the header to the
    leftmost entry. The setting is `app.set('trust proxy', n)`; the record below
    still spells it `trustProxy`. This unblocked [throttle](./throttle.md), which
    found it.
 2. ~~**`@dunx/mcp` drops JSON-RPC batches.**~~ **Fixed.** A batch is an array with
-   no `id`, so it fell through to the notification check and was answered with
+   no `id`, so it fell through to the notification check. It was answered with
    silence while the client held an outstanding id. `protocol.ts` now has a
    `rejection()` step ahead of that check which answers an array with `-32600`
    and a message naming the protocol revision. See [rpc](./rpc.md).
@@ -66,17 +66,17 @@ These are not features and do not wait on a roadmap decision.
    **Correction to that record, and it is what the fix followed.**
    [rpc](./rpc.md) reads the absence of batch handling as the defect, which would
    have made implementing it the fix. MCP **removed** JSON-RPC batching in
-   2025-06-18, listed first among that revision's major changes, and
+   2025-06-18, listed first among that revision's major changes.
    `PROTOCOL_VERSION` in the same file is `2025-06-18`. A batch is therefore not a
    request this server can answer, so the defect was the silence rather than the
    missing feature.
 3. ~~**`@arkv/logger` loses buffered entries on SIGTERM.**~~ **Not a defect.**
    [arkv-logger-transports](./arkv-logger-transports.md) reports that a batched
-   entry is lost on SIGTERM unless some handler is installed and that
-   `captureGlobalErrors` installs none, which is true. It is also documented and
+   entry is lost on SIGTERM unless some handler is installed, and that
+   `captureGlobalErrors` installs none. Both are true. It is also documented and
    deliberate: `packages/logger/README.md` states that installing a SIGINT or
    SIGTERM listener suppresses default termination, which is the host's decision
-   and not a logger's, and tells the caller to call `logger.close()` from its own
+   and not a logger's. It tells the caller to call `logger.close()` from its own
    shutdown hook.
 
    dunx already does. `packages/infra/src/logger/module.ts:79-82` calls
@@ -94,9 +94,9 @@ These are not features and do not wait on a roadmap decision.
 5. **`findNestedError` walks a typed array element by element.** It runs on the
    caller's object before sanitization looking for an `Error`, and treated a typed
    array as a plain object. No element of one can be an `Error`. A 64 KiB
-   `Uint8Array` cost 24 ms of blocked event loop per log call and a 1 MiB buffer
-   cost 1,415 ms, so `logger.info('upload', { body })` stalled a service for over a
-   second. One `ArrayBuffer.isView` guard. Found by
+   `Uint8Array` cost 24 ms of blocked event loop per log call, and a 1 MiB buffer
+   cost 1,415 ms. So `logger.info('upload', { body })` stalled a service for over
+   a second. One `ArrayBuffer.isView` guard. Found by
    [arkv-logger-serialization](./arkv-logger-serialization.md), which was looking
    for something else.
 6. **`shouldMask` lowercases the whole mask list once per key.** A twenty-key entry
@@ -192,10 +192,10 @@ be remembered rather than done first.
    folding the principal onto the one store instead of nesting a second
    `AsyncLocalStorage` in `AuthContext`, worth 363.7 ns to 26.0 ns on an
    authenticated request. `packages/auth/src/context.ts` documents why there are
-   two: `RequestContext` is the log record, every field in it is serialized into
-   every line the request writes, so a session object there is noise on each
-   entry and a redaction hazard in the ones that matter. Only `userId` goes in,
-   which is what correlates the lines without carrying the principal.
+   two: `RequestContext` is the log record, and every field in it is serialized
+   into every line the request writes. So a session object there would be noise
+   on each entry, and a redaction hazard in the ones that matter. Only `userId`
+   goes in, which is what correlates the lines without carrying the principal.
 
    A symbol-keyed field would survive `getContext()`'s spread while staying
    invisible to `JSON.stringify` and to any sanitizer walking string keys, so the

--- a/internal/ui/README.md
+++ b/internal/ui/README.md
@@ -29,7 +29,7 @@ explorer used are still used by this package's own `MethodBadge`, `StatusBadge` 
 
 - `Prose` was a rich version in `docs` and a thinner one in `openapi-ui`, so the
   same markdown rendered differently depending on which page you opened it in.
-- `ColorSchemeToggle` was correct in `docs` and buggy in `openapi-ui` - the
+- `ColorSchemeToggle` was correct in `docs` and buggy in `openapi-ui`. The
   explorer's first click was a no-op on a dark-OS machine, because it read the
   stored `auto` rather than the computed scheme.
 - `statusColor` and `METHOD_COLOR` lived in the explorer's `model.ts`, where the
@@ -44,9 +44,9 @@ component only one page has stays on that page.
 Two things it must **not** grow:
 
 - **A union that another package already declares.** `methodColor` and
-  `jobStateColor` take a plain `string` and fall back to grey on purpose:
+  `jobStateColor` take a plain `string` and fall back to grey on purpose.
   `HttpMethod` is `@dunx/http`'s, `OperationKey` is `@dunx/openapi`'s and
-  `JOB_STATES` is `@dunx/dashboard`'s, and a fourth here would only ever be
+  `JOB_STATES` is `@dunx/dashboard`'s, so a fourth here would only ever be
   converted to and from those three.
 - **A dependency.** Icons are inline paths rather than an icon package -
   `@tabler/icons-react` is 20 MB installed, and two of the three consumers inline

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -3,11 +3,13 @@
 [Better Auth](https://better-auth.com) for
 [dunx](https://github.com/petarzarkov/dunx).
 
-**This package is not an authentication system.** better-auth is, and it is very
-good at it. This is the wiring: a module that builds the instance from your
-`ConfigService`, five routes that mount its handler, a guard that composes with
-the `@Public()` and `@Roles()` metadata `@dunx/http` already carries, and two
-adapters that let it drive Bun's own APIs.
+This package wires better-auth into dunx: a module that builds the instance
+from your `ConfigService`, five routes that mount its handler, a guard that
+composes with the `@Public()` and `@Roles()` metadata `@dunx/http` already
+carries, and two adapters that let it drive Bun's own APIs.
+
+better-auth handles authentication itself; this package does not reimplement
+it.
 
 There is no dunx sign-in flow, no dunx session table and no dunx OAuth. Each is
 a better-auth feature reached through `AuthModule.forRoot`'s options, which
@@ -68,15 +70,15 @@ The [Authentication guide](../../docs/guide/17-authentication.md) is canonical.
 
 ## Notes
 
-- dunx ships no schema for better-auth's tables. They are better-auth's, they
-  change with its plugins, and `bunx @better-auth/cli generate` writes them.
+- dunx ships no schema for better-auth's tables: they belong to better-auth
+  and change with its plugins. `bunx @better-auth/cli generate` writes them.
   Export them under the singular model names the adapter looks up.
-- Under `setGlobalPrefix`, `basePath` is what better-auth matches and `mountAt`
+- Under `setGlobalPrefix`, `basePath` is what better-auth matches. `mountAt`
   is where the route is mounted. Omitting `mountAt` with a non-default
   `basePath` is a boot error.
 - `AuthContext` is a second `AsyncLocalStorage` store rather than a key in
-  `RequestContext`, because everything in that store is serialized into every
-  log line the request writes.
+  `RequestContext`. Everything in that store is serialized into every log
+  line the request writes.
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,8 +5,8 @@ The dependency injection container, modules, lifecycle, configuration, and the
 [dunx](https://github.com/petarzarkov/dunx).
 
 **Zero dependencies.** That is a constraint rather than a coincidence: it lets
-`@dunx/http` inject a logger without pulling a logging implementation in behind
-it.
+`@dunx/http` inject a logger without pulling in a logging implementation
+behind it.
 
 ## Install
 
@@ -58,14 +58,15 @@ preload = ["@dunx/transform/preload"]
 ## Notes
 
 - **The container is scoped.** Every module reference is a scope holding what it
-  declares, `exports` is its public surface, and `global: true` publishes those
-  exports app-wide. An absent `exports` exports nothing.
+  declares. `exports` is its public surface, and `global: true` publishes
+  those exports app-wide. An absent `exports` exports nothing.
 - A parameter whose type erases - an interface, a primitive, a union, a
   type-only import - is a **boot error naming that parameter**, not a silent
   `undefined`. A parameter with a default keeps its default instead.
-- Two contracts are always resolvable: `Logger` defaults to `ConsoleLogger` and
-  `RequestContext` to `AsyncLocalStorage`, so `@dunx/http` can log every request
-  in an app that imported no logging module. A module binding either one wins.
+- Two contracts are always resolvable: `Logger` defaults to `ConsoleLogger`, and
+  `RequestContext` to `AsyncLocalStorage`. This lets `@dunx/http` log every
+  request in an app that imported no logging module. A module binding either
+  one wins.
 - `ConsoleLogger` batches `info` and below into one write per event-loop turn;
   `warn` and above are never batched and flush what is queued behind them.
 

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -57,8 +57,8 @@ way to read this on a box with no browser. The queues page is bull-board's.
 
 ## Three things that are decisions
 
-- **`authorize` has no default**, and leaving it out serves the page to anyone
-  who can reach the port. Omitting it logs a warning naming the mount at boot.
+- **`authorize` has no default.** Leaving it out serves the page to anyone who
+  can reach the port. Omitting it logs a warning naming the mount at boot.
 - **A rejected request gets 404, not 403.** Register the middleware **ahead of
   any session guard**: a guard running first answers 401 and tells a prober the
   mount exists. `authorize` takes the raw `Request` so it can be self-sufficient.
@@ -67,9 +67,9 @@ way to read this on a box with no browser. The queues page is bull-board's.
 
 ## Notes
 
-- It depends on `@dunx/infra` and `bullmq` not at all. `QueueSource` and
-  `RedisProbe` restate structurally what `JobPublisher` and `RedisConnection`
-  already are, so `queues: publisher` is the whole wiring.
+- `QueueSource` and `RedisProbe` restate structurally what `JobPublisher` and
+  `RedisConnection` already are, so `queues: publisher` is the whole wiring.
+  It depends on neither `@dunx/infra` nor `bullmq`.
 - The board is built on the first request for the queues page, never at boot, so
   an app that never opens it holds no broker socket.
 - `commands: false` maps onto bull-board's own `readOnlyMode`.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -1,8 +1,9 @@
 # @dunx/http
 
-`Bun.serve` adapter for [dunx](https://github.com/petarzarkov/dunx). Class-based
-controllers **and WebSocket gateways**, standard decorators, and no JavaScript
-router - Bun's native `routes` does path params and per-method dispatch in Zig.
+`Bun.serve` adapter for [dunx](https://github.com/petarzarkov/dunx): class-based
+controllers, **WebSocket gateways**, and standard decorators. There is no
+JavaScript router - Bun's native `routes` does path params and per-method
+dispatch in Zig.
 
 `Bun.serve` takes `routes` and `websocket` in one call, so both live here: one
 `listen()`, one server, one port. No `express`, no `ws`, no `socket.io`.
@@ -89,7 +90,7 @@ from, and it may change in any release.
 - Handlers may return a `Response`, any JSON-serialisable value, or `undefined`
   for a 204.
 - Schemas, parsers and the status resolve at boot into the same closure the
-  middleware chain folds into, so a request reads no metadata and does no lookup.
+  middleware chain folds into. A request reads no metadata and does no lookup.
 
 ## License
 

--- a/packages/infra/README.md
+++ b/packages/infra/README.md
@@ -9,7 +9,7 @@ Where Bun ships the primitive, the primitive is what runs: `Bun.SQL`,
 `Bun.Image`, `Bun.cron`. No `pg`, no `better-sqlite3`, no `ioredis`, no
 `@aws-sdk`, no `glob`, no `sharp`.
 
-Three areas integrate a mature library rather than hand-rolling one, and each of
+Three areas integrate a mature library rather than hand-rolling one. Each of
 those drives a Bun API underneath. `drizzle-orm` and `bullmq` are **optional peer
 dependencies**, so an app using only `/files` installs neither.
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -19,6 +19,7 @@ bun add @dunx/openapi zod
 and ArkType work for validation too, but the OpenAPI document needs JSON Schema,
 and only zod has `z.toJSONSchema`. A non-zod schema validates at runtime and
 appears as a permissive entry in the document, with a warning at generation time.
+
 `swagger-ui-dist` is a regular dependency - nobody writes code against it, so
 nobody has a version opinion about it.
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -4,9 +4,10 @@ An OpenAPI 3.1 document generated from the routes an app already has, with
 **Swagger UI** served from the same `Bun.serve` as everything else.
 
 The difference from a reflection-based generator is what it reads. A route's
-schemas are the objects the request path validates against. Its metadata is
-what its guards enforce. Both are already on the route, so the document is not a
-second description that can drift from the first.
+schemas are the objects the request path validates against. Its security
+metadata (`@Public()`, `@Roles()`) is what its guards enforce. Both are already
+on the route, so the document is not a second description that can drift from
+the first.
 
 ## Install
 
@@ -15,10 +16,11 @@ bun add @dunx/openapi zod
 ```
 
 `zod` is a peer dependency. Route validation targets Standard Schema, so Valibot
-and ArkType work for validation too, but hoisting a schema into
-`components/schemas` needs `z.toJSONSchema`, which is zod's. `swagger-ui-dist` is
-a regular dependency - nobody writes code against it, so nobody has a version
-opinion about it.
+and ArkType work for validation too, but the OpenAPI document needs JSON Schema,
+and only zod has `z.toJSONSchema`. A non-zod schema validates at runtime and
+appears as a permissive entry in the document, with a warning at generation time.
+`swagger-ui-dist` is a regular dependency - nobody writes code against it, so
+nobody has a version opinion about it.
 
 ## Usage
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -4,7 +4,7 @@ An OpenAPI 3.1 document generated from the routes an app already has, with
 **Swagger UI** served from the same `Bun.serve` as everything else.
 
 The difference from a reflection-based generator is what it reads. A route's
-schemas are the objects the request path validates against, and its metadata is
+schemas are the objects the request path validates against. Its metadata is
 what its guards enforce. Both are already on the route, so the document is not a
 second description that can drift from the first.
 
@@ -14,8 +14,8 @@ second description that can drift from the first.
 bun add @dunx/openapi zod
 ```
 
-`zod` is a peer dependency: route validation targets Standard Schema, so Valibot
-and ArkType work for validation, but hoisting a schema into
+`zod` is a peer dependency. Route validation targets Standard Schema, so Valibot
+and ArkType work for validation too, but hoisting a schema into
 `components/schemas` needs `z.toJSONSchema`, which is zod's. `swagger-ui-dist` is
 a regular dependency - nobody writes code against it, so nobody has a version
 opinion about it.
@@ -39,8 +39,8 @@ await app.listen(3000);
 // GET /api/openapi.json  the document
 ```
 
-`forRootAsync` takes a factory that may inject, which is what an app needs to
-read its title off `ConfigService` or to contribute another library's schema.
+`forRootAsync` takes a factory that may inject, so an app can read its title off
+`ConfigService` or contribute another library's schema.
 
 ## What is here
 
@@ -64,7 +64,7 @@ return type to it at compile time instead of validating every response.
 ## Notes
 
 - `.meta({ id })` on a zod schema is what hoists it into `components/schemas`.
-  Without an id it is inlined at every use site, and `.strict()` after `.meta()`
+  Without an id it is inlined at every use site. `.strict()` after `.meta()`
   discards the metadata, so put `.meta()` last.
 - Prose belongs in `description`. Swagger UI labels a schema by `title`, which
   `@dunx/openapi` fills with the component name.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,8 +2,8 @@
 
 The container an app already has, with named bindings **replaced in place**, plus
 a real `Bun.serve` on port 0. Bun binds a socket in about a millisecond, so the
-thing under test is the thing that ships: there is no mocking framework, no fake
-request object and no in-memory transport.
+thing under test is the thing that ships. There is no mocking framework, no fake
+request object, and no in-memory transport.
 
 ## Install
 
@@ -51,10 +51,10 @@ The [Testing guide](../../docs/guide/11-testing.md) is canonical.
   stubbing `Logger` need not know how many modules bind it. Naming a token
   nobody binds is an error rather than a silent no-op.
 - The replacement happens before anything resolves, so the discarded provider is
-  never constructed: its `useFactory` never runs and its `onInit` never fires,
-  which makes overriding a database safe.
+  never constructed: its `useFactory` never runs and its `onInit` never fires.
+  That makes overriding a database safe.
 - Request logging and boot logging are off unless asked for.
-- An `HttpOptions` field not passed is absent; nothing is inherited from
+- An `HttpOptions` field not passed stays absent. Nothing is inherited from
   production. `middleware` and `onError` change what the application does, so
   pass the same object `main.ts` passes.
 

--- a/packages/transform/README.md
+++ b/packages/transform/README.md
@@ -36,8 +36,8 @@ await Bun.build({ entrypoints: ['src/main.ts'], plugins: [depsPlugin] });
 
 ## What it does
 
-It parses each file with `oxc-parser`, reads every class declaration's constructor
-parameter types, and appends one statement per class:
+It parses each file with `oxc-parser` and reads every class declaration's
+constructor parameter types. Then it appends one statement per class:
 
 ```ts
 Object.defineProperty(UsersService, Symbol.for('dunx.deps'), {
@@ -51,15 +51,15 @@ The record is a **thunk**, so it is evaluated when the container resolves the cl
 rather than when the module is defined. A dependency declared later in the file, or
 reached through a circular import, therefore needs no `forwardRef`.
 
-Only the appended statement is added - every other byte of the original source is
+Only the appended statement is added. Every other byte of the original source is
 preserved, so comments, formatting, and the line numbers in stack traces are
 unchanged.
 
 ## Parameters it will not guess
 
 A parameter whose type names nothing that exists at runtime is recorded as
-`unresolved` together with its original source text, and the container throws at
-boot:
+`unresolved`, together with its original source text. The container then throws
+at boot:
 
 ```
 UsersService cannot be constructed: parameter 2 (private readonly cfg: AppConfig)

--- a/tools/create-app/README.md
+++ b/tools/create-app/README.md
@@ -40,8 +40,8 @@ There is no flag for choosing features. The command opens a list:
 | Ctrl+C, Esc     | Stop, having written nothing                  |
 
 `◉` is chosen, `◈` is pulled in by something else you chose, `○` is neither. The
-two lines under the list update as you go: what your selection drags in, and which
-of it needs Redis or Postgres running to do anything.
+two lines under the list update as you go: one shows what your selection drags in,
+the other shows which of it needs Redis or Postgres running to do anything.
 
 Three more questions appear only when there is something to ask: a directory, when
 the command line named none; a package name, when the directory's is one npm would
@@ -56,9 +56,10 @@ reject; and whether to write into a directory that already has files in it.
 | `--yes`, `-y`   | off                | Skip the questions, take the minimal template |
 | `--help`        |                    | Print usage                                   |
 
-**Piped, redirected or in CI it asks nothing** and writes the minimal template, so
-a script never hangs on a question nothing can answer. To choose features without
-a terminal, call [`scaffold`](#programmatic-use) rather than passing flags.
+**Piped, redirected or in CI it asks nothing.** It writes the minimal template
+instead, so a script never hangs on a question nothing can answer. To choose
+features without a terminal, call [`scaffold`](#programmatic-use) rather than
+passing flags.
 
 The name is validated against npm's rules **before** anything is created, because
 an invalid one would otherwise surface as a confusing `bun install` failure inside
@@ -73,8 +74,8 @@ bunx @dunx/create-app .
 
 `.git`, `.gitkeep`, `.DS_Store` and `LICENSE` do not count as contents, so a fresh
 repo or a clone of an empty GitHub repository is a valid target without a question.
-Nothing else is ignored: `.gitignore` and `README.md` both come out of the template,
-and overwriting your copy of either is what the last question asks about.
+Nothing else is ignored: `.gitignore` and `README.md` both come out of the template.
+Overwriting your copy of either is what the last question asks about.
 
 ## What a composed app looks like
 
@@ -89,9 +90,10 @@ my-api/
   bunfig.toml        the transform preload
 ```
 
-Three files are generated for the selection and the feature directories are copied.
-`main.ts` is one file rather than two: a test imports `createApp` from it, and the
-`import.meta.main` block at the bottom is what stops that starting a server.
+Three files are generated for the selection, and the feature directories are just
+copied. `main.ts` is one file rather than two: a test imports `createApp` from it,
+and the `import.meta.main` block at the bottom stops that same import from
+starting a server.
 
 **There is no worker entry point, even with queues.** `QueueModule` is given
 `consume: true`, so the container opens the bullmq workers at `onInit` and closes
@@ -100,18 +102,21 @@ forked by bullmq itself into `src/jobs/jobs.processor.ts`.
 
 ## What it generates
 
-The `minimal` template, the same app as
-[`examples/minimal`](https://github.com/petarzarkov/dunx/tree/main/examples/minimal) a service, a controller, a module, `HttpFactory.create`, one test against a real
+The `minimal` template is the same app as
+[`examples/minimal`](https://github.com/petarzarkov/dunx/tree/main/examples/minimal):
+a service, a controller, a module, `HttpFactory.create`, one test against a real
 server, and the `bunfig.toml` preload line that makes constructor injection work.
 
-Its `src/` is a **byte-for-byte copy** of that example, and a test in this package
+Its `src/` is a **byte-for-byte copy** of that example. A test in this package
 fails if the two ever drift.
 
 Every app also gets an `AGENTS.md` naming its layout, its commands and the rules
 dunx fails at boot over, plus a `CLAUDE.md` pointing at it. Both link
 <https://petarzarkov.github.io/dunx/setup.md>, which is served per release, rather
-than copying the framework's own instructions into your repository. The example is the one CI boots, so keeping them
-identical is what makes the template trustworthy rather than merely plausible.
+than copying the framework's own instructions into your repository.
+
+The example is the one CI boots, so keeping them identical makes the template
+trustworthy rather than merely plausible.
 
 ## Two details
 
@@ -146,7 +151,7 @@ const { directory, files } = await scaffold({
 ```
 
 This is the scripted path the removed `--with` flag used to be. `features` takes
-the same names the list shows, in any order, and pulls in what they require;
+the same names the list shows, in any order, and pulls in what they require.
 `FEATURES` exports the set. Omitting it writes the minimal template.
 
 `scaffold` throws `ScaffoldError` for anything the caller can fix - an unknown

--- a/tools/create-app/templates/minimal/README.md
+++ b/tools/create-app/templates/minimal/README.md
@@ -26,12 +26,12 @@ preload = ["@dunx/transform/preload"]
 ```
 
 `@dunx/transform` reads each class's constructor parameter types when the file
-loads and records them, so the container can resolve them before calling `new`.
-Without it, providers are constructed with no arguments and boot fails saying so -
-it is not a silent `undefined`.
+loads and records them. The container uses that record to resolve them before
+calling `new`. Without it, providers are constructed with no arguments, and boot
+fails by naming the problem rather than returning a silent `undefined`.
 
 That is also why there is no `@Injectable()` and no `@Inject()`. Being listed in a
-module's `providers` is what makes a class injectable, and TC39 standard decorators
+module's `providers` is what makes a class injectable. TC39 standard decorators
 have no parameter decorators, so `@Inject()` does not exist.
 
 ## Next

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -11,7 +11,7 @@ bunx @dunx/mcp ./src/app.module.ts
 ```
 
 Point it at the file that declares your root module. `@Module` leaves a marker,
-so a module exported only by name is found on its own; `default` and `root` win
+so a module exported only by name is found on its own. `default` and `root` win
 if present, and `--export=<name>` settles a file that declares several. The path
 goes through `Bun.resolveSync`, so anything `import` accepts works.
 
@@ -38,14 +38,14 @@ The [Agent tooling guide](../../docs/guide/21-agent-tooling.md) is canonical.
 | `list_modules`     | The import graph                                          |
 | `describe_route`   | One route in full, with its schemas when `@dunx/openapi` is installed |
 
-Every filter is optional, and omitting one means everything, so a caller that
+Every filter is optional. Omitting one means everything, so a caller that
 knows nothing still gets a useful first answer.
 
 ## Notes
 
 - **It reads the app and never boots it.** `AppFactory.create` would open
-  database connections, start queue workers and run every `onInit`, so an agent
-  asking a question about the code would be running the code. The cost of that
+  database connections, start queue workers, and run every `onInit`. Asking a
+  question about the code would then mean running the code. The cost of that
   is no runtime state: the value of a config field is not answerable here.
 - It reads through the framework's own readers - `providersOf`, `modulesOf`,
   `routesOf`, `gatewaysOf` - so an answer cannot drift from what the container


### PR DESCRIPTION
## What

A readability pass across all 59 documentation files in the repo: guides, architecture docs, READMEs, and the migration guide.

## Why

The docs were technically thorough but read like compressed reference material. Dense multi-clause sentences, error cases before working examples, and defensive framing ("what it does not have") made the first impression harder than it needed to be.

## Changes

**Sentence structure:** Split sentences carrying 2-3 ideas into one-idea-per-sentence form across all files.

**Section ordering:** Moved error explanations and edge cases after working examples in guides 01-22.

**Framing:** Renamed "What it does not have" to "Design decisions" in the introduction. Reframed negative-first paragraphs across all guides and READMEs.

**Bridge sentences:** Added short transitional lines between major sections where topic jumps were abrupt.

**Bug fixes found along the way:**
- Markdown corruption in `bun-apis.md` (words run together with no space in code spans)
- Broken/incomplete sentence in `examples/databases/README.md`
- Grammatical fixes in `authentication.md` and `tools/create-app/README.md`
- Doubled-word typo in `cost-of-validation.md`
- Banned phrase "out of the box" in `internal/bench/README.md`
- 601-char paragraph over the 600-char budget in `cost-of-validation.md`

## What was NOT changed

- Code examples (untouched)
- Tables and benchmarks (untouched)
- Measurement numbers (untouched)
- Heading structure and topic organization (preserved)
- Technical accuracy (no claims added or removed)

## Verification

- `bun test scripts/no-slop.test.ts`: 5 pass, 0 fail
- `bun test scripts/no-em-dash.test.ts`: 1 pass, 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified setup, migration, testing, deployment, health-check, authentication, database, queue, logging, validation, and configuration guidance.
  * Expanded benchmark documentation with measured results, methodology, limitations, and reproducibility details.
  * Documented Bun-native routing, WebSocket behavior, storage errors, path traversal, module scoping, and dependency injection.
  * Updated examples and tooling guides with clearer runtime behavior, configuration, and usage instructions.
  * Improved wording, structure, consistency, and readability across project and package documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->