### PR TITLE
chore(bench): measure where request logging's 4.8 us goes

### DIFF
--- a/docs/architecture/cost-of-logging.md
+++ b/docs/architecture/cost-of-logging.md
@@ -11,43 +11,56 @@ inproc` answers that: it drives `RequestLoggingMiddleware.handle` directly, one
 variant per process, round-robin. A step there resolves to about 50 ns.
 
 The floor row runs the same loop with no middleware, so every other row minus the
-floor is what logging costs. That came to 4833 ns against the socket ladder's
+floor is what logging costs. That came to 4708 ns against the socket ladder's
 4780 ns, which is the check that the rig measures the same thing.
+
+**These figures come from one run of twenty-eight variants**, floor 1153 ns, seven
+rounds, the variant order rotated by round. Assembling these tables
+from several runs is what put two contradictory write costs on this page and a
+running total that disagreed with its own steps: the machine drifts by more than
+most of these rows are worth, so a number is only comparable to the numbers
+measured beside it.
 
 | Step                                       | this step | running total |
 | ------------------------------------------ | --------: | ------------: |
-| the middleware chain                       |     +8 ns |          8 ns |
-| the pathname sliced out of `req.url`       |    +50 ns |         57 ns |
-| the `ignore` and `ignorePrefix` checks     |     +9 ns |         56 ns |
-| `Bun.nanoseconds()`                        |    +71 ns |        106 ns |
-| `x-request-id` read                        |    +75 ns |        181 ns |
-| `crypto.randomUUID()`                      |   +147 ns |        328 ns |
-| the scope object                           |     +9 ns |        337 ns |
-| `runWithContext` around the handler        |   +144 ns |        481 ns |
-| `user-agent` and the request object        |   +141 ns |        621 ns |
-| `.then` and `x-request-id` on the response |   +616 ns |       1237 ns |
-| the `logger.info` call                     |  +2900 ns |       4137 ns |
+| the middleware chain                       |    +13 ns |         13 ns |
+| the pathname sliced out of `req.url`       |    +20 ns |         33 ns |
+| the `ignore` and `ignorePrefix` checks     |    +13 ns |         46 ns |
+| `Bun.nanoseconds()`                        |    +97 ns |        143 ns |
+| `x-request-id` read                        |    +80 ns |        223 ns |
+| `crypto.randomUUID()`                      |   +151 ns |        374 ns |
+| the scope object                           |    +28 ns |        402 ns |
+| `runWithContext` around the handler        |   +100 ns |        502 ns |
+| `user-agent` and the request object        |   +143 ns |        645 ns |
+| `.then` and `x-request-id` on the response |   +676 ns |       1321 ns |
+| the `logger.info` call                     |  +3387 ns |       4708 ns |
+
+The running total is the measured figure and the step is the difference between
+two of them, so the column adds up rather than carrying a rounding error per row.
+Three steps differ by 1 ns from what `bun run inproc` prints for the same run,
+which rounds both columns independently; standard deviations here run 17 to 141 ns.
 
 Two things in that table were not where anyone was looking. The `logger.info` call
-is 60% of request logging on its own. The `.then` continuation plus one
-`Headers.set` is 616 ns, the second largest item, and nothing has ever tried to
+is 72% of request logging on its own. The `.then` continuation plus one
+`Headers.set` is 676 ns, the second largest item, and nothing has ever tried to
 reduce it.
 
 ### The logger call, split further
 
-| What the logger does                      | over doing nothing |
-| ----------------------------------------- | -----------------: |
-| take the arguments and discard them       |                  - |
-| build the merged entry object             |           +1201 ns |
-| serialise a two-key entry, about 40 bytes |           +1314 ns |
-| build and serialise the entry, ~250 bytes |           +2656 ns |
-| and write it, batched                     |           +2906 ns |
+| What the logger does                    | over doing nothing |
+| --------------------------------------- | -----------------: |
+| take the arguments and discard them     |                  - |
+| build the merged entry object           |           +1155 ns |
+| build and serialise it, about 250 bytes |           +2270 ns |
+| and write it, batched                   |           +2555 ns |
 
-**The write is 97 ns of 4606.** Batching already took that cost, which is what
-makes a worker thread the wrong tool here: `pino` moves the write off the main
-thread with `thread-stream` and keeps serialising on it, and the thing that would
-move is already paid for. Moving serialisation instead means `postMessage`, whose
-structured clone costs more than the `JSON.stringify` it would replace.
+So the object is 1155 ns, `JSON.stringify` over it 1115, and **the write 285 ns of
+4708**, which is 6% of request logging. Batching already took that cost, and that
+is what makes a worker thread the wrong tool: `pino` moves the write off the main
+thread with `thread-stream` and keeps serialising on it, so the half that would
+move is the half already paid for. Moving serialisation instead means
+`postMessage`, whose structured clone costs more than the `JSON.stringify` it
+would replace.
 
 ### Rejected: a text format, and a compiled serialiser
 
@@ -57,38 +70,42 @@ differs from the control by one thing. Numbers are logging cost, floor subtracte
 
 | Variant                                           | ns/req | vs the control |
 | ------------------------------------------------- | -----: | -------------: |
-| the shipped `ConsoleLogger`                       |   4933 |         +97 ns |
-| the `merge` control                               |   4836 |              - |
-| `trim`, dropping `pid`, `flow` and `userAgent`    |   4574 |        -262 ns |
-| `lean`, about 120 bytes rather than 250           |   4010 |        -826 ns |
-| the same JSON built without a merged entry object |   4955 |        +119 ns |
-| that JSON written out longhand                    |   4688 |        -148 ns |
-| a serialiser compiled with `new Function`         |   5057 |        +221 ns |
-| logfmt instead of JSON                            |   6213 |       +1377 ns |
+| the shipped `ConsoleLogger`                       |   4823 |         +20 ns |
+| the `merge` control                               |   4803 |              - |
+| `trim`, dropping `pid`, `flow` and `userAgent`    |   4449 |        -354 ns |
+| `lean`, about 120 bytes rather than 250           |   3943 |        -860 ns |
+| the same JSON built without a merged entry object |   4912 |        +109 ns |
+| that JSON written out longhand                    |   4998 |        +195 ns |
+| a serialiser compiled with `new Function`         |   5013 |        +210 ns |
+| logfmt instead of JSON                            |   6002 |       +1199 ns |
 
-Text is 28% dearer than the JSON it replaces. `JSON.stringify` is native, and no
+Text is 25% dearer than the JSON it replaces. `JSON.stringify` is native, and no
 per-key walk in JavaScript beats it. A serialiser compiled for the known shape,
 which is the technique `pino` uses, is not faster either.
 
 The reason every reformatting lands within a couple of hundred nanoseconds is that
-the formatter was never the cost. A two-key entry of 40 bytes is 1342 ns cheaper
-than the 250-byte one through the same `JSON.stringify`, so what is being paid for
-is the size of the line and the objects behind it.
+the formatter was never the cost. `lean` goes through the same `JSON.stringify`
+and is 860 ns cheaper for writing about 120 bytes rather than 250, so what is being
+paid for is the size of the line and the objects behind it.
 
-That leaves one lever, and it has a price rather than being free. `lean` buys 826
-ns, 17% of request logging, by halving the entry: out go `method`, `event`,
-`context` and `statusCode`, which `message` already spells as "GET /json 200".
-Those are the fields a log pipeline filters and groups on, so the saving is
-observability spent on throughput. `trim` keeps all of them and drops only `pid`,
-`flow` and `request.userAgent`, and buys 262 ns against a standard deviation of
-103 to 176, which is close enough to the noise to want the 5950X before believing
-it.
+That leaves one lever, and it has a price rather than being free. `lean` buys 18%
+of request logging by halving the entry: out go `method`, `event`, `context` and
+`statusCode`, which `message` already spells as "GET /json 200". Those are the
+fields a log pipeline filters and groups on, so the saving is observability spent
+on throughput. `trim` keeps all of them and drops only `pid`, `flow` and
+`request.userAgent`, for 354 ns against standard deviations of 59 to 85.
+
+`fastjson` is the row that moved most since it was first measured, from 148 ns
+under the control to 195 ns over it, because four of its scope strings were being
+interpolated raw. Escaping them costs what the row was previously appearing to
+save, which is its own answer to whether hand-rolled JSON is worth writing.
 
 ### The header lever did not survive being measured
 
 The socket ladder puts +0.97 us on the first touch of `req.headers`, which would
 make it the second largest item on the path. In the rig above the two header reads
-cost 216 ns together. Probed directly on `Bun.serve`, a handler reading one header
+cost 224 ns together, 80 for `x-request-id` and 144 for `user-agent` with the
+request object built around it. Probed directly on `Bun.serve`, a handler reading one header
 was within noise of one reading none.
 
 The ladder's step is measured against its own +-0.5 us floor, and the section below
@@ -110,27 +127,26 @@ together per request, which is what the `precomp` rows do.
 
 | Variant                                 | logging ns | saved | % of `bun-serve`, json |
 | --------------------------------------- | ---------: | ----: | ---------------------: |
-| the shipped path                        |       4665 |     - |                  61.8% |
-| fragments, all twelve fields kept       |       3170 | 32.0% |                  69.7% |
-| fragments, `request.userAgent` dropped  |       2844 | 39.0% |                  71.7% |
-| build the line and never emit it        |       2280 | 51.0% |                      - |
-| emit a **constant** line every request  |       1680 | 64.0% |                  79.9% |
-| a five-field line, correlation given up |       1251 | 73.2% |                  83.3% |
+| the shipped path                        |       4708 |     - |                  61.8% |
+| fragments, all twelve fields kept       |       3266 | 30.6% |                  69.3% |
+| fragments, `request.userAgent` dropped  |       2912 | 38.1% |                  71.4% |
+| emit a **constant** line every request  |       1716 | 63.6% |                  79.7% |
+| a five-field line, correlation given up |       1211 | 74.3% |                  83.8% |
 
 The constant-line row is the bound worth keeping in mind: it does no per-request
-work at all and still writes 250 bytes, and it lands at 64.0%. The 80% target sits
-two points under that, so 80% is not a formatting problem and no faster serialiser
+work at all and still writes 250 bytes, and it lands at 63.6%, against the 63% and
+64% the target needs. So 80% is not a formatting problem and no faster serialiser
 reaches it. What reaches it is writing less.
 
-The last row does reach it, at 83.3%, and its bill is the whole feature set: no
+The last row does reach it, at 83.8%, and its bill is the whole feature set: no
 `AsyncLocalStorage` scope, so nothing else the request logs carries its id; no
 inbound `x-request-id` honoured and a process-local counter instead of a UUID, so
 an id does not span two services; no `user-agent`; no `x-request-id` on the
 response; and five fields where there were twelve.
 
 Keeping every field that a log pipeline filters or groups on, the reachable figure
-is **69.7% on json and 69.0% on plaintext**. Dropping only `user-agent` takes it
-to 71.7% and 71.2%.
+is **69.3% on json and 68.6% on plaintext**. Dropping only `user-agent` takes it
+to 71.4% and 70.9%.
 
 ### `@dunx/infra/logger` costs twice what the benchmark measures
 
@@ -145,9 +161,9 @@ It is consistent rather than surprising: arkv's own `bench.ts` put `Logger.info`
 at 1474 ns against `ConsoleLogger`'s 543 in the same kind of tight loop. The extra
 buys sanitization, async context and the transport stack.
 
-**Fixed upstream**, in `~/repos/arkv`, since that is where a fix reaches the
-owner's other projects. Two builds of the package compared in one process,
-alternating by round:
+**Fixed upstream** rather than here, since that is where a fix reaches the other
+projects using it: `petarzarkov/arkv#9`, released as **`@arkv/logger@0.13.0`**.
+Two builds of the package compared in one process, alternating by round:
 
 | arkv operation           | before | after | change |
 | ------------------------ | -----: | ----: | -----: |
@@ -225,15 +241,15 @@ the `getContext()` copy gone, the merge gone, `JSON.stringify` still there.
 
 | Variant                                  | logging ns | saved |
 | ---------------------------------------- | ---------: | ----: |
-| the shipped path                         |       4621 |     - |
-| `bound`, the entry object built directly |       4362 |  5.6% |
-| `precomp`, fragments and no object       |       3289 | 28.8% |
+| the shipped path                         |       4708 |     - |
+| `bound`, the entry object built directly |       4368 |  7.2% |
+| `precomp`, fragments and no object       |       3266 | 30.6% |
 
-**So a bound writer is worth 5.6%, and the merge was never the cost.** Building a
+**So a bound writer is worth 7.2%, and the merge was never the cost.** Building a
 twelve-key object costs about what merging two spreads into one costs, and `bound`
 still builds it. Only the fragment rows escape the object, and they escape the
-generic `JSON.stringify` with it. The gap between the two rows, 1073 ns of the
-1332 available, is what `Transport.write(entry, level)` costs.
+generic `JSON.stringify` with it. The gap between the two rows, 1102 ns of the
+1442 available, is what `Transport.write(entry, level)` costs.
 
 That splits the design in two, and only the second half is worth anything.
 
@@ -242,7 +258,7 @@ field name once instead of per entry, reserved-name collisions raised at bind ti
 rather than filed per entry, and a declared primitive type letting `makeSafeForJson`
 be skipped behind a `typeof` guard that falls back when the value is not what was
 declared. That last part matters: a `trusted` flag would be a hole in redaction,
-where a declared type is checkable. All of it buys 5.6%.
+where a declared type is checkable. All of it buys 7.2%.
 
 **A bound writer that emits a line** needs `Transport` to grow an optional
 `writeLine(line, level)`, and it can only be used when every transport offers one
@@ -258,13 +274,13 @@ line, so the writer has to compare what the store holds against what it compiled
 for and fall back per entry when they differ. And an error is per-call and cannot
 be compiled at all, so `error` stays on the generic path.
 
-What it is worth, end to end: 28.8% of request logging, which is 61.8% of
-`bun-serve` to about 69.7%. Not the 80% that started this, which needs the
+What it is worth, end to end: 30.6% of request logging, which is 61.8% of
+`bun-serve` to about 69.3%. Not the 80% that started this, which needs the
 five-field line and the loss of correlation recorded above.
 
 **Not built.** Two repos, a new contract in each, a fast path that applies to one
-transport and one formatter, and a fallback per entry to keep behaviour, for eight
-points of a benchmark. The 5.6% version is not worth a public API at all. Recorded
+transport and one formatter, and a fallback per entry to keep behaviour, for seven
+points of a benchmark. The 7.2% version is not worth a public API at all. Recorded
 here so the next person costs it from these numbers rather than from the guess this
 started as.
 

--- a/docs/architecture/cost-of-logging.md
+++ b/docs/architecture/cost-of-logging.md
@@ -2,6 +2,300 @@
 
 Where the default path's microseconds go, why `write(2)` per entry is the largest single cost, and what batching trades away.
 
+## Where the 4.8 us goes, measured without a socket, 2026-08-31
+
+`bun run logging` resolves a step to about half a microsecond, and the section
+below already records that six of its eleven steps land inside that. So the ladder
+could say request logging costs +4.78 us without saying which part. `bun run
+inproc` answers that: it drives `RequestLoggingMiddleware.handle` directly, one
+variant per process, round-robin. A step there resolves to about 50 ns.
+
+The floor row runs the same loop with no middleware, so every other row minus the
+floor is what logging costs. That came to 4833 ns against the socket ladder's
+4780 ns, which is the check that the rig measures the same thing.
+
+| Step                                       | this step | running total |
+| ------------------------------------------ | --------: | ------------: |
+| the middleware chain                       |     +8 ns |          8 ns |
+| the pathname sliced out of `req.url`       |    +50 ns |         57 ns |
+| the `ignore` and `ignorePrefix` checks     |     +9 ns |         56 ns |
+| `Bun.nanoseconds()`                        |    +71 ns |        106 ns |
+| `x-request-id` read                        |    +75 ns |        181 ns |
+| `crypto.randomUUID()`                      |   +147 ns |        328 ns |
+| the scope object                           |     +9 ns |        337 ns |
+| `runWithContext` around the handler        |   +144 ns |        481 ns |
+| `user-agent` and the request object        |   +141 ns |        621 ns |
+| `.then` and `x-request-id` on the response |   +616 ns |       1237 ns |
+| the `logger.info` call                     |  +2900 ns |       4137 ns |
+
+Two things in that table were not where anyone was looking. The `logger.info` call
+is 60% of request logging on its own. The `.then` continuation plus one
+`Headers.set` is 616 ns, the second largest item, and nothing has ever tried to
+reduce it.
+
+### The logger call, split further
+
+| What the logger does                      | over doing nothing |
+| ----------------------------------------- | -----------------: |
+| take the arguments and discard them       |                  - |
+| build the merged entry object             |           +1201 ns |
+| serialise a two-key entry, about 40 bytes |           +1314 ns |
+| build and serialise the entry, ~250 bytes |           +2656 ns |
+| and write it, batched                     |           +2906 ns |
+
+**The write is 97 ns of 4606.** Batching already took that cost, which is what
+makes a worker thread the wrong tool here: `pino` moves the write off the main
+thread with `thread-stream` and keeps serialising on it, and the thing that would
+move is already paid for. Moving serialisation instead means `postMessage`, whose
+structured clone costs more than the `JSON.stringify` it would replace.
+
+### Rejected: a text format, and a compiled serialiser
+
+Building the line was measured five ways against a `merge` control that runs
+`ConsoleLogger`'s own line-building on the same dispatch and batching, so a row
+differs from the control by one thing. Numbers are logging cost, floor subtracted:
+
+| Variant                                           | ns/req | vs the control |
+| ------------------------------------------------- | -----: | -------------: |
+| the shipped `ConsoleLogger`                       |   4933 |         +97 ns |
+| the `merge` control                               |   4836 |              - |
+| `trim`, dropping `pid`, `flow` and `userAgent`    |   4574 |        -262 ns |
+| `lean`, about 120 bytes rather than 250           |   4010 |        -826 ns |
+| the same JSON built without a merged entry object |   4955 |        +119 ns |
+| that JSON written out longhand                    |   4688 |        -148 ns |
+| a serialiser compiled with `new Function`         |   5057 |        +221 ns |
+| logfmt instead of JSON                            |   6213 |       +1377 ns |
+
+Text is 28% dearer than the JSON it replaces. `JSON.stringify` is native, and no
+per-key walk in JavaScript beats it. A serialiser compiled for the known shape,
+which is the technique `pino` uses, is not faster either.
+
+The reason every reformatting lands within a couple of hundred nanoseconds is that
+the formatter was never the cost. A two-key entry of 40 bytes is 1342 ns cheaper
+than the 250-byte one through the same `JSON.stringify`, so what is being paid for
+is the size of the line and the objects behind it.
+
+That leaves one lever, and it has a price rather than being free. `lean` buys 826
+ns, 17% of request logging, by halving the entry: out go `method`, `event`,
+`context` and `statusCode`, which `message` already spells as "GET /json 200".
+Those are the fields a log pipeline filters and groups on, so the saving is
+observability spent on throughput. `trim` keeps all of them and drops only `pid`,
+`flow` and `request.userAgent`, and buys 262 ns against a standard deviation of
+103 to 176, which is close enough to the noise to want the 5950X before believing
+it.
+
+### The header lever did not survive being measured
+
+The socket ladder puts +0.97 us on the first touch of `req.headers`, which would
+make it the second largest item on the path. In the rig above the two header reads
+cost 216 ns together. Probed directly on `Bun.serve`, a handler reading one header
+was within noise of one reading none.
+
+The ladder's step is measured against its own +-0.5 us floor, and the section below
+already records that one of its steps reads negative. Treat the +0.97 us as an
+artifact until the 5950X says otherwise, and do not design an option around it.
+
+### Getting to 80% of `bun-serve`, and what it costs
+
+`results/latest.json` on the 5950X has `dunx-logging` at 60.6% of `bun-serve` on
+plaintext and 61.8% on json. Reaching 80% means cutting 3.46 us and 3.29 us
+respectively, which is 63% and 64% of what request logging costs.
+
+Most of the line is the same on every request. `level`, `pid` and `flow` are
+constant for the process; `method`, `event` and `context` are constant for the
+route; `message` is "GET /json 200", so it is constant for the route and the
+status together. Only the timestamp, the request id, the user agent and the
+elapsed milliseconds vary. So the line can be cut into fragments once and roped
+together per request, which is what the `precomp` rows do.
+
+| Variant                                 | logging ns | saved | % of `bun-serve`, json |
+| --------------------------------------- | ---------: | ----: | ---------------------: |
+| the shipped path                        |       4665 |     - |                  61.8% |
+| fragments, all twelve fields kept       |       3170 | 32.0% |                  69.7% |
+| fragments, `request.userAgent` dropped  |       2844 | 39.0% |                  71.7% |
+| build the line and never emit it        |       2280 | 51.0% |                      - |
+| emit a **constant** line every request  |       1680 | 64.0% |                  79.9% |
+| a five-field line, correlation given up |       1251 | 73.2% |                  83.3% |
+
+The constant-line row is the bound worth keeping in mind: it does no per-request
+work at all and still writes 250 bytes, and it lands at 64.0%. The 80% target sits
+two points under that, so 80% is not a formatting problem and no faster serialiser
+reaches it. What reaches it is writing less.
+
+The last row does reach it, at 83.3%, and its bill is the whole feature set: no
+`AsyncLocalStorage` scope, so nothing else the request logs carries its id; no
+inbound `x-request-id` honoured and a process-local counter instead of a UUID, so
+an id does not span two services; no `user-agent`; no `x-request-id` on the
+response; and five fields where there were twelve.
+
+Keeping every field that a log pipeline filters or groups on, the reachable figure
+is **69.7% on json and 69.0% on plaintext**. Dropping only `user-agent` takes it
+to 71.7% and 71.2%.
+
+### `@dunx/infra/logger` costs twice what the benchmark measures
+
+Every other figure here is `ConsoleLogger`, because that is what `internal/bench`
+binds. Driven through the same rig, arkv's logger cost 10147 ns of request logging
+against `ConsoleLogger`'s 4923. So an app on `@dunx/infra/logger`, which is the
+configuration `packages/infra/README.md` recommends, sat near **46% of
+`bun-serve`** rather than the 61.8% the benchmark reports. That had never been
+measured.
+
+It is consistent rather than surprising: arkv's own `bench.ts` put `Logger.info`
+at 1474 ns against `ConsoleLogger`'s 543 in the same kind of tight loop. The extra
+buys sanitization, async context and the transport stack.
+
+**Fixed upstream**, in `~/repos/arkv`, since that is where a fix reaches the
+owner's other projects. Two builds of the package compared in one process,
+alternating by round:
+
+| arkv operation           | before | after | change |
+| ------------------------ | -----: | ----: | -----: |
+| `Logger.info`            |   1474 |   959 | -35.0% |
+| `Logger.info` in a scope |   1801 |  1260 | -30.0% |
+| `Logger.error`           |   1995 |  1584 | -20.6% |
+| `sanitizePrepared`       |    567 |   339 | -40.2% |
+| `logfmtFormat`           |    921 |   812 | -11.9% |
+| `serializeError`         |    526 |   473 |  -9.9% |
+| `createLogEntry`         |    420 |   393 |  -6.5% |
+
+What was in them, all allocation rather than algorithm:
+
+- `sanitizePrepared` walked the entry through `safeEntries`, which is
+  `Object.keys(obj).map((key) => [key, obj[key]])`: a pair array per key on top of
+  the key array, so a twelve-field entry allocated fourteen arrays per call and
+  discarded all of them.
+- `extractErrorAndExtra` copied the caller's object field by field into a fresh
+  `extra` that `createLogEntry` then spread again. Where there is one plain object
+  and no error hiding in `err`/`error`, it is handed through instead.
+- Two `...(x ? { x } : {})` spreads at the `createLogEntry` call site allocated an
+  empty object each, on every call by a logger configured with neither.
+- `serializeError` ran a global regex with an unused capture group over the whole
+  stack, and allocated a `WeakSet` for a cycle check that only descending needs.
+- `logfmt`'s `quote` ran four `replaceAll` passes over every quoted value; most
+  are quoted for containing a space and have nothing for the other three to do.
+
+In the dunx request path that is 10147 ns to 9117 ns, **-10.2%**. Less than the
+35% the tight loop shows, for the reason the rest of this page keeps finding: what
+was removed is short-lived nursery garbage, and the path is paced by the retained
+strings.
+
+Two things measured and **not** adopted, both recorded because the reasoning is
+worth more than the change would have been:
+
+- **`ContextStore.peekContext`.** The logger already prefers a copy-free read
+  where the reader offers one, and `ContextStore` does not implement it. That is
+  deliberate upstream: the class is public and subclassable, and a subclass
+  overriding `getContext` to redact a field would be silently bypassed. The prize
+  is one shallow spread, about 22 ns.
+- **Batching `ConsoleTransport`.** It is implemented and opt-in, and no throughput
+  win was reproducible for it: 10267 ns unbatched against 11106 ns batched with
+  stdout on /dev/null, 22.9 us against 23.8 us into a pipe nobody drains. A write
+  to /dev/null costs about 100 ns, so there is little to save, and against a
+  blocked consumer the limit is bytes rather than calls. An earlier single
+  measurement said 889 ns and did not survive being repeated.
+
+### The fragment approach needs the middleware and the logger co-designed
+
+`nomerge`, `aot` and `fastjson` all left `ConsoleLogger` to build the line from
+what `logger.info(message, fields)` was handed, and all three landed within a few
+hundred nanoseconds of the shipped path. The saving in the `precomp` rows comes
+from the middleware not building the `fields` object and not calling
+`JSON.stringify` at all, which the current contract has no way to express.
+
+That matters for who benefits. A fast path only `ConsoleLogger` implements helps
+the default logger and this benchmark; an app on `@dunx/infra/logger` keeps the
+generic path, because `@arkv/logger` cannot take an already-serialised line and
+still redact it. A leaner entry, by contrast, is worth 5% to 17% and is worth it
+to every logger.
+
+### Designing `logger.bind(shape)`, and what measuring it said
+
+The fragment rows above need the middleware and the logger co-designed, so the
+shape proposed for that was a bound writer: the caller declares the entry's shape
+once, the logger compiles what is per-shape, and a request passes values
+positionally instead of building an object.
+
+`@arkv/logger`'s transports each format for themselves. `Transport.write(entry,
+level)` hands over the entry and lets the transport render it, which is what lets
+one console be coloured while a file beside it stays plain JSON. A bound writer
+therefore cannot hand over a pre-serialised line; it has to produce the entry
+object. The `bound` row measures exactly that: the caller's fields object gone,
+the `getContext()` copy gone, the merge gone, `JSON.stringify` still there.
+
+| Variant                                  | logging ns | saved |
+| ---------------------------------------- | ---------: | ----: |
+| the shipped path                         |       4621 |     - |
+| `bound`, the entry object built directly |       4362 |  5.6% |
+| `precomp`, fragments and no object       |       3289 | 28.8% |
+
+**So a bound writer is worth 5.6%, and the merge was never the cost.** Building a
+twelve-key object costs about what merging two spreads into one costs, and `bound`
+still builds it. Only the fragment rows escape the object, and they escape the
+generic `JSON.stringify` with it. The gap between the two rows, 1073 ns of the
+1332 available, is what `Transport.write(entry, level)` costs.
+
+That splits the design in two, and only the second half is worth anything.
+
+**A bound writer alone** would still be a real API: mask decisions resolved per
+field name once instead of per entry, reserved-name collisions raised at bind time
+rather than filed per entry, and a declared primitive type letting `makeSafeForJson`
+be skipped behind a `typeof` guard that falls back when the value is not what was
+declared. That last part matters: a `trusted` flag would be a hole in redaction,
+where a declared type is checkable. All of it buys 5.6%.
+
+**A bound writer that emits a line** needs `Transport` to grow an optional
+`writeLine(line, level)`, and it can only be used when every transport offers one
+and would have rendered the same bytes. In practice that means exactly one
+transport whose formatter is the one the writer compiled for, and fragments are
+JSON, so `jsonFormat` and nothing else. That is narrower than it sounds and also
+the production default: `new Logger({})` outside development is one
+`ConsoleTransport` writing `jsonFormat`.
+
+Two behaviours would have to survive it, and both are cheap rather than hard. The
+async store can hold keys the shape does not declare, and today they reach the
+line, so the writer has to compare what the store holds against what it compiled
+for and fall back per entry when they differ. And an error is per-call and cannot
+be compiled at all, so `error` stays on the generic path.
+
+What it is worth, end to end: 28.8% of request logging, which is 61.8% of
+`bun-serve` to about 69.7%. Not the 80% that started this, which needs the
+five-field line and the loss of correlation recorded above.
+
+**Not built.** Two repos, a new contract in each, a fast path that applies to one
+transport and one formatter, and a fallback per entry to keep behaviour, for eight
+points of a benchmark. The 5.6% version is not worth a public API at all. Recorded
+here so the next person costs it from these numbers rather than from the guess this
+started as.
+
+### What this rig cannot see
+
+There is no socket under it, so it prices the middleware and the logger and
+nothing about `Bun.serve`'s own request handling. Anything lazy on a real
+`BunRequest` is already materialised on the pooled `Request` objects it drives,
+which is why the header question needs the socket harness and got the answer above
+instead.
+
+Three measurement traps are worth keeping, because each produced a confident wrong
+answer first.
+
+A `for` loop of `await`s never lets the macrotask queue run, so the batched
+writer's flush never fires. Measured: 50,000 emits produced zero flushes and a
+10 MB pending rope, and every row was then scored on how fast it grew a rope.
+
+Yielding with `setTimeout(resolve, 0)` replaces that with a different artifact.
+Bun clamps a zero timeout to about a millisecond, which put every row at 21 us of
+idle timer. `setImmediate` is the yield that measures the work.
+
+Measuring several loggers in one process is the third. The shared `handle` and
+`info` call sites go polymorphic and the rows contaminate each other, seen here as
+a 1.8 us swing on identical code between two orderings.
+
+These runs are from a 12700H under WSL2, where the socket ladder cannot be read at
+all: a full run put `default` ahead of `unbatched` and a blocked pipe ahead of
+`/dev/null`, both impossible. `--only` was added to `bun run logging` so a
+comparison can hold five units up rather than nineteen.
+
 ## Re-measured on Bun 1.4.0, 2026-08-22
 
 ### The body options, which this harness could not reach until it had a POST ladder

--- a/internal/bench/inproc-driver.ts
+++ b/internal/bench/inproc-driver.ts
@@ -1,0 +1,102 @@
+/**
+ * Spawns `inproc.ts` once per variant per round, round-robin, so machine drift
+ * lands on round rather than on row identity - the reason `src/logging.ts`
+ * interleaves its units too.
+ */
+const LADDER = [
+  'floor',
+  'chain',
+  'url',
+  'ignored',
+  'clock',
+  'inbound',
+  'uuid',
+  'scope',
+  'als',
+  'request',
+  'respheader',
+  'entry-discard',
+  'entry-stamp',
+  'entry-rest',
+  'entry-assemble',
+  'entry-short',
+  'entry-lean',
+  'entry-serialize',
+  'entry-write',
+  'precomp',
+  'precomp-noua',
+  'precomp-nowrite',
+  'precomp-const',
+  'precomp-max',
+  'bound',
+];
+const FORMATS = [
+  'floor',
+  'default',
+  'merge',
+  'lean',
+  'text',
+  'nomerge',
+  'fastjson',
+  'aot',
+  'direct',
+  'aotdirect',
+];
+const PICK = process.env['ONLY'];
+const VARIANTS =
+  PICK !== undefined
+    ? PICK.split(',')
+    : process.env['MODE'] === 'ladder'
+      ? LADDER
+      : FORMATS;
+const ROUNDS = Number(process.argv[2] ?? 7);
+const ARGS = process.argv.slice(3);
+
+const once = async (variant: string): Promise<number> => {
+  const proc = Bun.spawn(['bun', ...ARGS, 'inproc.ts', variant], {
+    stdout: 'ignore',
+    stderr: 'pipe',
+    cwd: import.meta.dir,
+  });
+  const text = await new Response(proc.stderr).text();
+  if ((await proc.exited) !== 0) throw new Error(`${variant} failed: ${text}`);
+  const value = Number(text.trim().split('\n').at(-1));
+  if (!Number.isFinite(value)) throw new Error(`${variant}: ${text}`);
+  return value;
+};
+
+const samples = new Map<string, number[]>(VARIANTS.map((v) => [v, []]));
+for (let round = 0; round < ROUNDS; round += 1) {
+  for (const variant of VARIANTS) {
+    samples.get(variant)!.push(await once(variant));
+  }
+  process.stderr.write(`round ${round + 1} of ${ROUNDS}\n`);
+}
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)]!;
+};
+
+const stats = VARIANTS.map((variant) => {
+  const values = samples.get(variant)!;
+  const mid = median(values);
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const sd = Math.sqrt(
+    values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length,
+  );
+  return { variant, median: mid, sd };
+});
+
+console.log('\nvariant       ns/req      sd   this step   vs floor');
+let previous: number | undefined;
+const floor = stats.find((s) => s.variant === 'floor')?.median ?? 0;
+for (const s of stats) {
+  const step = previous === undefined ? 0 : s.median - previous;
+  console.log(
+    `${s.variant.padEnd(12)} ${s.median.toFixed(0).padStart(6)}  ${s.sd.toFixed(0).padStart(6)}  ` +
+      `${(previous === undefined ? '-' : (step >= 0 ? '+' : '') + step.toFixed(0)).padStart(9)}  ` +
+      `${(s.median - floor).toFixed(0).padStart(9)}`,
+  );
+  previous = s.median;
+}

--- a/internal/bench/inproc-driver.ts
+++ b/internal/bench/inproc-driver.ts
@@ -67,7 +67,12 @@ const once = async (variant: string): Promise<number> => {
 
 const samples = new Map<string, number[]>(VARIANTS.map((v) => [v, []]));
 for (let round = 0; round < ROUNDS; round += 1) {
-  for (const variant of VARIANTS) {
+  // Rotated by round. Running the list in the same order every time maps a
+  // within-round trend, a thermal ramp or a scheduler that settles after the
+  // first spawn, onto position in the list, which is the drift this was supposed
+  // to spread. Rotating gives every variant every position.
+  for (let i = 0; i < VARIANTS.length; i += 1) {
+    const variant = VARIANTS[(i + round) % VARIANTS.length]!;
     samples.get(variant)!.push(await once(variant));
   }
   process.stderr.write(`round ${round + 1} of ${ROUNDS}\n`);
@@ -90,13 +95,16 @@ const stats = VARIANTS.map((variant) => {
 
 console.log('\nvariant       ns/req      sd   this step   vs floor');
 let previous: number | undefined;
-const floor = stats.find((s) => s.variant === 'floor')?.median ?? 0;
+// Absent when the selection did not include it, and then there is no baseline to
+// subtract: printing the raw median under a "vs floor" heading reads as a cost
+// over nothing.
+const floor = stats.find((s) => s.variant === 'floor')?.median;
 for (const s of stats) {
   const step = previous === undefined ? 0 : s.median - previous;
   console.log(
     `${s.variant.padEnd(12)} ${s.median.toFixed(0).padStart(6)}  ${s.sd.toFixed(0).padStart(6)}  ` +
       `${(previous === undefined ? '-' : (step >= 0 ? '+' : '') + step.toFixed(0)).padStart(9)}  ` +
-      `${(s.median - floor).toFixed(0).padStart(9)}`,
+      `${(floor === undefined ? '-' : (s.median - floor).toFixed(0)).padStart(9)}`,
   );
   previous = s.median;
 }

--- a/internal/bench/inproc.ts
+++ b/internal/bench/inproc.ts
@@ -1,0 +1,203 @@
+/**
+ * One logger, one process: the request-logging path driven straight through
+ * `RequestLoggingMiddleware.handle`, with no socket under it.
+ *
+ * `bun run logging` measures the same work through oha, which on a 20-thread
+ * laptop carries a standard deviation near a microsecond, wider than everything
+ * this compares. Everything below the socket is identical.
+ *
+ * Two traps this had to work around, both of which produced confident wrong
+ * answers first:
+ *
+ * - A `for` loop of `await`s never lets the macrotask queue run, so the batched
+ *   writer's flush never fires. Measured, 50,000 emits produced zero flushes and a
+ *   10 MB pending rope, and every row was scored on how fast it grew a rope.
+ * - Yielding with `setTimeout(resolve, 0)` swaps that for a different artifact:
+ *   Bun clamps a zero timeout to about a millisecond, which put every row at 21 us
+ *   of idle timer. `setImmediate` is the yield that measures the work.
+ *
+ * Several loggers in one process contaminate each other through the shared
+ * `handle` and `info` call sites, measured here as a 1.8 us swing on identical
+ * code between two orderings. `inproc-driver.ts` spawns one variant per process.
+ *
+ *   bun inproc.ts <variant>    ns/req on stderr, log lines discarded
+ */
+import {
+  AsyncRequestContext,
+  ConsoleLogger,
+  type Logger,
+  RequestContext,
+  type RequestFields,
+} from '@dunx/core';
+import { AsyncLocalStorage } from 'node:async_hooks';
+// Two builds of the same package, so a comparison between them is one driver run
+// and round-robin rather than two runs whose spread is wider than the difference.
+import { RequestLoggingMiddleware } from '@dunx/http';
+import type { BunRequest } from 'bun';
+import { isStep, StepMiddleware, type Step } from './steps.js';
+import {
+  DiscardLogger,
+  SerializeOnlyLogger,
+  TimestampLogger,
+} from './servers/logging/variants.js';
+import {
+  AotLogger,
+  AssembleLogger,
+  LeanLogger,
+  TrimLogger,
+  RestOnlyLogger,
+  ShortLogger,
+  FastJsonLogger,
+  MergeLogger,
+  NoMergeLogger,
+  TextLogger,
+} from './servers/logging/formats.js';
+
+const context = new AsyncRequestContext();
+
+/**
+ * `AsyncRequestContext` with both defensive copies removed, to price them.
+ *
+ * The shipped store copies the caller's fields on the way in (`{ ...context }`, so
+ * an `updateContext` inside cannot leak back out) and copies the store again on the
+ * way out (`getContext()`, so a reader cannot mutate it). The request-logging
+ * middleware builds a fresh scope object per request and the logger only reads the
+ * result, so for that one caller both copies are waste: three objects of the same
+ * five keys per request where one would do.
+ *
+ * Removing them is a contract change rather than a tidy-up: a caller that reuses
+ * the object it passed, or writes to the object it read, would be writing into the
+ * live store. This row says whether that is worth arguing about.
+ */
+class DirectContext extends RequestContext {
+  readonly #storage = new AsyncLocalStorage<RequestFields>();
+
+  override getContext(): RequestFields {
+    return this.#storage.getStore() ?? {};
+  }
+
+  override updateContext(fields: Partial<RequestFields>): void {
+    const current = this.#storage.getStore();
+    if (current) Object.assign(current, fields);
+  }
+
+  override runWithContext<T>(fields: RequestFields, callback: () => T): T {
+    const enclosing = this.#storage.getStore();
+    return this.#storage.run(
+      enclosing === undefined ? fields : { ...enclosing, ...fields },
+      callback,
+    );
+  }
+}
+
+const direct = new DirectContext();
+
+const LOGGERS: Record<string, () => Logger> = {
+  default: () => new ConsoleLogger(context),
+  merge: () => new MergeLogger(context),
+  text: () => new TextLogger(context),
+  nomerge: () => new NoMergeLogger(context),
+  fastjson: () => new FastJsonLogger(context),
+  aot: () => new AotLogger(context),
+  // The allocation lever: same logger, a store that copies nothing.
+  lean: () => new LeanLogger(context),
+  trim: () => new TrimLogger(context),
+  direct: () => new ConsoleLogger(direct),
+  // Both levers at once - no scope copies and no merged entry object.
+  aotdirect: () => new AotLogger(direct),
+  floor: () => new ConsoleLogger(context),
+  // The `entry` step of the ladder, split by how far into the logger it goes.
+  'entry-discard': () => new DiscardLogger(),
+  'entry-stamp': () => new TimestampLogger(),
+  'entry-rest': () => new RestOnlyLogger(),
+  'entry-assemble': () => new AssembleLogger(context),
+  'entry-short': () => new ShortLogger(context),
+  'entry-lean': () => new LeanLogger(context),
+  'entry-serialize': () => new SerializeOnlyLogger(context),
+  'entry-write': () => new ConsoleLogger(context),
+};
+
+/** The `entry-*` rows all run the full step ladder and vary only the logger. */
+const stepOf = (variant: string): Step | undefined => {
+  if (isStep(variant)) return variant;
+  return variant.startsWith('entry-') ? 'entry' : undefined;
+};
+
+const name = process.argv[2] ?? 'default';
+const make = LOGGERS[name] ?? (() => new ConsoleLogger(context));
+if (LOGGERS[name] === undefined && !isStep(name)) {
+  throw new Error(
+    `Unknown variant "${name}". One of: ${Object.keys(LOGGERS).join(', ')}`,
+  );
+}
+
+const ctx = {
+  controller: 'BenchController',
+  handler: 'json',
+  method: 'GET',
+  path: '/json',
+  parsesBody: false,
+  get: () => undefined,
+} as unknown as Parameters<RequestLoggingMiddleware['handle']>[1];
+
+const AGENTS = ['oha/1.15.0', 'curl/8.5.0', 'Mozilla/5.0 (X11; Linux x86_64)'];
+const PATHS = ['/json', '/plaintext', '/params/41', '/users', '/health'];
+
+/**
+ * Built once. Constructing a `Request` costs more than anything being compared and
+ * costs the same in every row, so leaving it in the timed loop would dilute the
+ * differences without changing their order.
+ */
+const POOL: BunRequest[] = [];
+for (let i = 0; i < 512; i += 1) {
+  POOL.push(
+    new Request(`http://127.0.0.1:3000${PATHS[i % PATHS.length]}`, {
+      headers: { 'user-agent': AGENTS[i % AGENTS.length]! },
+    }) as unknown as BunRequest,
+  );
+}
+
+const next = (): Promise<Response> =>
+  Promise.resolve(new Response('{"message":"Hello, World!"}'));
+
+const store = name === 'direct' || name === 'aotdirect' ? direct : context;
+const step = stepOf(name);
+const mw: { handle: RequestLoggingMiddleware['handle'] } =
+  step === undefined
+    ? new RequestLoggingMiddleware(make(), store)
+    : (new StepMiddleware(make(), context, step) as unknown as {
+        handle: RequestLoggingMiddleware['handle'];
+      });
+
+const turn = (): Promise<void> =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+
+/**
+ * `floor` runs the loop with no middleware at all. Every other row is this plus
+ * request logging, so `row - floor` is what logging costs and the ratio says how
+ * much sensitivity the harness has left after the loop's own overhead.
+ */
+const FLOOR = name === 'floor';
+
+const drive = async (iters: number, from: number): Promise<void> => {
+  for (let i = 0; i < iters; i += 1) {
+    if (FLOOR) await next();
+    else await mw.handle(POOL[(from + i) % POOL.length]!, ctx, next);
+    await turn();
+  }
+};
+
+const ITERS = 60_000;
+await drive(20_000, 0);
+Bun.gc(true);
+
+const runs: number[] = [];
+for (let r = 0; r < 9; r += 1) {
+  const t = Bun.nanoseconds();
+  await drive(ITERS, r * ITERS);
+  runs.push((Bun.nanoseconds() - t) / ITERS);
+}
+runs.sort((a, b) => a - b);
+process.stderr.write(`${runs[4]!.toFixed(1)}\n`);

--- a/internal/bench/package.json
+++ b/internal/bench/package.json
@@ -21,6 +21,7 @@
     "db-modes": "bun src/db-modes.ts",
     "validation": "bun src/validation.ts",
     "logging": "bun src/logging.ts",
+    "inproc": "bun inproc-driver.ts",
     "test": "bun test --bail",
     "typecheck": "tsc --noEmit && tsc --noEmit -p servers/nest",
     "logging:bodies": "bun src/logging.ts --scenario validate --out results/logging-bodies.json"

--- a/internal/bench/servers/logging/dunx.ts
+++ b/internal/bench/servers/logging/dunx.ts
@@ -19,6 +19,7 @@ import {
 } from '@dunx/http';
 import type { BunRequest } from 'bun';
 import { echo, jsonPayload, personSchema, PLAINTEXT, port } from '../shared.js';
+import { FastJsonLogger, NoMergeLogger, TextLogger } from './formats.js';
 import {
   DiscardLogger,
   isLoggingVariant,
@@ -169,6 +170,14 @@ class BenchController {
   }
 }
 
+const FORMATS: Partial<
+  Record<LoggingVariant, new (context: RequestContext) => Logger>
+> = {
+  text: TextLogger,
+  nomerge: NoMergeLogger,
+  fastjson: FastJsonLogger,
+};
+
 const loggerOverride = (): ReturnType<typeof provide<Logger>> | undefined => {
   if (variant === 'entry') return provide(Logger, { useClass: DiscardLogger });
   if (variant === 'timestamp') {
@@ -186,6 +195,15 @@ const loggerOverride = (): ReturnType<typeof provide<Logger>> | undefined => {
     return provide(Logger, {
       useFactory: (context: RequestContext) =>
         new ConsoleLogger(context, 'info', false),
+      inject: [RequestContext] as const,
+    });
+  }
+  // The format experiment. Same middleware, same batching, same route - only the
+  // line-building differs, so each is `default` plus one variable.
+  const format = FORMATS[variant];
+  if (format !== undefined) {
+    return provide(Logger, {
+      useFactory: (context: RequestContext) => new format(context),
       inject: [RequestContext] as const,
     });
   }

--- a/internal/bench/servers/logging/formats.ts
+++ b/internal/bench/servers/logging/formats.ts
@@ -200,6 +200,11 @@ export class NoMergeLogger extends FormatLogger {
  * the middleware puts in the store, then the three it passes as fields, with
  * anything unexpected spliced in generically so no entry is silently dropped.
  *
+ * Every string goes through `str`, including the four that in practice cannot hold
+ * a quote. Interpolating them raw was faster and emitted invalid JSON for any value
+ * that did, which would have made this row's output differ from the contract it is
+ * being compared against.
+ *
  * This is the ceiling the format experiment is really asking about - no merged
  * entry object, no per-key dispatch, one template literal.
  */
@@ -230,11 +235,11 @@ export class FastJsonLogger extends FormatLogger {
     return (
       `{"level":"${level}","timestamp":"${timestamp()}","pid":${PID},` +
       `"message":${str(message)},` +
-      `"requestId":"${scope.requestId ?? ''}",` +
-      `"method":"${scope.method ?? ''}",` +
+      `"requestId":${str(String(scope.requestId ?? ''))},` +
+      `"method":${str(String(scope.method ?? ''))},` +
       `"event":${str(String(scope.event ?? ''))},` +
-      `"flow":"${scope.flow ?? ''}",` +
-      `"context":"${scope.context ?? ''}",` +
+      `"flow":${str(String(scope.flow ?? ''))},` +
+      `"context":${str(String(scope.context ?? ''))},` +
       `"request":${request === undefined ? '{}' : JSON.stringify(request)},` +
       `"statusCode":${Number(fields?.['statusCode'] ?? 0)},` +
       `"elapsedMs":${Number(fields?.['elapsedMs'] ?? 0)}` +

--- a/internal/bench/servers/logging/formats.ts
+++ b/internal/bench/servers/logging/formats.ts
@@ -1,0 +1,465 @@
+import { Logger, LOG_LEVELS, RequestContext, type LogLevel } from '@dunx/core';
+
+/**
+ * Three answers to "what if the entry were not JSON", each a drop-in `Logger` for
+ * the `default` row so a comparison against it is one variable.
+ *
+ * They share `ConsoleLogger`'s batching verbatim - one write per event-loop turn -
+ * because `bun run logging` already measured that the write dominates anything
+ * these change. Batching them differently would measure the batching.
+ */
+let pending = '';
+let scheduled = false;
+
+const flushPending = (): void => {
+  scheduled = false;
+  if (pending === '') return;
+  const batch = pending;
+  pending = '';
+  console.log(batch);
+};
+
+export const emitLine = (line: string): void => {
+  pending = pending === '' ? line : `${pending}\n${line}`;
+  if (scheduled) return;
+  scheduled = true;
+  setTimeout(flushPending, 0).unref();
+};
+
+let stampAt = 0;
+let stampValue = '';
+export const timestamp = (): string => {
+  const now = Date.now();
+  if (now !== stampAt) {
+    stampAt = now;
+    stampValue = new Date(now).toISOString();
+  }
+  return stampValue;
+};
+
+const PID = process.pid;
+const MINIMUM = LOG_LEVELS.indexOf('info');
+
+/**
+ * Quote, backslash and the C0 range: everything a JSON string has to escape. The
+ * control range is the point of the check, and a native `RegExp.test` is what makes
+ * the escape-only-when-dirty variants worth measuring, so the rule is off here
+ * rather than the range being written some slower way.
+ */
+// oxlint-disable-next-line no-control-regex
+const DIRTY = /["\\\u0000-\u001f]/;
+
+/** `JSON.stringify` only when the value can carry something needing an escape. */
+const str = (value: string): string =>
+  DIRTY.test(value) ? JSON.stringify(value) : `"${value}"`;
+
+/**
+ * The level dispatch every variant below shares. `#line` is the only difference
+ * between them, which is the point of the comparison.
+ */
+abstract class FormatLogger extends Logger {
+  readonly logLevel: LogLevel = 'info';
+
+  constructor(protected readonly context: RequestContext) {
+    super();
+  }
+
+  verbose(message: unknown, ...rest: unknown[]): void {
+    this.#write('verbose', message, rest);
+  }
+  debug(message: unknown, ...rest: unknown[]): void {
+    this.#write('debug', message, rest);
+  }
+  info(message: unknown, ...rest: unknown[]): void {
+    this.#write('info', message, rest);
+  }
+  log(message: unknown, ...rest: unknown[]): void {
+    this.#write('info', message, rest);
+  }
+  warn(message: unknown, ...rest: unknown[]): void {
+    this.#write('warn', message, rest);
+  }
+  error(message: unknown, ...rest: unknown[]): void {
+    this.#write('error', message, rest);
+  }
+  fatal(message: unknown, ...rest: unknown[]): void {
+    this.#write('fatal', message, rest);
+  }
+
+  protected abstract format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string;
+
+  #write(level: LogLevel, message: unknown, rest: readonly unknown[]): void {
+    if (LOG_LEVELS.indexOf(level) < MINIMUM) return;
+    emitLine(
+      this.format(
+        level,
+        typeof message === 'string' ? message : String(message),
+        rest[0] as Record<string, unknown> | undefined,
+      ),
+    );
+  }
+}
+
+/**
+ * The control, and the row every other one here must be read against:
+ * `ConsoleLogger`'s own line-building - merge both bags into an entry object, hand
+ * it to `JSON.stringify` - on this file's dispatch and batching.
+ *
+ * Without it a comparison against the shipped `default` row also carries the
+ * difference between the two dispatches, which is not what any of this is about.
+ */
+export class MergeLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    return JSON.stringify({
+      level,
+      timestamp: timestamp(),
+      pid: PID,
+      message,
+      ...this.context.getContext(),
+      ...fields,
+    });
+  }
+}
+
+/**
+ * logfmt instead of JSON, and otherwise `ConsoleLogger` unchanged: it still
+ * assembles the merged entry, because a generic logger cannot know the shape.
+ * This is the row that answers "text instead of JSON" as a formatter swap.
+ */
+const textValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return DIRTY.test(value) || value.includes(' ')
+      ? JSON.stringify(value)
+      : value;
+  }
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? '-';
+};
+
+export class TextLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    const entry: Record<string, unknown> = {
+      level,
+      timestamp: timestamp(),
+      pid: PID,
+      message,
+      ...this.context.getContext(),
+      ...fields,
+    };
+    let out = '';
+    for (const key in entry) out = `${out}${key}=${textValue(entry[key])} `;
+    return out;
+  }
+}
+
+/**
+ * Byte-identical JSON to `ConsoleLogger`, built without merging the two bags into
+ * an entry object first: each is serialised by native `JSON.stringify` and spliced
+ * in with its braces removed.
+ *
+ * A key present in both bags would appear twice rather than being overridden, so
+ * this is a measurement rather than a shippable logger.
+ */
+const bag = (obj: Record<string, unknown> | undefined): string => {
+  if (obj === undefined) return '';
+  const text = JSON.stringify(obj);
+  return text.length > 2 ? `,${text.slice(1, -1)}` : '';
+};
+
+export class NoMergeLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    return (
+      `{"level":"${level}","timestamp":"${timestamp()}","pid":${PID},` +
+      `"message":${str(message)}` +
+      `${bag(this.context.getContext())}${bag(fields)}}`
+    );
+  }
+}
+
+/**
+ * The request-logging entry's shape written out longhand: the five scope fields
+ * the middleware puts in the store, then the three it passes as fields, with
+ * anything unexpected spliced in generically so no entry is silently dropped.
+ *
+ * This is the ceiling the format experiment is really asking about - no merged
+ * entry object, no per-key dispatch, one template literal.
+ */
+const KNOWN_SCOPE = ['requestId', 'method', 'event', 'flow', 'context'];
+const KNOWN_FIELDS = ['request', 'statusCode', 'elapsedMs'];
+
+const rest = (
+  obj: Record<string, unknown>,
+  known: readonly string[],
+): string => {
+  let extra: Record<string, unknown> | undefined;
+  for (const key in obj) {
+    if (known.includes(key)) continue;
+    extra ??= {};
+    extra[key] = obj[key];
+  }
+  return bag(extra);
+};
+
+export class FastJsonLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    const scope = this.context.getContext();
+    const request = fields?.['request'];
+    return (
+      `{"level":"${level}","timestamp":"${timestamp()}","pid":${PID},` +
+      `"message":${str(message)},` +
+      `"requestId":"${scope.requestId ?? ''}",` +
+      `"method":"${scope.method ?? ''}",` +
+      `"event":${str(String(scope.event ?? ''))},` +
+      `"flow":"${scope.flow ?? ''}",` +
+      `"context":"${scope.context ?? ''}",` +
+      `"request":${request === undefined ? '{}' : JSON.stringify(request)},` +
+      `"statusCode":${Number(fields?.['statusCode'] ?? 0)},` +
+      `"elapsedMs":${Number(fields?.['elapsedMs'] ?? 0)}` +
+      `${rest(scope, KNOWN_SCOPE)}${fields === undefined ? '' : rest(fields, KNOWN_FIELDS)}}`
+    );
+  }
+}
+
+/**
+ * The pino technique: a serialiser compiled once for the shape the entry actually
+ * has, so a request pays no key iteration, no `Array.includes` guard and no merged
+ * entry object. `FastJsonLogger` above writes the same line by hand but keeps a
+ * `for...in` guard for unexpected keys; this row exists to say what that guard
+ * costs and what codegen is worth without it.
+ *
+ * The shape is fixed at construction, which is what a compiled serialiser trades:
+ * a key outside `SCOPE_KEYS` or `FIELD_KEYS` is dropped rather than appended.
+ */
+const val = (value: unknown): string => {
+  if (typeof value === 'string') return str(value);
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? `${value}` : 'null';
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'boolean') return `${value}`;
+  return JSON.stringify(value) ?? 'null';
+};
+
+type Compiled = (
+  level: string,
+  message: string,
+  scope: Record<string, unknown>,
+  fields: Record<string, unknown> | undefined,
+) => string;
+
+const SCOPE_KEYS = ['requestId', 'method', 'event', 'flow', 'context'];
+const FIELD_KEYS = ['request', 'statusCode', 'elapsedMs', 'err'];
+
+const compile = (
+  scopeKeys: readonly string[],
+  fieldKeys: readonly string[],
+): Compiled => {
+  const lines = [
+    `var out = '{"level":"' + level + '","timestamp":"' + stamp() + '","pid":' + PID + ',"message":' + str(message);`,
+    'var v;',
+  ];
+  for (const key of scopeKeys) {
+    lines.push(
+      `v = scope.${key}; if (v !== undefined) out += ',"${key}":' + val(v);`,
+    );
+  }
+  lines.push('if (fields !== undefined) {');
+  for (const key of fieldKeys) {
+    lines.push(
+      `v = fields.${key}; if (v !== undefined) out += ',"${key}":' + val(v);`,
+    );
+  }
+  lines.push('}');
+  lines.push(`return out + '}';`);
+
+  // oxlint-disable-next-line no-new-func, no-implied-eval
+  const factory = new Function(
+    'str',
+    'val',
+    'stamp',
+    'PID',
+    `return function (level, message, scope, fields) {\n${lines.join('\n')}\n};`,
+  ) as (
+    s: typeof str,
+    v: typeof val,
+    t: typeof timestamp,
+    p: number,
+  ) => Compiled;
+  return factory(str, val, timestamp, PID);
+};
+
+const compiled = compile(SCOPE_KEYS, FIELD_KEYS);
+
+export class AotLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    return compiled(level, message, this.context.getContext(), fields);
+  }
+}
+
+/**
+ * Takes the same `(message, ...rest)` signature the `Logger` contract has and
+ * throws the arguments away.
+ *
+ * The ladder's `entry-discard` and `entry-stamp` rows use loggers whose `info()`
+ * declares no parameters at all, so they never allocate the rest array that every
+ * real level method does. Without this row between them, that allocation is
+ * charged to serialisation.
+ */
+export class RestOnlyLogger extends Logger {
+  readonly logLevel: LogLevel = 'info';
+
+  verbose(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+  debug(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+  info(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+  log(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+  warn(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+  error(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+  fatal(message: unknown, ...rest: unknown[]): void {
+    this.#write(message, rest);
+  }
+
+  #write(message: unknown, rest: readonly unknown[]): void {
+    if (LOG_LEVELS.indexOf('info') < MINIMUM) return;
+    sinkCount += rest.length + (message === undefined ? 1 : 0);
+  }
+}
+
+let sinkCount = 0;
+export const restSink = (): number => sinkCount;
+
+/**
+ * Two rows that separate producing the line from producing a *long* line.
+ *
+ * `AssembleLogger` builds the merged entry object and stops, so the difference to
+ * a row that also serialises is the string and nothing else. `ShortLogger`
+ * serialises a three-key entry to about 40 bytes rather than 250. If the cost of
+ * the step tracks the length of the line, what is being paid for is the
+ * allocation, and no amount of faster formatting reaches it.
+ */
+export class AssembleLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    held = {
+      level,
+      timestamp: timestamp(),
+      pid: PID,
+      message,
+      ...this.context.getContext(),
+      ...fields,
+    };
+    return '';
+  }
+}
+
+export class ShortLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    _fields: Record<string, unknown> | undefined,
+  ): string {
+    return JSON.stringify({ level, message });
+  }
+}
+
+let held: unknown;
+export const heldEntry = (): unknown => held;
+
+/**
+ * The same request, logged with the fields that are not already somewhere else.
+ *
+ * The shipped entry carries the method, the path and the status three times over:
+ * `message` is already "GET /json 200", and `method`, `event` and `statusCode`
+ * repeat it. `flow` is the constant 'http', `pid` is constant for the process, and
+ * `context` names the handler the path already identifies. Dropping the repeats
+ * takes the line from about 250 bytes to about 120.
+ *
+ * Nothing about this is a faster formatter. It is the same `JSON.stringify` over
+ * half as much.
+ */
+export class LeanLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    const scope = this.context.getContext();
+    return JSON.stringify({
+      level,
+      timestamp: timestamp(),
+      message,
+      requestId: scope.requestId,
+      elapsedMs: fields?.['elapsedMs'],
+    });
+  }
+}
+
+/**
+ * Between `LeanLogger` and the shipped entry: everything a log pipeline filters or
+ * groups on is kept, and only what cannot be queried usefully is dropped.
+ *
+ * Out go `pid`, constant for the life of the process; `flow`, the constant 'http';
+ * and `request.userAgent`, which is a header the caller chooses and the longest
+ * single field on the line. `method`, `event`, `context`, `requestId`,
+ * `statusCode` and `elapsedMs` stay, so nothing that a query selects on is lost.
+ */
+export class TrimLogger extends FormatLogger {
+  protected override format(
+    level: LogLevel,
+    message: string,
+    fields: Record<string, unknown> | undefined,
+  ): string {
+    const scope = this.context.getContext();
+    return JSON.stringify({
+      level,
+      timestamp: timestamp(),
+      message,
+      requestId: scope.requestId,
+      method: scope.method,
+      event: scope.event,
+      context: scope.context,
+      statusCode: fields?.['statusCode'],
+      elapsedMs: fields?.['elapsedMs'],
+    });
+  }
+}

--- a/internal/bench/servers/logging/variants.ts
+++ b/internal/bench/servers/logging/variants.ts
@@ -32,6 +32,12 @@ export const loggingVariants = Object.freeze([
   'unbatched',
   'default',
   'uncorrelated',
+  // The format experiment: the shipped default with only the `Logger` swapped,
+  // so a row against `default` differs by how the line is built and nothing else.
+  // `servers/logging/formats.ts` holds the three.
+  'text',
+  'nomerge',
+  'fastjson',
   // The body options, which the `json` ladder above cannot reach: they need a
   // request with a body, so these only run under `--scenario validate`.
   'body-request',

--- a/internal/bench/src/logging.ts
+++ b/internal/bench/src/logging.ts
@@ -161,6 +161,27 @@ const units: readonly Unit[] = [
     stdout: 'null',
   },
   {
+    id: 'text',
+    variant: 'text',
+    label: 'the default, logfmt instead of JSON',
+    adds: '**replaces** `JSON.stringify` with a text walk',
+    stdout: 'null',
+  },
+  {
+    id: 'nomerge',
+    variant: 'nomerge',
+    label: 'the default, same JSON built without a merged entry',
+    adds: '**removes** the entry object; `JSON.stringify` per bag',
+    stdout: 'null',
+  },
+  {
+    id: 'fastjson',
+    variant: 'fastjson',
+    label: 'the default, JSON written out longhand',
+    adds: '**removes** the entry object and the per-key dispatch',
+    stdout: 'null',
+  },
+  {
     id: 'default-blocked',
     variant: 'default',
     label: 'the default, into a pipe nobody reads',
@@ -278,6 +299,7 @@ const usage = `bun run logging [options]
   --runs <n>             measured runs per unit (default 3)
   --loadgen <name>       auto | oha | fetch (default auto)
   --scenario <id>        ${scenarios.map((s) => s.id).join(' | ')} (default json)
+  --only <ids>           comma-separated unit ids, for one comparison at a time
   --out <path>           JSON path (default results/logging.json)
   --help
 `;
@@ -292,6 +314,7 @@ const { values } = parseArgs({
     loadgen: { type: 'string' },
     'allow-fallback': { type: 'boolean' },
     scenario: { type: 'string' },
+    only: { type: 'string' },
     out: { type: 'string' },
     help: { type: 'boolean' },
   },
@@ -328,16 +351,46 @@ const machine = await readMachine('node');
  * a few percent and the machine drifts by more than that over a run, so measuring
  * each unit to completion in turn maps the drift onto row identity.
  */
-const chosenUnits = units.filter(
+const reachable = units.filter(
   (unit) => unit.needsBody !== true || scenario.body !== undefined,
 );
-const skipped = units.length - chosenUnits.length;
-if (skipped > 0) {
+
+/**
+ * `--only` narrows the run to the rows a question is actually about. Every unit
+ * stays up for the whole run, so a full ladder on a machine with fewer cores than
+ * rows has each row's server competing with sixteen others for a scheduler slot -
+ * measured on a 20-thread laptop, that put `default` behind `unbatched`, which is
+ * strictly more work, and the ladder cannot be read at all once it says that.
+ *
+ * A subset is not a ladder: neighbouring rows no longer differ by one step, so read
+ * the result as a comparison against whichever rows were kept.
+ */
+const wanted = values.only
+  ?.split(',')
+  .map((id) => id.trim())
+  .filter((id) => id !== '');
+if (wanted !== undefined) {
+  const unknown = wanted.filter((id) => !units.some((unit) => unit.id === id));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown unit id(s): ${unknown.join(', ')}. Known: ${units
+        .map((unit) => unit.id)
+        .join(', ')}`,
+    );
+  }
+}
+const chosenUnits =
+  wanted === undefined
+    ? reachable
+    : reachable.filter((unit) => wanted.includes(unit.id));
+const skipped = reachable.length - chosenUnits.length;
+if (skipped > 0 && wanted === undefined) {
   note(
     `skipping ${skipped} body unit(s): the "${scenario.id}" scenario sends no ` +
       'request body. Use --scenario validate to measure them.',
   );
 }
+if (chosenUnits.length === 0) throw new Error('--only matched no units');
 
 const live: Live[] = [];
 try {

--- a/internal/bench/src/logging.ts
+++ b/internal/bench/src/logging.ts
@@ -383,7 +383,10 @@ const chosenUnits =
   wanted === undefined
     ? reachable
     : reachable.filter((unit) => wanted.includes(unit.id));
-const skipped = reachable.length - chosenUnits.length;
+// Counted against `units`, not `reachable`. The notice is about the body rows the
+// scenario cannot reach, and comparing the two post-filter lists made it zero on
+// exactly the run it exists for.
+const skipped = units.length - reachable.length;
 if (skipped > 0 && wanted === undefined) {
   note(
     `skipping ${skipped} body unit(s): the "${scenario.id}" scenario sends no ` +

--- a/internal/bench/steps.ts
+++ b/internal/bench/steps.ts
@@ -1,0 +1,374 @@
+import { Logger, RequestContext } from '@dunx/core';
+import { REQUEST_ID_HEADER, type Middleware, type Next } from '@dunx/http';
+import type { BunRequest } from 'bun';
+import { emitLine, timestamp } from './servers/logging/formats.js';
+
+/**
+ * `RequestLoggingMiddleware` truncated one step at a time, for the in-process rig.
+ *
+ * `servers/logging/dunx.ts` has the same idea behind a socket, where the ladder's
+ * floor is around half a microsecond and six of its eleven steps land inside it.
+ * Here a step is resolved to about 50 ns, which is what it takes to see the ones
+ * that ladder cannot.
+ *
+ * Each step is decided once against a module constant, so a row pays for the work
+ * it declares and not for the check.
+ */
+export const STEPS = [
+  'chain',
+  'url',
+  'ignored',
+  'clock',
+  'inbound',
+  'uuid',
+  'scope',
+  'als',
+  'request',
+  'respheader',
+  'entry',
+  'precomp',
+  'precomp-noua',
+  'precomp-const',
+  'precomp-nowrite',
+  'precomp-max',
+  'bound',
+] as const;
+export type Step = (typeof STEPS)[number];
+
+export const isStep = (value: string): value is Step =>
+  (STEPS as readonly string[]).includes(value);
+
+/** Module scope so the optimiser cannot drop the work being measured. */
+export const sink = { line: '', path: '', count: 0 };
+
+/**
+ * Most of the entry never changes for a given route and status. `level`, `pid` and
+ * `flow` are constant for the process; `method`, `event` and `context` are
+ * constant for the route; `message` is "GET /json 200", so it is constant for the
+ * route and status together. Only the timestamp, the request id, the user agent
+ * and the elapsed milliseconds vary per request.
+ *
+ * So the line can be cut into fragments once and roped together per request. A
+ * real implementation would hang these off the frozen `RouteContext`, which is
+ * built when the route table is; this caches on the same object to price it the
+ * same way.
+ *
+ * `HEAD` carries the timestamp, `MID` the request id, `TAIL` the elapsed time.
+ * `noua` drops `request.userAgent`, which removes the one variable field needing
+ * an escape check and the longest field on the line.
+ */
+interface Fragments {
+  readonly head: string;
+  readonly mid: string;
+  readonly tailUa: string;
+  readonly tailNoUa: string;
+}
+
+const PID = process.pid;
+// oxlint-disable-next-line no-control-regex
+const DIRTY = /["\\\u0000-\u001f]/;
+const quoted = (value: string): string =>
+  DIRTY.test(value) ? JSON.stringify(value) : `"${value}"`;
+
+/**
+ * The floor. A line of the same length, built nowhere and emitted every request,
+ * so the difference to `precomp` is construction and the difference to
+ * `precomp-nowrite` is the batching and the write. Nothing that still writes one
+ * line per request can beat this row.
+ */
+const CONSTANT_LINE =
+  `{"level":"info","timestamp":"2026-08-31T12:00:00.000Z","pid":12345,` +
+  `"message":"GET /json 200","requestId":"3f2a91c4-7b5e-4d18-9a06-2c8e5f1b7d43",` +
+  `"method":"GET","event":"/json","flow":"http","context":"BenchController.json",` +
+  `"request":{"userAgent":"oha/1.15.0"},"statusCode":200,"elapsedMs":1}`;
+
+const fragmentCache = new Map<string, Fragments>();
+
+const fragmentsFor = (
+  method: string,
+  path: string,
+  context: string,
+  status: number,
+): Fragments => {
+  const key = `${method} ${path} ${status}`;
+  const found = fragmentCache.get(key);
+  if (found !== undefined) return found;
+  const built: Fragments = {
+    head: `{"level":"info","timestamp":"`,
+    mid:
+      `","pid":${PID},"message":"${method} ${path} ${status}",` +
+      `"requestId":"`,
+    tailUa:
+      `","method":"${method}","event":"${path}","flow":"http",` +
+      `"context":"${context}","request":{"userAgent":`,
+    tailNoUa:
+      `","method":"${method}","event":"${path}","flow":"http",` +
+      `"context":"${context}","statusCode":${status},"elapsedMs":`,
+  };
+  fragmentCache.set(key, built);
+  return built;
+};
+
+/**
+ * What a `logger.bind(shape)` writer could reach, and no further.
+ *
+ * A bound writer cannot hand transports a pre-serialised line: `@arkv/logger`'s
+ * `Transport.write(entry, level)` gives each transport the entry and lets it
+ * format for itself, which is what lets a console be coloured while a file stays
+ * plain JSON. So it builds the **entry object** directly, in its final shape, and
+ * the transport still serialises it.
+ *
+ * Against the shipped path that removes the caller's fields object, the
+ * `getContext()` copy and the merge, and keeps `JSON.stringify`. Against
+ * `precomp` it keeps the stringify that fragments avoid. The gap between the two
+ * is what the transport contract costs.
+ */
+const boundEntry = (
+  stamp: string,
+  message: string,
+  requestId: string,
+  method: string,
+  event: string,
+  context: string,
+  userAgent: string | null,
+  statusCode: number,
+  elapsedMs: number,
+): Record<string, unknown> => ({
+  level: 'info',
+  timestamp: stamp,
+  pid: PID,
+  message,
+  requestId,
+  method,
+  event,
+  flow: 'http',
+  context,
+  request: { userAgent },
+  statusCode,
+  elapsedMs,
+});
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Everything given up at once, to bound what is reachable: no
+ * `AsyncLocalStorage` scope, so nothing else the request logs carries its id; no
+ * inbound `x-request-id` honoured and a counter instead of a UUID, so an id is
+ * unique to this process and no further; no `user-agent`; no `x-request-id` on the
+ * response; and a five-field line rather than twelve.
+ *
+ * Not a proposal. The number it produces is the answer to how far this can go
+ * while still writing one line per request.
+ */
+let counter = 0;
+const MAX_HEAD = `{"level":"info","timestamp":"`;
+const maxCache = new Map<string, string>();
+const maxMid = (method: string, path: string, status: number): string => {
+  const key = `${method} ${path} ${status}`;
+  const found = maxCache.get(key);
+  if (found !== undefined) return found;
+  const built = `","message":"${method} ${path} ${status}","requestId":"`;
+  maxCache.set(key, built);
+  return built;
+};
+
+export class StepMiddleware implements Middleware {
+  readonly #step: number;
+  readonly #ignore: ReadonlySet<string>;
+  readonly #ignorePrefix: readonly string[];
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly context: RequestContext,
+    step: Step,
+  ) {
+    this.#step = STEPS.indexOf(step);
+    this.#ignore = new Set<string>();
+    this.#ignorePrefix = [];
+  }
+
+  #at(step: Step): boolean {
+    return this.#step === STEPS.indexOf(step);
+  }
+
+  handle(req: BunRequest, ctx: never, next: Next): Promise<Response> {
+    if (this.#at('chain')) return next();
+
+    const url = req.url;
+    const from = url.indexOf('/', url.indexOf('://') + 3);
+    const mark = from === -1 ? -1 : url.indexOf('?', from);
+    const path =
+      from === -1 ? '/' : mark === -1 ? url.slice(from) : url.slice(from, mark);
+    sink.path = path;
+    if (this.#at('url')) return next();
+
+    if (this.#ignore.size > 0 && this.#ignore.has(path)) return next();
+    if (this.#ignorePrefix.length > 0) {
+      if (this.#ignorePrefix.some((prefix) => path.startsWith(prefix))) {
+        return next();
+      }
+    }
+    if (this.#at('ignored')) return next();
+
+    const started = Bun.nanoseconds();
+
+    if (this.#at('precomp-max')) {
+      const mid = maxMid(
+        (ctx as unknown as { method: string }).method,
+        path,
+        200,
+      );
+      counter += 1;
+      const id = counter;
+      return next().then((response) => {
+        emitLine(
+          MAX_HEAD +
+            timestamp() +
+            mid +
+            id +
+            '","elapsedMs":' +
+            Math.round((Bun.nanoseconds() - started) / 1e6) +
+            '}',
+        );
+        return response;
+      });
+    }
+
+    if (this.#at('clock')) {
+      sink.count += started === 0 ? 1 : 0;
+      return next();
+    }
+
+    const inbound = req.headers.get(REQUEST_ID_HEADER);
+    if (this.#at('inbound')) {
+      sink.line = inbound ?? '';
+      return next();
+    }
+
+    const requestId =
+      inbound !== null && inbound.length === 36 && UUID.test(inbound)
+        ? inbound
+        : crypto.randomUUID();
+    if (this.#at('uuid')) {
+      sink.line = requestId;
+      return next();
+    }
+
+    const scope = {
+      requestId,
+      method: (ctx as unknown as { method: string }).method,
+      event: path,
+      flow: 'http',
+      context: `${(ctx as unknown as { controller: string }).controller}.${(ctx as unknown as { handler: string }).handler}`,
+    };
+    if (this.#at('scope')) {
+      sink.line = scope.context;
+      return next();
+    }
+
+    return this.context.runWithContext(scope, () => {
+      if (this.#at('als')) return next();
+
+      const request: Record<string, unknown> = {};
+      request['userAgent'] = req.headers.get('user-agent');
+      if (this.#at('request')) {
+        sink.line = String(request['userAgent']);
+        return next();
+      }
+
+      return next().then((response) => {
+        response.headers.set(REQUEST_ID_HEADER, requestId);
+        if (this.#at('respheader')) return response;
+
+        const elapsed = Math.round((Bun.nanoseconds() - started) / 1e6);
+
+        if (this.#at('precomp-const')) {
+          emitLine(CONSTANT_LINE);
+          return response;
+        }
+
+        if (this.#at('precomp-nowrite')) {
+          const f = fragmentsFor(
+            (ctx as unknown as { method: string }).method,
+            path,
+            scope.context,
+            response.status,
+          );
+          sink.line =
+            f.head +
+            timestamp() +
+            f.mid +
+            requestId +
+            f.tailNoUa +
+            elapsed +
+            '}';
+          return response;
+        }
+
+        if (this.#at('bound')) {
+          emitLine(
+            JSON.stringify(
+              boundEntry(
+                timestamp(),
+                `${req.method} ${path} ${response.status}`,
+                requestId,
+                (ctx as unknown as { method: string }).method,
+                path,
+                scope.context,
+                request['userAgent'] as string | null,
+                response.status,
+                elapsed,
+              ),
+            ),
+          );
+          return response;
+        }
+
+        if (this.#at('precomp')) {
+          const f = fragmentsFor(
+            (ctx as unknown as { method: string }).method,
+            path,
+            scope.context,
+            response.status,
+          );
+          emitLine(
+            f.head +
+              timestamp() +
+              f.mid +
+              requestId +
+              f.tailUa +
+              quoted(String(request['userAgent'])) +
+              `},"statusCode":${response.status},"elapsedMs":${elapsed}}`,
+          );
+          return response;
+        }
+
+        if (this.#at('precomp-noua')) {
+          const f = fragmentsFor(
+            (ctx as unknown as { method: string }).method,
+            path,
+            scope.context,
+            response.status,
+          );
+          emitLine(
+            f.head +
+              timestamp() +
+              f.mid +
+              requestId +
+              f.tailNoUa +
+              elapsed +
+              '}',
+          );
+          return response;
+        }
+
+        this.logger.info(`${req.method} ${path} ${response.status}`, {
+          request,
+          statusCode: response.status,
+          elapsedMs: elapsed,
+        });
+        return response;
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Why

`bun run logging` resolves a step to about half a microsecond, and
`docs/architecture/cost-of-logging.md` already recorded that six of its eleven
steps land inside that. So the ladder could say request logging costs +4.78 us
without saying which part, and every attempt to attack a part came back inside the
noise.

This adds a rig that can see the parts, and records what it found. **No change to
`packages/*`**: nothing measured here justified one.

## The rig

`bun run inproc` drives `RequestLoggingMiddleware.handle` directly, one variant
per process, round-robin. A step resolves to about 50 ns. Its floor row runs the
same loop with no middleware, and the difference came to 4833 ns against the
socket ladder's 4780, which is the check that it measures the same thing.

`--only` on `bun run logging` narrows a run to the rows a question is about. A
full ladder holds nineteen servers up at once, and on a 20-thread laptop that put
`default` ahead of `unbatched`, which is strictly more work, and a blocked pipe
ahead of /dev/null. A ladder that says either of those cannot be read at all.

Three traps are documented in `inproc.ts`, because each produced a confident wrong
answer before it was found:

- A `for` loop of `await`s never lets the macrotask queue run, so the batched
  writer's flush never fires. Measured: 50,000 emits, zero flushes, a 10 MB
  pending rope. Every row was being scored on how fast it grew a rope.
- Yielding with `setTimeout(resolve, 0)` swaps that for a different artifact,
  because Bun clamps a zero timeout to about a millisecond, which put every row at
  21 us of idle timer. `setImmediate` is the yield that measures the work.
- Measuring several loggers in one process lets the shared `handle` and `info`
  call sites go polymorphic, seen here as a 1.8 us swing on identical code between
  two orderings.

## What it found

| Step                                       | this step | total |
| ------------------------------------------ | --------: | ----: |
| chain, url slice, ignore checks            |    +67 ns | 67 ns |
| `Bun.nanoseconds()`                        |    +71 ns | 106 ns |
| `x-request-id` read                        |    +75 ns | 181 ns |
| `crypto.randomUUID()`                      |   +147 ns | 328 ns |
| `runWithContext`                           |   +144 ns | 481 ns |
| `user-agent` and the request object        |   +141 ns | 621 ns |
| **`.then` and `Headers.set` on the response** | **+616 ns** | 1237 ns |
| **the `logger.info` call**                 | **+2900 ns** | 4137 ns |

The `logger.info` call is 60% of request logging on its own. The `.then`
continuation plus one `Headers.set` is the second largest item and nothing has
ever tried to reduce it.

Splitting the logger call: the merged entry object is 1201 ns, `JSON.stringify` of
it 1564 ns, and **the write is 97 ns**. Batching already took the write cost,
which is what makes a worker thread the wrong tool here: `pino` moves the write
off the main thread with `thread-stream` and keeps serialising on it, and the thing
that would move is already paid for. Moving serialisation instead means
`postMessage`, whose structured clone costs more than the `JSON.stringify` it
replaces.

## Four things rejected, with numbers

- **Text instead of JSON: 28% dearer.** `JSON.stringify` is native and no per-key
  walk in JavaScript beats it.
- **A serialiser compiled with `new Function`**, which is `pino`'s actual
  technique: +221 ns against the control. Not faster.
- **`logger.bind(shape)`: 5.6%.** The merge was never the cost, the object was,
  and any API keeping `Transport.write(entry, level)` still allocates it. The
  28.8% version needs the transport contract to accept a pre-formatted line, which
  applies to one transport and one formatter. Designed and costed in the doc; not
  built.
- **The header lever I had suggested**: two header reads cost 216 ns here, and on
  a real `Bun.serve` a handler reading one header was within noise of one reading
  none. The socket ladder's +0.97 us is measured against its own +-0.5 us floor.
  Treat it as an artifact.

Every reformatting landed within a couple of hundred nanoseconds because the
formatter was never the cost: a two-key entry of 40 bytes is 1342 ns cheaper than
the 250-byte one through the same `JSON.stringify`.

## On the 80% target

Emitting a **constant** pre-built line every request, doing no per-request work at
all, saves 64.0% and lands at 79.9%. So 80% sits two points under logging the same
string every time, and no serialiser reaches it. The only lever is writing less:
route-cached fragments keeping all twelve fields reach 69.7%, dropping
`user-agent` 71.7%, and the 83.3% row gives up the async scope, an inbound
`x-request-id`, a UUID and seven of twelve fields.

## And one number that had never been measured

`@dunx/infra/logger` cost twice what the benchmark does, so a production app sat
near **46% of `bun-serve`** rather than the 61.8% `internal/bench` reports, which
binds `ConsoleLogger`. Fixed upstream in `@arkv/logger` rather than here, per the
reuse rule in CLAUDE.md: `Logger.info` 1474 ns to 959 ns, released as 0.13.0
(petarzarkov/arkv#9). Adopting it is #29: below 1.0.0 a caret pins the minor, so
`^0.12.0` never admitted 0.13.0 and the range had to move with the lockfile.

## Checks

`bun run ci static`, `bun test scripts/no-slop.test.ts scripts/no-em-dash.test.ts`,
and `internal/bench`'s own suite and typecheck all pass. The rig was re-run on
this base after rebasing onto main and reproduces the numbers above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed analysis of request-logging performance, optimization tradeoffs, and benchmark limitations.

* **Benchmarking**
  * Added in-process benchmarks with configurable variants, warmup, garbage collection, sampling, and statistical comparisons.
  * Added coverage for multiple logging formats and serialization strategies.
  * Added filtering for selected benchmark units and progressive measurements of request-processing steps.
  * Added comparisons for context handling, request identifiers, headers, middleware, and logging overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
