### PR TITLE
chore(infra): @arkv/logger 0.13.0, for a third off a log call

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -228,7 +228,7 @@
       "name": "@dunx/infra",
       "version": "3.1.3",
       "dependencies": {
-        "@arkv/logger": "^0.12.0",
+        "@arkv/logger": "^0.13.0",
         "@arkv/timezones": "^0.0.2",
       },
       "devDependencies": {
@@ -347,7 +347,7 @@
 
     "@arkv/colors": ["@arkv/colors@0.8.0", "", {}, "sha512-r4xt9tTUpeEgfOnKfVfdvP1QMgX4aMQtK1z12sGbB85hEqH6ijBiugZbKAo7HqfCaHtIXycX3diptQL+OfcimA=="],
 
-    "@arkv/logger": ["@arkv/logger@0.12.0", "", { "dependencies": { "@arkv/colors": "^0.8.0", "@arkv/shared": "^0.8.0" } }, "sha512-+T8Guxk9iH5mLwiytfGcbJ8ozeELbyRm89ZCPuwT829w+nu3Uvd6+kaT0OT6/PMsiGcW4FH573T7sZC50ywTQw=="],
+    "@arkv/logger": ["@arkv/logger@0.13.0", "", { "dependencies": { "@arkv/colors": "^0.8.0", "@arkv/shared": "^0.8.0" } }, "sha512-iRwp2nxr4VYj0zoZvFzJ1eSSUdtk/NRIRyxar48oJf8GIIrk592ATxoOInaTyAMo/vKjoBWZjIW485DeQ+VtEA=="],
 
     "@arkv/shared": ["@arkv/shared@0.8.0", "", {}, "sha512-c9YTix/b35KTEmIl+qlyjm74SzqWEXXcvwr4rqhYPWr7ihirdSaydOFFNFQSyQYgefVOc4JEKdpb4gOhSsKcrA=="],
 

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -100,7 +100,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@arkv/logger": "^0.12.0",
+    "@arkv/logger": "^0.13.0",
     "@arkv/timezones": "^0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Adopts `@arkv/logger@0.13.0`, which is the perf work from
[petarzarkov/arkv#9](https://github.com/petarzarkov/arkv/pull/9).

| arkv operation           |   before |   after | change |
| ------------------------ | -------: | ------: | -----: |
| `Logger.info`            |     1474 |     959 | -35.0% |
| `Logger.info` in a scope |     1801 |    1260 | -30.0% |
| `Logger.error`           |     1995 |    1584 | -20.6% |
| `sanitizePrepared`       |      567 |     339 | -40.2% |
| `logfmtFormat`           |      921 |     812 | -11.9% |
| `serializeError`         |      526 |     473 |  -9.9% |

Measured with two builds of that package imported into one process and timed
alternately by round, because separate runs drift by more than the changes do.

In `@dunx/http`'s request path it came to **10147 ns to 9117 per request, about
10%**. Smaller than the 35%, because what was removed is short-lived nursery
garbage and that path is paced by the strings it retains rather than by the
objects behind them. That figure is what `@dunx/infra/logger` costs, which is the
logger `packages/infra/README.md` recommends and the one `internal/bench` does not
measure: the benchmark binds `ConsoleLogger`.

## Why the range moved and not just the lockfile

`bun install` reported no changes, and `bun update --force` was explicit about it:

```
+ @arkv/logger@0.12.0 (v0.13.0 available)
```

Below 1.0.0 a caret pins the minor rather than the major, so `^0.12.0` is
`>=0.12.0 <0.13.0` and never admitted 0.13.0. The dependency range had to move
with the lockfile.

## What does not change

`0.13.0` adds one opt-in option, `batchConsole`. It needs nothing from
`LoggerModule`: `LoggerSettings` already passes a whole `LoggerConfig` through, so
a consumer that wants it can set it today.

It stays off, and on this evidence should. Measured against this request path it
was **slower**: 10267 ns unbatched against 11106 batched with stdout on /dev/null,
and 22.9 us against 23.8 us with stdout in a pipe nobody drains. A write to
/dev/null costs about 100 ns so there is little to save, and against a blocked
consumer the limit is bytes rather than calls.

## Checks

`bun run build`, `bun run ci static`, `bun run ci unit`, `bun run ci examples`,
and `packages/infra`'s own logger suite all pass. The diff is two lines: the
dependency range and the lockfile entry, whose integrity hash matches the one
arkv's publish step recorded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the logging component to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->