### PR TITLE
feat(http): requestIdHeader, the 11% that leaves the process

### DIFF
--- a/docs/guide/13-logging.md
+++ b/docs/guide/13-logging.md
@@ -489,7 +489,7 @@ Any UUID version is accepted; the check reads the shape rather than the version 
 
 It is set on the response of every request the middleware handles - which is every
 request except an `ignore`d one, and one of those too if `correlateIgnored` is on.
-See the option below.
+See the option below. `requestIdHeader: false` stops it going out at all.
 
 ### Options
 
@@ -499,10 +499,34 @@ interface RequestLoggingOptions {
   requestBody?: boolean; // default false
   responseBody?: boolean; // default false
   ignore?: readonly string[]; // paths skipped entirely - see below
+  ignorePrefix?: readonly string[]; // prefixes skipped, for a whole mount
   correlateIgnored?: boolean; // default false; keep the id on an ignored path
   correlate?: boolean; // default true; false drops the async scope - see below
+  requestIdHeader?: boolean; // default true; false stops `x-request-id` going out
+  trace?: boolean; // default false; adopt W3C Trace Context - see below
 }
 ```
+
+### `requestIdHeader`
+
+The response header is the only part of request logging that leaves the process,
+and it is about 500 ns of the 4.7 µs the path costs, which is 11%. It is the
+largest single thing you can turn off without losing a field from a log line.
+
+```ts
+requestLogging: {
+  requestIdHeader: false;
+}
+```
+
+What you keep: the id is still minted, still on every line the middleware writes,
+and still in the `AsyncLocalStorage` scope, so everything else the request logs
+carries it. What you lose is the outward half, a caller quoting an id back at you,
+and that includes failures: the error mapper stamps a fresh `Response` from what
+the middleware recorded, and `false` stops it recording.
+
+Turn it off on a service nothing correlates from the outside. Leave it on at an
+edge.
 
 **Both body options default to `false`**, and the request body is the field most
 likely to contain a password. Turn them on in development.

--- a/examples/full/src/http/http-options.ts
+++ b/examples/full/src/http/http-options.ts
@@ -69,6 +69,7 @@ export class AppHttpOptions extends HttpOptionsProvider {
       // ~360 ns per request, so off by default. On here so `traceId` joins
       // `requestId` and `@dunx/http/client` forwards it upstream.
       trace: true,
+      requestIdHeader: true,
     };
   }
 }

--- a/internal/bench/inproc-driver.ts
+++ b/internal/bench/inproc-driver.ts
@@ -14,6 +14,7 @@ const LADDER = [
   'scope',
   'als',
   'request',
+  'then',
   'respheader',
   'entry-discard',
   'entry-stamp',

--- a/internal/bench/steps.ts
+++ b/internal/bench/steps.ts
@@ -24,6 +24,7 @@ export const STEPS = [
   'scope',
   'als',
   'request',
+  'then',
   'respheader',
   'entry',
   'precomp',
@@ -277,6 +278,11 @@ export class StepMiddleware implements Middleware {
       }
 
       return next().then((response) => {
+        // `then` and `respheader` split what used to be one step. The row below
+        // it returns `next()` directly, so a single step was carrying both the
+        // promise continuation and the `Headers.set`, which are unrelated costs.
+        if (this.#at('then')) return response;
+
         response.headers.set(REQUEST_ID_HEADER, requestId);
         if (this.#at('respheader')) return response;
 

--- a/packages/http/src/server/request-id.ts
+++ b/packages/http/src/server/request-id.ts
@@ -46,10 +46,14 @@ export class RequestIds {
    * Called by `RequestLoggingMiddleware` and by nothing else. Splitting minting
    * from recording would let a second caller invent an id the log line does not
    * carry.
+   *
+   * `expose: false` mints without recording, so {@link stamp} answers without a
+   * header as it does for a path that minted none. That is how
+   * `requestIdHeader: false` reaches the error mapper.
    */
-  static assign(req: Request): string {
+  static assign(req: Request, expose = true): string {
     const id = traceId(req.headers.get(REQUEST_ID_HEADER));
-    (req as Tagged)[ID] = id;
+    if (expose) (req as Tagged)[ID] = id;
     return id;
   }
 

--- a/packages/http/src/server/request-logging.test.ts
+++ b/packages/http/src/server/request-logging.test.ts
@@ -381,3 +381,84 @@ describe('request logging', () => {
     );
   });
 });
+
+/**
+ * `x-request-id` on the response is the only part of request logging that leaves
+ * the process, so turning it off has to leave everything inside it working: the
+ * entry, the async scope, and the same silence on a failure.
+ */
+describe('requestIdHeader', () => {
+  const opts = { requestLogging: { requestIdHeader: false } } as const;
+
+  it('answers without the header and still logs the id', async () => {
+    const seen: { header?: string | undefined } = {};
+    const entries = await captured(async () => {
+      await withApp(async (_app, url) => {
+        const response = await fetch(new URL('things', url));
+        seen.header = response.headers.get('x-request-id') ?? undefined;
+      }, opts);
+    });
+
+    expect(seen.header).toBeUndefined();
+    const entry = entries.find((e) =>
+      String(e['message']).startsWith('GET /things'),
+    );
+    expect(String(entry?.['requestId'])).toMatch(UUID);
+  });
+
+  it('keeps the async scope, so a handler still logs the same id', async () => {
+    const entries = await captured(async () => {
+      await withApp(async (app, url) => {
+        handlerLogger.current = app.get(Logger);
+        await fetch(new URL('things/inner', url));
+        handlerLogger.current = undefined;
+      }, opts);
+    });
+
+    const fromHandler = entries.find(
+      (e) => e['message'] === 'from the handler',
+    );
+    const fromMiddleware = entries.find((e) =>
+      String(e['message']).startsWith('GET /things/inner'),
+    );
+    expect(fromHandler?.['requestId']).toBeDefined();
+    expect(fromHandler?.['requestId']).toBe(fromMiddleware?.['requestId']);
+  });
+
+  /**
+   * A failure never returns the middleware's response: the error mapper builds a
+   * fresh one, and stamps it from what `RequestIds.assign` recorded. Turning the
+   * header off has to reach that path too, or it would come back on the 500s.
+   */
+  it('stays off on a failure, which the error mapper answers', async () => {
+    const seen: { header?: string | undefined; status?: number } = {};
+    await captured(async () => {
+      await withApp(async (_app, url) => {
+        const response = await fetch(new URL('things/broken', url));
+        seen.status = response.status;
+        seen.header = response.headers.get('x-request-id') ?? undefined;
+      }, opts);
+    });
+
+    expect(seen.status).toBe(500);
+    expect(seen.header).toBeUndefined();
+  });
+
+  it('is on by default, on both a success and a failure', async () => {
+    const seen: { ok?: string | undefined; failed?: string | undefined } = {};
+    await captured(async () => {
+      await withApp(async (_app, url) => {
+        seen.ok =
+          (await fetch(new URL('things', url))).headers.get('x-request-id') ??
+          undefined;
+        seen.failed =
+          (await fetch(new URL('things/broken', url))).headers.get(
+            'x-request-id',
+          ) ?? undefined;
+      });
+    });
+
+    expect(String(seen.ok)).toMatch(UUID);
+    expect(String(seen.failed)).toMatch(UUID);
+  });
+});

--- a/packages/http/src/server/request-logging.ts
+++ b/packages/http/src/server/request-logging.ts
@@ -57,6 +57,16 @@ export interface RequestLoggingOptions {
    */
   readonly correlate?: boolean;
   /**
+   * Put `x-request-id` on the response. Default `true`, and ~500 ns of the 4.7 us
+   * the path costs, which is the largest thing here that can go without losing a
+   * field from a line.
+   *
+   * `false` keeps the id on this middleware's own lines and in the async scope,
+   * and withholds it from every response including a failure's: the error mapper
+   * stamps from what `RequestIds.assign` recorded, and this stops it recording.
+   */
+  readonly requestIdHeader?: boolean;
+  /**
    * Adopt W3C Trace Context, so `traceId`, `spanId` and `parentSpanId` join
    * `requestId`. Default `false`: it costs a header read and 8 random bytes, and
    * `requestId` already spans two dunx services. `@dunx/http/client` sends the
@@ -103,6 +113,7 @@ export class RequestLoggingMiddleware implements Middleware {
   readonly #correlateIgnored: boolean;
   readonly #correlate: boolean;
   readonly #trace: boolean;
+  readonly #requestIdHeader: boolean;
 
   constructor(
     private readonly logger: Logger,
@@ -117,6 +128,7 @@ export class RequestLoggingMiddleware implements Middleware {
     this.#correlateIgnored = options.correlateIgnored ?? false;
     this.#correlate = options.correlate ?? true;
     this.#trace = options.trace ?? false;
+    this.#requestIdHeader = options.requestIdHeader ?? true;
   }
 
   /** Both guards check emptiness first, so configuring neither costs two reads. */
@@ -141,7 +153,7 @@ export class RequestLoggingMiddleware implements Middleware {
     }
 
     const started = Bun.nanoseconds();
-    const requestId = RequestIds.assign(req);
+    const requestId = RequestIds.assign(req, this.#requestIdHeader);
     const scope: ScopeFields = {
       requestId,
       method: ctx.method,
@@ -246,9 +258,11 @@ export class RequestLoggingMiddleware implements Middleware {
     path: string,
     next: Next,
   ): Promise<Response> {
-    const requestId = RequestIds.assign(req);
+    const requestId = RequestIds.assign(req, this.#requestIdHeader);
     const stamp = (response: Response): Response => {
-      response.headers.set(REQUEST_ID_HEADER, requestId);
+      if (this.#requestIdHeader) {
+        response.headers.set(REQUEST_ID_HEADER, requestId);
+      }
       return response;
     };
     if (!this.#correlate) return next().then(stamp);
@@ -347,7 +361,9 @@ export class RequestLoggingMiddleware implements Middleware {
         statusCode: response.status,
         elapsedMs: elapsedMs(started),
       });
-      response.headers.set(REQUEST_ID_HEADER, requestId);
+      if (this.#requestIdHeader) {
+        response.headers.set(REQUEST_ID_HEADER, requestId);
+      }
       return response;
     }
     return body.then((value) => {
@@ -358,7 +374,9 @@ export class RequestLoggingMiddleware implements Middleware {
         ...(value === undefined ? {} : { responseBody: value }),
         elapsedMs: elapsedMs(started),
       });
-      response.headers.set(REQUEST_ID_HEADER, requestId);
+      if (this.#requestIdHeader) {
+        response.headers.set(REQUEST_ID_HEADER, requestId);
+      }
       return response;
     });
   }

--- a/tools/create-app/templates/features/http/http-options.ts
+++ b/tools/create-app/templates/features/http/http-options.ts
@@ -69,6 +69,7 @@ export class AppHttpOptions extends HttpOptionsProvider {
       // ~360 ns per request, so off by default. On here so `traceId` joins
       // `requestId` and `@dunx/http/client` forwards it upstream.
       trace: true,
+      requestIdHeader: true,
     };
   }
 }


### PR DESCRIPTION
> Stacked on #28, which contains the rig this measures with. Base is
> `chore/logging-cost-measurement`; retarget to `main` once that merges.

## Why `headers.set` is on the logging path at all

It is not logging. `x-request-id` on the response is request-id propagation, and
it lives in the logging middleware because that is what mints the id:
`RequestIds.assign` records it, `#succeeded` puts it on the response, and
`RequestIds.stamp` exists so the error mapper can attach it to a failure, which
builds a fresh `Response` outside the chain. The point is letting a caller
correlate a response with server logs, and it is why an id is minted rather than
just logged.

It was also unconditional. `RequestLoggingOptions` had `correlate`, `trace`,
`ignore` and the body flags, and no way to turn it off.

## What it costs

The ladder attributed 676 ns to a single `respheader` step, but that step was
carrying two unrelated things: the `.then` continuation **and** the `Headers.set`.
Splitting them:

| | in situ | isolated |
| --- | ---: | ---: |
| the `.then` continuation | 381 ns | 55 ns |
| **`response.headers.set`** | **759 ns +- 44** | 177 ns |

The continuation is irreducible: the status cannot be logged without observing the
response. The header is not. Against the 4708 ns request logging costs, **759 ns
is 11%**, and it is the largest thing on this path that can go without losing a
field from a log line.

There is no cheaper way to attach it. Supplying the header at construction instead
of setting it afterwards measures 278 ns against 139, twice as much. The only
saving available is not attaching it.

The isolated figures are much smaller than the in-situ ones, which is the same
amplification every other part of this path shows.

## The option

```ts
requestLogging: { requestIdHeader: false };
```

Keeps every inward use of the id: still minted, still on every line this
middleware writes, still in the `AsyncLocalStorage` scope for everything else the
request logs. Gives up the outward one.

**It reaches failures too**, which is the part worth getting right. The error
mapper stamps a fresh `Response` from what `RequestIds.assign` recorded, so
`assign` now takes `expose` and simply does not record. `stamp` then answers
without a header exactly as it already does for a path that minted no id. Without
that, the header would have vanished from every 200 and reappeared on every 500.

## Tests

Four, covering: no header but the id still logged, the async scope still intact so
a handler logs the same id, the header still absent on a failure, and both on by
default. The first and third were run against a build with the option forced on to
confirm they fail without it.

## Notes on the smaller pieces

- The bench rig gains a `then` row. One step was carrying both costs and reporting
  them as one number, which is how 676 ns looked like a single item for so long.
- `examples/full` states the option, but without a comment: that group's comment
  density budget is at its cap and three lines of explanation tipped it over.
  `docs/guide/13-logging.md` carries the explanation instead.
- That guide's options block was missing `ignorePrefix` and `trace`. Added, since
  the block is presented as the full set.
- `bun run sync:templates` after touching a vendored feature folder.

## Checks

`bun run build`, `ci static`, `ci unit`, `ci examples`, the docs voice gates and
`packages/http`'s own 533 tests all pass.
