### PR TITLE
feat(bench): a dunx-logging-arkv subject, so the production logger is measured

### DIFF
--- a/internal/bench/servers/dunx-logging-arkv.ts
+++ b/internal/bench/servers/dunx-logging-arkv.ts
@@ -1,0 +1,80 @@
+import { Module } from '@dunx/core';
+import { LoggerModule } from '@dunx/infra/logger';
+import {
+  Controller,
+  Get,
+  HttpFactory,
+  type Input,
+  Post,
+  type RouteSchemas,
+} from '@dunx/http';
+import { echo, jsonPayload, personSchema, PLAINTEXT, port } from './shared.js';
+
+/**
+ * `dunx-logging`, with `@arkv/logger` bound instead of core's `ConsoleLogger`.
+ *
+ * That is what `LoggerModule.forRoot()` does, and it is the configuration
+ * `packages/infra/README.md` recommends, so it is what most production apps run.
+ * Nothing else in the suite measured it: `dunx-logging` binds the default
+ * `ConsoleLogger`, which sanitizes nothing, and the two are not the same price.
+ *
+ * This row exists because the difference was estimated twice and the two estimates
+ * disagreed by 5.7x. Tight-loop benches put `Logger.info` at 1474 ns against
+ * `ConsoleLogger`'s 543, so +931 ns; an in-process rig with no socket under it put
+ * the gap at +5324 ns. A figure derived from the second went into
+ * `docs/architecture/cost-of-logging.md` and had to be retracted. Neither estimate
+ * is worth quoting, and this row is the thing that settles it.
+ *
+ * `isDevelopment: false` so the entry is JSON rather than the coloured rendering,
+ * matching what `dunx-logging` writes and what a container runs.
+ */
+class Greeter {
+  text(): string {
+    return PLAINTEXT;
+  }
+
+  payload(): { message: string } {
+    return jsonPayload();
+  }
+}
+
+const plain = {} as const satisfies RouteSchemas;
+const validate = {
+  body: personSchema,
+  status: 200,
+} as const satisfies RouteSchemas;
+
+@Controller()
+class BenchController {
+  constructor(private readonly greeter: Greeter) {}
+
+  @Get('/plaintext')
+  plaintext(): Response {
+    return new Response(this.greeter.text());
+  }
+
+  @Get('/json')
+  json(): { message: string } {
+    return this.greeter.payload();
+  }
+
+  @Get('/params/:id', plain)
+  params(input: Input<typeof plain>): { id: string | undefined } {
+    return { id: input.req.params['id'] };
+  }
+
+  @Post('/validate', validate)
+  validate(input: Input<typeof validate>): { name: string; age: number } {
+    return echo(input.body);
+  }
+}
+
+@Module({
+  imports: [LoggerModule.forRoot({ isDevelopment: false })],
+  controllers: [BenchController],
+  providers: [Greeter],
+})
+class AppModule {}
+
+const app = await HttpFactory.create(AppModule, { port: port() });
+await app.listen();

--- a/internal/bench/src/subjects.ts
+++ b/internal/bench/src/subjects.ts
@@ -41,6 +41,19 @@ export const subjects: readonly Subject[] = [
     ],
   },
   {
+    id: 'dunx-logging-arkv',
+    label: '@dunx/http (+ request logging, @arkv/logger)',
+    runtime: 'bun',
+    entry: 'servers/dunx-logging-arkv.ts',
+    preload: ['@dunx/transform/preload'],
+    versionOf: '@dunx/http',
+    validator: 'zod (Standard Schema)',
+    notes: [
+      '`dunx-logging` with `LoggerModule.forRoot()` bound, which is what `packages/infra/README.md` recommends and therefore what most production apps run.',
+      'It is here because the gap to `dunx-logging` was estimated twice and the estimates disagreed by 5.7x. Nothing that quotes a figure for this configuration should predate this row.',
+    ],
+  },
+  {
     id: 'elysia',
     label: 'Elysia',
     runtime: 'bun',


### PR DESCRIPTION
## Why

`dunx-logging` binds core's `ConsoleLogger`. `LoggerModule.forRoot()` binds
`@arkv/logger`, which is what `packages/infra/README.md` recommends and therefore
what most production apps run. **No row in the suite measured it**, and that gap is
how an unmeasured "46% of `bun-serve`" reached `docs/architecture/cost-of-logging.md`
and had to be retracted the same day (#32).

The difference between the two loggers has now been estimated three times, by three
methods, and they do not agree:

| method | arkv over `ConsoleLogger` |
| --- | ---: |
| tight-loop benches (`Logger.info` 1474 vs 543 ns) | +931 ns |
| in-process rig, no socket | +5324 ns |
| **this subject, through a socket** | **+3.49 µs, a 1.45x ratio** |

Three answers spanning 5.7x is the argument for measuring it rather than for
quoting any of them.

## What it is

`dunx-logging` with `LoggerModule.forRoot({ isDevelopment: false })` and nothing
else changed, so the pair differs by the bound `Logger` alone. `isDevelopment:
false` selects JSON rather than the coloured rendering, matching what
`dunx-logging` writes and what a container runs.

Verified it is actually arkv rather than a silent fallback to `ConsoleLogger`,
which would have made the row measure the same thing twice: the resolved `Logger`
has `child()` and `stats()`, which `ConsoleLogger` does not, and is the same
instance as `BackingLogger`.

## The number in the table above is not a result

It came from a run on a battery-powered laptop that put `@dunx/http` at **104.6% of
raw `Bun.serve`**, which is impossible, with standard deviations of 10-14k req/s on
a ~40k median. The two logging subjects sit adjacent in the same round-robin so
their comparison is the most trustworthy thing in that run, and it is still not
worth publishing.

**This needs a run on the machine `results/latest.json` came from**, the 5950X:

```bash
bun run start --subjects bun-serve,dunx,dunx-logging,dunx-logging-arkv
```

Until then, nothing about the cost of the production logging configuration should
carry a percent sign.

## Checks

`bun run ci static` and `internal/bench`'s own suite pass. The subject boots,
serves all four scenarios, and writes arkv-formatted entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new HTTP benchmark scenario with request logging.
  * Added support for plaintext, JSON, parameterized, and validated POST requests.
  * Added production-oriented configuration and startup support for the benchmark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->