### PR TITLE
refactor: share contracts across packages instead of restating them

### DIFF
--- a/internal/bench/src/db-modes.ts
+++ b/internal/bench/src/db-modes.ts
@@ -32,14 +32,8 @@ import {
   startSubject,
   type SubjectProcess,
 } from './subject-process.js';
-import type {
-  LoadRequest,
-  LoadSample,
-  MachineInfo,
-  Scenario,
-  Spread,
-  Subject,
-} from './types.js';
+import type { MachineInfo, Scenario, Spread, Subject } from './types.js';
+import { driveUnits, note, num, type Live } from './driver.js';
 
 type Mode = 'async' | 'sync';
 
@@ -90,17 +84,6 @@ const units: readonly Unit[] = [
   { id: 'write:sync', mode: 'sync', scenario: WRITE },
 ];
 
-const note = (message: string): void => {
-  process.stderr.write(`${message}\n`);
-};
-
-interface Live {
-  readonly unit: Unit;
-  readonly server: SubjectProcess;
-  readonly request: LoadRequest;
-  readonly samples: LoadSample[];
-}
-
 interface Result {
   readonly id: string;
   readonly scenario: string;
@@ -133,7 +116,7 @@ interface Report {
  */
 const servers = new Map<Mode, SubjectProcess>();
 
-const bring = async (unit: Unit): Promise<Live> => {
+const bring = async (unit: Unit): Promise<Live<Unit>> => {
   let server = servers.get(unit.mode);
   if (server === undefined) {
     const chosen = subject(unit.mode);
@@ -165,7 +148,7 @@ const bring = async (unit: Unit): Promise<Live> => {
   };
 };
 
-const collect = (live: Live): Result => ({
+const collect = (live: Live<Unit>): Result => ({
   id: live.unit.id,
   scenario: live.unit.scenario.id,
   mode: live.unit.mode,
@@ -209,9 +192,6 @@ if (values.help === true) {
   process.exit(0);
 }
 
-const num = (raw: string | undefined, fallback: number): number =>
-  raw === undefined ? fallback : Number(raw);
-
 const config = {
   connections: num(values.connections, 64),
   durationSeconds: num(values.duration, 4),
@@ -231,33 +211,7 @@ const machine = await readMachine('node');
  * throughput drifts by more than such a gap over the minutes a run takes. Measuring
  * each unit to completion in turn would map that drift onto unit identity.
  */
-const live: Live[] = [];
-try {
-  for (const unit of units) {
-    live.push(await bring(unit));
-    note(`up   ${unit.id}`);
-  }
-
-  const options = {
-    connections: config.connections,
-    durationSeconds: config.durationSeconds,
-  };
-  for (const entry of live) {
-    await generator.run(entry.request, {
-      ...options,
-      durationSeconds: config.warmupSeconds,
-    });
-  }
-
-  for (let round = 0; round < config.runs; round += 1) {
-    note(`round ${round + 1} of ${config.runs}`);
-    for (const entry of live) {
-      entry.samples.push(await generator.run(entry.request, options));
-    }
-  }
-} finally {
-  for (const server of servers.values()) await server.stop();
-}
+const live = await driveUnits(units, bring, generator, config);
 
 const results = live.map(collect);
 for (const result of results) {

--- a/internal/bench/src/db-modes.ts
+++ b/internal/bench/src/db-modes.ts
@@ -118,6 +118,9 @@ const servers = new Map<Mode, SubjectProcess>();
 
 const bring = async (unit: Unit): Promise<Live<Unit>> => {
   let server = servers.get(unit.mode);
+  // Only this call's own server is this call's to clean up: a later unit reusing
+  // one must not stop it out from under the entry that already holds it.
+  const started = server === undefined;
   if (server === undefined) {
     const chosen = subject(unit.mode);
     server = await startSubject(chosen, bunCommand(chosen), {
@@ -126,26 +129,34 @@ const bring = async (unit: Unit): Promise<Live<Unit>> => {
     servers.set(unit.mode, server);
   }
 
-  const url = `${server.baseUrl}${unit.scenario.path}`;
-  const probe = await fetch(url, { method: unit.scenario.method });
-  const body = await probe.text();
-  const matches =
-    unit.scenario.expectBody === ''
-      ? body.startsWith('{')
-      : body === unit.scenario.expectBody;
-  if (probe.status !== unit.scenario.expectStatus || !matches) {
-    throw new Error(
-      `${unit.id} answered ${probe.status} ${JSON.stringify(body)}, expected ` +
-        `${unit.scenario.expectStatus} ${JSON.stringify(unit.scenario.expectBody)}`,
-    );
-  }
+  try {
+    const url = `${server.baseUrl}${unit.scenario.path}`;
+    const probe = await fetch(url, { method: unit.scenario.method });
+    const body = await probe.text();
+    const matches =
+      unit.scenario.expectBody === ''
+        ? body.startsWith('{')
+        : body === unit.scenario.expectBody;
+    if (probe.status !== unit.scenario.expectStatus || !matches) {
+      throw new Error(
+        `${unit.id} answered ${probe.status} ${JSON.stringify(body)}, expected ` +
+          `${unit.scenario.expectStatus} ${JSON.stringify(unit.scenario.expectBody)}`,
+      );
+    }
 
-  return {
-    unit,
-    server,
-    request: { url, method: unit.scenario.method },
-    samples: [],
-  };
+    return {
+      unit,
+      server,
+      request: { url, method: unit.scenario.method },
+      samples: [],
+    };
+  } catch (error) {
+    if (started) {
+      await server.stop();
+      servers.delete(unit.mode);
+    }
+    throw error;
+  }
 };
 
 const collect = (live: Live<Unit>): Result => ({

--- a/internal/bench/src/driver.ts
+++ b/internal/bench/src/driver.ts
@@ -33,6 +33,10 @@ export interface DriverConfig {
  * busier over the run then moves every subject together instead of penalising
  * whichever went last. `db-modes`, `logging` and `validation` each had a copy of
  * this loop, which is three places for the measurement to drift apart.
+ *
+ * **`bring` owns what it starts until it returns.** Teardown here can only reach a
+ * server that reached a `Live` entry, so a `bring` that starts a process and then
+ * throws - a failed probe, most likely - must stop that process itself.
  */
 export const driveUnits = async <U extends { readonly id: string }>(
   units: readonly U[],

--- a/internal/bench/src/driver.ts
+++ b/internal/bench/src/driver.ts
@@ -1,0 +1,75 @@
+import type { SubjectProcess } from './subject-process.js';
+import type { LoadGenerator, LoadRequest, LoadSample } from './types.js';
+
+/** Progress goes to stderr, so stdout stays the report a caller may redirect. */
+export const note = (message: string): void => {
+  process.stderr.write(`${message}\n`);
+};
+
+export const num = (raw: string | undefined, fallback: number): number =>
+  raw === undefined ? fallback : Number(raw);
+
+/** One subject under measurement: what it is, where it runs, what it answered. */
+export interface Live<U> {
+  readonly unit: U;
+  readonly server: SubjectProcess;
+  readonly request: LoadRequest;
+  readonly samples: LoadSample[];
+}
+
+/** The subset of `BenchConfig` a side harness reads. */
+export interface DriverConfig {
+  readonly connections: number;
+  readonly durationSeconds: number;
+  readonly warmupSeconds: number;
+  readonly runs: number;
+}
+
+/**
+ * Bring every unit up, warm each one, then sample them round-robin, stopping
+ * every server that started whether or not the run finished.
+ *
+ * Round-robin rather than one subject at a time: a machine that drifts warmer or
+ * busier over the run then moves every subject together instead of penalising
+ * whichever went last. `db-modes`, `logging` and `validation` each had a copy of
+ * this loop, which is three places for the measurement to drift apart.
+ */
+export const driveUnits = async <U extends { readonly id: string }>(
+  units: readonly U[],
+  bring: (unit: U) => Promise<Live<U>>,
+  generator: LoadGenerator,
+  config: DriverConfig,
+): Promise<readonly Live<U>[]> => {
+  const live: Live<U>[] = [];
+  try {
+    for (const unit of units) {
+      live.push(await bring(unit));
+      note(`up   ${unit.id}`);
+    }
+
+    const options = {
+      connections: config.connections,
+      durationSeconds: config.durationSeconds,
+    };
+    for (const entry of live) {
+      await generator.run(entry.request, {
+        ...options,
+        durationSeconds: config.warmupSeconds,
+      });
+    }
+
+    for (let round = 0; round < config.runs; round += 1) {
+      note(`round ${round + 1} of ${config.runs}`);
+      for (const entry of live) {
+        entry.samples.push(await generator.run(entry.request, options));
+      }
+    }
+  } finally {
+    // By distinct server, not by entry: `db-modes` runs several units against one
+    // process per mode, so stopping per entry would stop the same one repeatedly.
+    for (const server of new Set(live.map((entry) => entry.server))) {
+      await server.stop();
+    }
+  }
+  return live;
+};

--- a/internal/bench/src/logging.ts
+++ b/internal/bench/src/logging.ts
@@ -23,16 +23,9 @@ import {
   bunCommand,
   startSubject,
   type StdoutSink,
-  type SubjectProcess,
 } from './subject-process.js';
-import type {
-  LoadRequest,
-  LoadSample,
-  LoggingReport,
-  LoggingUnit,
-  Scenario,
-  Subject,
-} from './types.js';
+import type { LoggingReport, LoggingUnit, Scenario, Subject } from './types.js';
+import { driveUnits, note, num, type Live } from './driver.js';
 
 const subject: Subject = {
   id: 'dunx',
@@ -229,18 +222,7 @@ const units: readonly Unit[] = [
   },
 ];
 
-const note = (message: string): void => {
-  process.stderr.write(`${message}\n`);
-};
-
-interface Live {
-  readonly unit: Unit;
-  readonly server: SubjectProcess;
-  readonly request: LoadRequest;
-  readonly samples: LoadSample[];
-}
-
-const bring = async (unit: Unit, scenario: Scenario): Promise<Live> => {
+const bring = async (unit: Unit, scenario: Scenario): Promise<Live<Unit>> => {
   const server = await startSubject(
     subject,
     bunCommand(subject),
@@ -277,7 +259,7 @@ const bring = async (unit: Unit, scenario: Scenario): Promise<Live> => {
   };
 };
 
-const collect = (live: Live): LoggingUnit => ({
+const collect = (live: Live<Unit>): LoggingUnit => ({
   id: live.unit.id,
   label: live.unit.label,
   adds: live.unit.adds,
@@ -325,9 +307,6 @@ if (values.help === true) {
   console.log(usage);
   process.exit(0);
 }
-
-const num = (raw: string | undefined, fallback: number): number =>
-  raw === undefined ? fallback : Number(raw);
 
 const chosenId = values.scenario ?? 'json';
 const scenario = scenarios.find((entry) => entry.id === chosenId);
@@ -395,33 +374,12 @@ if (skipped > 0 && wanted === undefined) {
 }
 if (chosenUnits.length === 0) throw new Error('--only matched no units');
 
-const live: Live[] = [];
-try {
-  for (const unit of chosenUnits) {
-    live.push(await bring(unit, scenario));
-    note(`up   ${unit.id}`);
-  }
-
-  const options = {
-    connections: config.connections,
-    durationSeconds: config.durationSeconds,
-  };
-  for (const entry of live) {
-    await generator.run(entry.request, {
-      ...options,
-      durationSeconds: config.warmupSeconds,
-    });
-  }
-
-  for (let round = 0; round < config.runs; round += 1) {
-    note(`round ${round + 1} of ${config.runs}`);
-    for (const entry of live) {
-      entry.samples.push(await generator.run(entry.request, options));
-    }
-  }
-} finally {
-  for (const entry of live) await entry.server.stop();
-}
+const live = await driveUnits(
+  chosenUnits,
+  (unit) => bring(unit, scenario),
+  generator,
+  config,
+);
 
 const results = live.map(collect);
 const baseline = results[0]?.rps.median ?? 0;

--- a/internal/bench/src/validation.ts
+++ b/internal/bench/src/validation.ts
@@ -21,14 +21,8 @@ import { selectGenerator, type LoadGeneratorChoice } from './loadgen/index.js';
 import { readMachine } from './machine.js';
 import { resultsDir } from './paths.js';
 import { spread } from './stats.js';
-import {
-  bunCommand,
-  startSubject,
-  type SubjectProcess,
-} from './subject-process.js';
+import { bunCommand, startSubject } from './subject-process.js';
 import type {
-  LoadRequest,
-  LoadSample,
   Scenario,
   Subject,
   ValidationReport,
@@ -39,6 +33,7 @@ import {
   validatorIds,
   type ValidatorId,
 } from '../servers/validation/schemas.js';
+import { driveUnits, note, num, type Live } from './driver.js';
 
 const EXPECT_BODY = '{"name":"Ada Lovelace","age":36}';
 
@@ -178,22 +173,11 @@ const unitsFor = (chosen: readonly ValidatorId[]): readonly Unit[] => {
   return [...decompose, ...perValidator];
 };
 
-const note = (message: string): void => {
-  process.stderr.write(`${message}\n`);
-};
-
-interface Live {
-  readonly unit: Unit;
-  readonly server: SubjectProcess;
-  readonly request: LoadRequest;
-  readonly samples: LoadSample[];
-}
-
 /**
  * Spawns the unit, checks it answers the exact expected bytes, and warms it up.
  * The process is then left running, because the measured rounds are interleaved.
  */
-const bring = async (unit: Unit): Promise<Live> => {
+const bring = async (unit: Unit): Promise<Live<Unit>> => {
   const server = await startSubject(unit.subject, bunCommand(unit.subject), {
     VALIDATOR: unit.validator,
   });
@@ -227,7 +211,7 @@ const bring = async (unit: Unit): Promise<Live> => {
   };
 };
 
-const collect = (live: Live): ValidationUnit => ({
+const collect = (live: Live<Unit>): ValidationUnit => ({
   id: live.unit.id,
   group: live.unit.group,
   label: live.unit.label,
@@ -278,9 +262,6 @@ if (values.help === true) {
   process.exit(0);
 }
 
-const num = (raw: string | undefined, fallback: number): number =>
-  raw === undefined ? fallback : Number(raw);
-
 const chosen: readonly ValidatorId[] =
   values.validators === undefined
     ? validatorIds
@@ -315,33 +296,7 @@ const units = unitsFor(chosen);
  * first attempt at this had `raw:parse` come out *slower* than `raw:noop`, which does
  * strictly more work. Interleaving spreads the drift across every row instead.
  */
-const live: Live[] = [];
-try {
-  for (const unit of units) {
-    live.push(await bring(unit));
-    note(`up   ${unit.id}`);
-  }
-
-  const options = {
-    connections: config.connections,
-    durationSeconds: config.durationSeconds,
-  };
-  for (const entry of live) {
-    await generator.run(entry.request, {
-      ...options,
-      durationSeconds: config.warmupSeconds,
-    });
-  }
-
-  for (let round = 0; round < config.runs; round += 1) {
-    note(`round ${round + 1} of ${config.runs}`);
-    for (const entry of live) {
-      entry.samples.push(await generator.run(entry.request, options));
-    }
-  }
-} finally {
-  for (const entry of live) await entry.server.stop();
-}
+const live = await driveUnits(units, bring, generator, config);
 
 const results = live.map(collect);
 for (const result of results) {

--- a/internal/docs/scripts/extract/bench.ts
+++ b/internal/docs/scripts/extract/bench.ts
@@ -67,7 +67,12 @@ export const readBench = (file: string): BenchModel | null => {
   // mismatch branch to `never` and the guard stops guarding - while the file on disk
   // is whatever a previous version of the harness wrote.
   const raw: unknown = JSON.parse(readFileSync(file, 'utf8'));
-  const version = (raw as { schemaVersion?: unknown }).schemaVersion;
+  // `null` is valid JSON and reading a property off it throws, which would turn a
+  // truncated report into a crashed build rather than a skipped section.
+  const version =
+    typeof raw === 'object' && raw !== null
+      ? (raw as { schemaVersion?: unknown }).schemaVersion
+      : undefined;
   if (version !== BENCH_SCHEMA_VERSION) {
     console.warn(
       `docs: benchmark schemaVersion ${String(version)}, expected ${BENCH_SCHEMA_VERSION} - skipping`,

--- a/internal/docs/scripts/extract/bench.ts
+++ b/internal/docs/scripts/extract/bench.ts
@@ -62,13 +62,19 @@ export const readBench = (file: string): BenchModel | null => {
     return null;
   }
 
-  const report = JSON.parse(readFileSync(file, 'utf8')) as BenchReport;
-  if (report.schemaVersion !== BENCH_SCHEMA_VERSION) {
+  // Read the version off untyped JSON, not off `BenchReport`. The harness types
+  // `schemaVersion` as the literal `1`, so checking it through that type narrows the
+  // mismatch branch to `never` and the guard stops guarding - while the file on disk
+  // is whatever a previous version of the harness wrote.
+  const raw: unknown = JSON.parse(readFileSync(file, 'utf8'));
+  const version = (raw as { schemaVersion?: unknown }).schemaVersion;
+  if (version !== BENCH_SCHEMA_VERSION) {
     console.warn(
-      `docs: benchmark schemaVersion ${report.schemaVersion}, expected ${BENCH_SCHEMA_VERSION} - skipping`,
+      `docs: benchmark schemaVersion ${String(version)}, expected ${BENCH_SCHEMA_VERSION} - skipping`,
     );
     return null;
   }
+  const report = raw as BenchReport;
 
   return projectBench(report);
 };

--- a/internal/docs/scripts/extract/model.ts
+++ b/internal/docs/scripts/extract/model.ts
@@ -1,3 +1,15 @@
+import type {
+  BenchConfig,
+  MachineInfo,
+  Report,
+  Runtime,
+  Scenario,
+  ScenarioResult,
+  Spread,
+  StartupResult,
+  SubjectInfo,
+} from '../../../bench/src/types.js';
+
 export const SymbolKind = Object.freeze({
   Class: 'class',
   Function: 'function',
@@ -176,105 +188,26 @@ export interface CoverageModel {
 /**
  * The benchmark report, as `internal/bench` writes it to `results/latest.json`.
  * The shape is that harness's contract, documented in `internal/bench/README.md`
- * and versioned by `schemaVersion`; this is a mirror of it, not a re-derivation.
- * A build with no run emits `null` in its place.
+ * and versioned by `schemaVersion`. A build with no run emits `null` in its place.
  */
 export const BENCH_SCHEMA_VERSION = 1;
 
-export type BenchRuntime =
-  | 'bun'
-  | 'node'
-  | 'go'
-  | 'rust'
-  | 'jvm'
-  | 'dotnet'
-  | 'python';
-
-export interface BenchMachine {
-  readonly cpuModel: string;
-  readonly cores: number;
-  readonly ramGiB: number;
-  readonly platform: string;
-  readonly kernel: string;
-  readonly arch: string;
-  readonly bun: string;
-  readonly node: string;
-}
-
-export interface BenchLoadGenerator {
-  readonly id: string;
-  readonly version: string;
-  readonly binary: string | null;
-  readonly limitations: readonly string[];
-}
-
-export interface BenchConfig {
-  readonly connections: number;
-  readonly durationSeconds: number;
-  readonly warmupSeconds: number;
-  readonly runs: number;
-  readonly startupSamples: number;
-}
-
-export interface BenchSpread {
-  readonly median: number;
-  readonly min: number;
-  readonly max: number;
-  readonly stddev: number;
-}
-
-export interface ReportSubject {
-  readonly id: string;
-  readonly label: string;
-  readonly runtime: BenchRuntime;
-  readonly version: string;
-  readonly validator: string;
-  readonly notes: readonly string[];
-  readonly entry: string;
-  readonly preload: readonly string[];
-  readonly versionOf: string | null;
-}
-
-export interface ReportScenario {
-  readonly id: string;
-  readonly title: string;
-  readonly description: string;
-  readonly method: string;
-  readonly path: string;
-  readonly body?: string | undefined;
-  readonly contentType?: string | undefined;
-  readonly expectStatus: number;
-  readonly expectBody: string;
-  readonly expectMime: string;
-}
-
-export interface ReportResult {
-  readonly subject: string;
-  readonly scenario: string;
-  readonly rps: BenchSpread;
-  readonly latencyP50Ms: BenchSpread;
-  readonly latencyP99Ms: BenchSpread;
-  readonly totalErrors: number;
-  readonly totalNon2xx: number;
-}
-
-export interface ReportStartup {
-  readonly subject: string;
-  readonly samplesMs: readonly number[];
-  readonly medianMs: number;
-}
-
-export interface BenchReport {
-  readonly schemaVersion: number;
-  readonly generatedAt: string;
-  readonly machine: BenchMachine;
-  readonly loadGenerator: BenchLoadGenerator;
-  readonly config: BenchConfig;
-  readonly subjects: readonly ReportSubject[];
-  readonly scenarios: readonly ReportScenario[];
-  readonly results: readonly ReportResult[];
-  readonly startup: readonly ReportStartup[];
-}
+/**
+ * Aliases onto the harness's own types. It owns the shape because it writes the
+ * file, so a field added or renamed there is a compile error here rather than a
+ * silent mismatch - which is how `toolchains` came to be in the file and not in
+ * the nine interfaces that used to sit here.
+ */
+export type BenchRuntime = Runtime;
+export type BenchMachine = MachineInfo;
+export type BenchLoadGenerator = Report['loadGenerator'];
+export type BenchSpread = Spread;
+export type ReportSubject = SubjectInfo;
+export type ReportScenario = Scenario;
+export type ReportResult = ScenarioResult;
+export type ReportStartup = StartupResult;
+export type BenchReport = Report;
+export type { BenchConfig };
 
 /**
  * What the *site* carries, which is strictly what it renders.

--- a/packages/core/src/di/app.ts
+++ b/packages/core/src/di/app.ts
@@ -13,7 +13,7 @@ import {
 import { ROOT_MODULE, type ModuleRef } from './module.js';
 import { buildScopes, type Binding } from './scope.js';
 import { provide, type Registration } from './provider.js';
-import { ShutdownHooks, type ShutdownHookOptions } from './shutdown-hooks.js';
+import { ShutdownAware, type ShutdownHookOptions } from './shutdown-hooks.js';
 import { describeToken, isCtor, type InjectionToken } from './token.js';
 
 /**
@@ -84,7 +84,7 @@ export interface App {
   ): this;
 }
 
-class Application implements App {
+class Application extends ShutdownAware implements App {
   readonly closed: Promise<void>;
   /** Shadowing notices from the scope graph. Surfaced, not logged: core has no logger. */
   readonly warnings: readonly string[];
@@ -92,9 +92,9 @@ class Application implements App {
   #resolveClosed: (() => void) | undefined;
   #shuttingDown: Promise<void> | undefined;
   #draining: Promise<void> | undefined;
-  readonly #hooks = new ShutdownHooks();
 
   constructor(injector: Injector, warnings: readonly string[] = []) {
+    super();
     this.#injector = injector;
     this.warnings = warnings;
     this.closed = new Promise<void>((resolve) => {
@@ -197,14 +197,6 @@ class Application implements App {
     } catch {
       console.error(`[dunx] ${name ?? 'A provider'}.${phase}() failed`, error);
     }
-  }
-
-  enableShutdownHooks(
-    signals: readonly ShutdownSignal[] = ['SIGTERM', 'SIGINT'],
-    options: ShutdownHookOptions = {},
-  ): this {
-    this.#hooks.install(() => this.shutdown(), signals, options);
-    return this;
   }
 }
 

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -40,7 +40,11 @@ export {
 // own an application class with its own `enableShutdownHooks`, and three copies of
 // "drain, then make sure the process actually ends" is three chances to fix the
 // hang in one of them and not the others - which is how it got missed the first time.
-export { ShutdownHooks, type ShutdownHookOptions } from './shutdown-hooks.js';
+export {
+  ShutdownAware,
+  ShutdownHooks,
+  type ShutdownHookOptions,
+} from './shutdown-hooks.js';
 // collectModules + readControllers are the adapter seam: an HTTP package walks the
 // import graph and finds which instances to scan. Injector, readModule and the
 // lifecycle guards stay internal - exporting Injector would freeze the container's

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -24,7 +24,12 @@ export { inject } from './inject.js';
 // twice, for routes and for gateway handlers, and `@dunx/infra` a third time for
 // `@JobHandler`. Three copies meant a fix to the dedup or the `Object.prototype`
 // stop landing in one of them.
-export { classOf, markedMethods, type MarkedMethod } from './marked.js';
+export {
+  classOf,
+  inertInstance,
+  markedMethods,
+  type MarkedMethod,
+} from './marked.js';
 // `teardownError` and `teardownFailures` are exported because every application
 // class runs its own teardown phase - @dunx/http stops a server between two of
 // them, @dunx/infra stops queue workers - and each has to collect failures the same
@@ -109,6 +114,7 @@ export {
   token,
   type AbstractCtor,
   type Ctor,
+  type HandlerMethod,
   type InjectionToken,
   type Token,
 } from './token.js';

--- a/packages/core/src/di/marked.ts
+++ b/packages/core/src/di/marked.ts
@@ -70,3 +70,17 @@ export const classOf = (
     ? { token: entry.token, ctor: entry.provider.ctor }
     : undefined;
 };
+
+/**
+ * An instance of `ctor` with its prototype chain and nothing behind it: every
+ * method is reachable and `instance.constructor` still resolves to the class, but
+ * no constructor runs, so a class whose dependencies are absent can still be read.
+ *
+ * This is what makes route, gateway and OpenAPI discovery constructing-free. Three
+ * call sites across `@dunx/http` and `@dunx/openapi` each cast to a local
+ * `Prototyped` interface to do it.
+ */
+export const inertInstance = (ctor: Ctor<unknown>): object =>
+  Object.create(
+    (ctor as unknown as { readonly prototype: object }).prototype,
+  ) as object;

--- a/packages/core/src/di/shutdown-hooks.ts
+++ b/packages/core/src/di/shutdown-hooks.ts
@@ -94,3 +94,29 @@ export class ShutdownHooks {
     }, afterMs).unref();
   }
 }
+
+/**
+ * The half of an application class that is the same in every one of them: hold a
+ * {@link ShutdownHooks}, and install it against this object's own `shutdown()`.
+ *
+ * `@dunx/core`, `@dunx/http` and `@dunx/infra` each own an application class, and
+ * each used to carry an identical copy of the installer. Three copies of "drain,
+ * then make sure the process actually ends" is three chances to fix a hang in one
+ * and not the others, which is how it was missed the first time.
+ *
+ * `shutdown` is abstract rather than assumed, so a subclass that does not have one
+ * is a compile error rather than a handler installed against `undefined`.
+ */
+export abstract class ShutdownAware {
+  readonly #hooks = new ShutdownHooks();
+
+  abstract shutdown(): Promise<void>;
+
+  enableShutdownHooks(
+    signals: readonly ShutdownSignal[] = ['SIGTERM', 'SIGINT'],
+    options: ShutdownHookOptions = {},
+  ): this {
+    this.#hooks.install(() => this.shutdown(), signals, options);
+    return this;
+  }
+}

--- a/packages/core/src/di/token.ts
+++ b/packages/core/src/di/token.ts
@@ -15,6 +15,16 @@ export type Ctor<T> = new (...args: never[]) => T;
 // injected without needing token() at all.
 export type AbstractCtor<T> = abstract new (...args: never[]) => T;
 
+/**
+ * A method a decorator may mark, whatever it takes. `never[]` for the same reason
+ * `Ctor` uses it: it is what makes an arbitrary method signature assignable, so a
+ * handler declares the payload type it expects rather than the widest one.
+ *
+ * `@dunx/http`'s gateways and `@dunx/infra`'s job and schedule decorators all
+ * mark methods, and each used to declare this line itself.
+ */
+export type HandlerMethod = (...args: never[]) => unknown;
+
 export type InjectionToken<T> = AbstractCtor<T> | Token<T>;
 
 export const token = <T>(description: string): Token<T> => ({ description });

--- a/packages/dashboard/src/html.ts
+++ b/packages/dashboard/src/html.ts
@@ -1,5 +1,6 @@
 import { metaOf } from './api/snapshot.js';
 import type { DashboardOptions } from './options.js';
+import { embedJson } from '@dunx/http/internal';
 
 /**
  * The page is a shell: a boot stylesheet, the mount's metadata as JSON, and the
@@ -26,15 +27,6 @@ html, body { margin: 0; padding: 0; background: #fff; }
   font: 15px/1.6 ui-sans-serif, system-ui, sans-serif; }
 `;
 
-const escape = (value: string): string => Bun.escapeHTML(value);
-
-/**
- * `<` is the only character that can end the data block early, and escaping it as
- * `<` keeps the text valid JSON. The parser sees the same document either way.
- */
-const embed = (model: unknown): string =>
-  JSON.stringify(model).replaceAll('<', '\\u003c');
-
 /** The id the bundle reads its meta from. Shared with `internal/dashboard-ui`. */
 export const META_ELEMENT_ID = 'dunx-dashboard-meta';
 
@@ -52,16 +44,16 @@ export const renderShell = (
     // reach a search index or a referrer log if it is ever exposed by mistake.
     '<meta name="robots" content="noindex, nofollow">' +
     '<meta name="referrer" content="no-referrer">' +
-    `<title>${escape(title)}</title>` +
+    `<title>${Bun.escapeHTML(title)}</title>` +
     // A `data:` URI, so the tab icon costs no request either. Same mark as the
     // documentation site and the API explorer - `@dunx/ui` declares it once and
     // the bundle build emits it next to the script.
-    `<link rel="icon" type="image/svg+xml" href="${escape(favicon)}">` +
+    `<link rel="icon" type="image/svg+xml" href="${Bun.escapeHTML(favicon)}">` +
     `<style>${BOOT}</style></head><body><div id="root"></div>` +
     '<noscript><p class="no-js">This dashboard needs JavaScript. Every panel ' +
-    `also answers as JSON under <code>${escape(options.path)}/api</code>.</p></noscript>` +
+    `also answers as JSON under <code>${Bun.escapeHTML(options.path)}/api</code>.</p></noscript>` +
     `<script type="application/json" id="${META_ELEMENT_ID}">` +
-    `${embed(metaOf(options))}</script>` +
+    `${embedJson(metaOf(options))}</script>` +
     `<script>${ui}</script></body></html>`
   );
 };

--- a/packages/http/src/client/module.ts
+++ b/packages/http/src/client/module.ts
@@ -77,7 +77,7 @@ const serviceFrom = (
 
 /**
  * A named client binds its own options token, so two of them do not collide on
- * `HttpClientOptions` - the flat container reports that as a duplicate binding.
+ * `HttpClientOptions` - a scope binding that class twice reports a duplicate.
  */
 const namedModule = (
   target: ClientTarget,

--- a/packages/http/src/client/module.ts
+++ b/packages/http/src/client/module.ts
@@ -77,7 +77,8 @@ const serviceFrom = (
 
 /**
  * A named client binds its own options token, so two of them do not collide on
- * `HttpClientOptions` - a scope binding that class twice reports a duplicate.
+ * `HttpClientOptions` - a scope reports a duplicate when it binds that class
+ * twice.
  */
 const namedModule = (
   target: ClientTarget,

--- a/packages/http/src/inspect.ts
+++ b/packages/http/src/inspect.ts
@@ -2,6 +2,7 @@ import {
   classOf,
   collectModules,
   dependenciesOf,
+  inertInstance,
   readControllers,
   type Ctor,
   type Dependency,
@@ -22,10 +23,6 @@ import { isGateway } from './ws/marker.js';
  * `Object.create(Controller.prototype)` is that chain with nothing behind it, so
  * no constructor or dependency of one has to exist.
  */
-interface Prototyped {
-  readonly prototype: object;
-}
-
 export interface RouteInputs {
   readonly body?: string;
   readonly query?: string;
@@ -100,8 +97,7 @@ const nodeFor = (route: DiscoveredRoute, module: string): RouteNode => ({
 export const routesOf = (root: ModuleRef): readonly RouteNode[] =>
   collectModules(root).flatMap((module) =>
     readControllers(module).flatMap((controller) => {
-      const { prototype } = controller as unknown as Prototyped;
-      return discoverRoutes(Object.create(prototype) as object).map((route) =>
+      return discoverRoutes(inertInstance(controller)).map((route) =>
         nodeFor(route, module.name),
       );
     }),
@@ -135,9 +131,7 @@ export interface GatewayNode {
 }
 
 const gatewayFor = (ctor: Ctor<unknown>, module: string): GatewayNode => {
-  const { name, path, handlers } = discoverGateway(
-    Object.create((ctor as unknown as Prototyped).prototype) as object,
-  );
+  const { name, path, handlers } = discoverGateway(inertInstance(ctor));
 
   return {
     name,

--- a/packages/http/src/internal.ts
+++ b/packages/http/src/internal.ts
@@ -26,4 +26,5 @@ export {
   type RouteNode,
 } from './inspect.js';
 export { buildContext } from './server/context.js';
+export { embedJson } from './server/html.js';
 export { isGateway } from './ws/marker.js';

--- a/packages/http/src/server/application.ts
+++ b/packages/http/src/server/application.ts
@@ -3,7 +3,7 @@ import {
   AppError,
   Logger,
   runtimeInfo,
-  ShutdownHooks,
+  ShutdownAware,
   teardownError,
   teardownFailures as toFailures,
   type App,
@@ -160,7 +160,7 @@ export interface HttpApp extends App {
   listen(port?: number): Promise<string>;
 }
 
-export class HttpApplication implements HttpApp {
+export class HttpApplication extends ShutdownAware implements HttpApp {
   /** Forwarded from the container so an app can log scope warnings at boot. */
   readonly warnings: readonly string[];
   /**
@@ -188,7 +188,6 @@ export class HttpApplication implements HttpApp {
   #server: Server<SocketData> | undefined;
   #resolveClosed: (() => void) | undefined;
   #shuttingDown: Promise<void> | undefined;
-  readonly #hooks = new ShutdownHooks();
 
   constructor(
     app: App,
@@ -197,6 +196,7 @@ export class HttpApplication implements HttpApp {
     root: ModuleRef,
     websocket?: WebSocketRuntime,
   ) {
+    super();
     this.#app = app;
     this.#root = root;
     this.warnings = app.warnings;
@@ -442,14 +442,6 @@ export class HttpApplication implements HttpApp {
       if (failures.length > 0) throw teardownError(failures);
     })();
     return this.#shuttingDown;
-  }
-
-  enableShutdownHooks(
-    signals: readonly ShutdownSignal[] = ['SIGTERM', 'SIGINT'],
-    options: ShutdownHookOptions = {},
-  ): this {
-    this.#hooks.install(() => this.shutdown(), signals, options);
-    return this;
   }
 
   // Collision detection re-runs inside buildRoutes on these final paths.

--- a/packages/http/src/server/html.ts
+++ b/packages/http/src/server/html.ts
@@ -1,0 +1,11 @@
+/**
+ * Serialise a value for a `<script type="application/json">` block.
+ *
+ * `<` is the only character that can end the data block early, and escaping it as
+ * `\u003c` keeps the text valid JSON - the parser sees the same document either
+ * way. `@dunx/dashboard` and `@dunx/openapi` both inline a model into a page they
+ * serve, and both had a copy of this; if the escaping ever proves insufficient,
+ * one fix should cover both pages.
+ */
+export const embedJson = (value: unknown): string =>
+  JSON.stringify(value).replaceAll('<', '\\u003c');

--- a/packages/http/src/ws/decorators.ts
+++ b/packages/http/src/ws/decorators.ts
@@ -1,9 +1,7 @@
 import { HandlerKind, markGateway, markHandler } from './marker.js';
+import type { HandlerMethod } from '@dunx/core';
 
 type GatewayTarget = abstract new (...args: never[]) => object;
-// never[] is what makes an arbitrary method signature assignable, so a handler
-// may declare the payload type it expects. See the README, "Typed payloads".
-type HandlerMethod = (...args: never[]) => unknown;
 
 export const Gateway =
   (path = '/') =>

--- a/packages/infra/src/queue/decorators.ts
+++ b/packages/infra/src/queue/decorators.ts
@@ -1,8 +1,5 @@
 import { markJobHandler, type JobMeta } from './marker.js';
-
-// never[] is what makes an arbitrary method signature assignable, so a handler may
-// declare the `Job<T>` payload type it expects rather than the widest one.
-type HandlerMethod = (...args: never[]) => unknown;
+import type { HandlerMethod } from '@dunx/core';
 
 /**
  * Marks a method as the consumer of `name` on `queue`.

--- a/packages/infra/src/queue/worker.ts
+++ b/packages/infra/src/queue/worker.ts
@@ -2,15 +2,13 @@ import {
   AppFactory,
   collectModules,
   Logger,
-  ShutdownHooks,
+  ShutdownAware,
   teardownError,
   teardownFailures,
   type App,
   type InjectionToken,
   type ModuleRef,
   type ResolvedModule,
-  type ShutdownHookOptions,
-  type ShutdownSignal,
 } from '@dunx/core';
 import { Worker, type Job } from 'bullmq';
 import { QueueConnection } from './connection.js';
@@ -315,7 +313,7 @@ export class QueueConsumer {
 }
 
 /** A worker process: a {@link QueueConsumer} plus the container it owns. */
-class WorkerApplication implements WorkerApp {
+class WorkerApplication extends ShutdownAware implements WorkerApp {
   readonly closed: Promise<void>;
   /** Forwarded from the container, so a worker reports scope warnings too. */
   readonly warnings: readonly string[];
@@ -323,9 +321,9 @@ class WorkerApplication implements WorkerApp {
   readonly #consumer: QueueConsumer;
   #resolveClosed: (() => void) | undefined;
   #shuttingDown: Promise<void> | undefined;
-  readonly #hooks = new ShutdownHooks();
 
   constructor(app: App, consumer: QueueConsumer) {
+    super();
     this.warnings = app.warnings;
     this.#app = app;
     this.#consumer = consumer;
@@ -383,14 +381,6 @@ class WorkerApplication implements WorkerApp {
       if (failures.length > 0) throw teardownError(failures);
     })();
     return this.#shuttingDown;
-  }
-
-  enableShutdownHooks(
-    signals: readonly ShutdownSignal[] = ['SIGTERM', 'SIGINT'],
-    options: ShutdownHookOptions = {},
-  ): this {
-    this.#hooks.install(() => this.shutdown(), signals, options);
-    return this;
   }
 }
 

--- a/packages/infra/src/redis/module.ts
+++ b/packages/infra/src/redis/module.ts
@@ -76,7 +76,8 @@ const connectionFrom = (
 
 /**
  * A named connection binds its own options token, so two of them do not collide
- * on `RedisOptions` - a scope binding that class twice reports a duplicate.
+ * on `RedisOptions` - a scope reports a duplicate when it binds that class
+ * twice.
  */
 const namedModule = (
   target: ConnectionTarget,

--- a/packages/infra/src/redis/module.ts
+++ b/packages/infra/src/redis/module.ts
@@ -76,7 +76,7 @@ const connectionFrom = (
 
 /**
  * A named connection binds its own options token, so two of them do not collide
- * on `RedisOptions` - the flat container reports that as a duplicate binding.
+ * on `RedisOptions` - a scope binding that class twice reports a duplicate.
  */
 const namedModule = (
   target: ConnectionTarget,

--- a/packages/infra/src/schedule/decorators.ts
+++ b/packages/infra/src/schedule/decorators.ts
@@ -6,10 +6,7 @@ import {
   type Overlap,
   type ScheduleMeta,
 } from './marker.js';
-
-// never[] is what makes an arbitrary method signature assignable, so a handler may
-// declare whatever parameters it wants rather than the widest ones.
-type HandlerMethod = (...args: never[]) => unknown;
+import type { HandlerMethod } from '@dunx/core';
 
 /**
  * The largest delay `setTimeout` can hold. Bun clamps anything above it to 1 ms and

--- a/packages/openapi/src/discover.ts
+++ b/packages/openapi/src/discover.ts
@@ -1,10 +1,11 @@
-import { collectModules, readControllers, type ModuleRef } from '@dunx/core';
+import {
+  collectModules,
+  inertInstance,
+  readControllers,
+  type ModuleRef,
+} from '@dunx/core';
 import { HIDDEN } from '@dunx/http';
 import { discoverRoutes, type DiscoveredRoute } from '@dunx/http/internal';
-
-interface Prototyped {
-  readonly prototype: object;
-}
 
 /**
  * Every route a module graph declares, read without constructing a thing.
@@ -20,8 +21,7 @@ export const describeRoutes = (root: ModuleRef): readonly DiscoveredRoute[] => {
 
   for (const module of collectModules(root)) {
     for (const controller of readControllers(module)) {
-      const { prototype } = controller as unknown as Prototyped;
-      for (const route of discoverRoutes(Object.create(prototype) as object)) {
+      for (const route of discoverRoutes(inertInstance(controller))) {
         if (route.meta?.get(HIDDEN.id) === true) continue;
         routes.push(route);
       }

--- a/packages/openapi/src/html.ts
+++ b/packages/openapi/src/html.ts
@@ -1,6 +1,7 @@
 import type { SwaggerAssets } from './swagger.js';
 import type { OpenApiDocument } from './types.js';
 import { renderUiOptions, type SwaggerUiOptions } from './ui-options.js';
+import { embedJson } from '@dunx/http/internal';
 
 /**
  * A Swagger UI shell: its stylesheet, its bundle, the document embedded as JSON,
@@ -30,15 +31,6 @@ html, body { margin: 0; padding: 0; background: #fafafa; }
 .no-js { padding: 3rem 1.5rem; text-align: center;
   font: 15px/1.6 ui-sans-serif, system-ui, sans-serif; }
 `;
-
-const escape = (value: string): string => Bun.escapeHTML(value);
-
-/**
- * `<` is the only character that can end the data block early, and escaping it as
- * `<` keeps the text valid JSON. The parser sees the same document either way.
- */
-const embed = (value: unknown): string =>
-  JSON.stringify(value).replaceAll('<', '\\u003c');
 
 export interface PageOptions {
   /** Where the JSON document is served, so the page can link to it. */
@@ -76,16 +68,16 @@ export const renderShell = (
   return (
     '<!doctype html><html lang="en"><head><meta charset="utf-8">' +
     '<meta name="viewport" content="width=device-width, initial-scale=1">' +
-    `<title>${escape(title)}</title>` +
-    `<link rel="stylesheet" href="${escape(style)}">` +
-    (icon === false ? '' : `<link rel="icon" href="${escape(icon)}">`) +
+    `<title>${Bun.escapeHTML(title)}</title>` +
+    `<link rel="stylesheet" href="${Bun.escapeHTML(style)}">` +
+    (icon === false ? '' : `<link rel="icon" href="${Bun.escapeHTML(icon)}">`) +
     `<style>${BOOT}</style></head><body><div id="${MOUNT_ELEMENT_ID}"></div>` +
     '<noscript><p class="no-js">This API explorer needs JavaScript. ' +
-    `The document itself is at <a href="${escape(options.jsonHref)}">` +
-    `${escape(options.jsonHref)}</a>.</p></noscript>` +
+    `The document itself is at <a href="${Bun.escapeHTML(options.jsonHref)}">` +
+    `${Bun.escapeHTML(options.jsonHref)}</a>.</p></noscript>` +
     `<script type="application/json" id="${DOCUMENT_ELEMENT_ID}">` +
-    `${embed(document)}</script>` +
-    `<script src="${escape(script)}"></script>` +
+    `${embedJson(document)}</script>` +
+    `<script src="${Bun.escapeHTML(script)}"></script>` +
     // `defer` is not enough on its own: the bundle defines `SwaggerUIBundle` as a
     // global, so this has to run after it and a plain trailing script does.
     // The options object carries `spec` last so a caller cannot replace the
@@ -93,7 +85,7 @@ export const renderShell = (
     // `BaseLayout`: the standalone one needs a second ~1 MiB preset file and all it
     // adds is a URL bar for loading other documents.
     '<script>(function(){' +
-    `var node=document.getElementById(${embed(DOCUMENT_ELEMENT_ID)});` +
+    `var node=document.getElementById(${embedJson(DOCUMENT_ELEMENT_ID)});` +
     `var options=${renderUiOptions({ layout: 'BaseLayout', ...ui }, MOUNT_ELEMENT_ID)};` +
     'options.spec=JSON.parse(node.textContent);' +
     'window.ui=SwaggerUIBundle(options);' +


### PR DESCRIPTION
A second reuse pass, favouring shared contracts a consumer imports over matching
shapes declared twice.

- `internal/docs` re-declared nine interfaces describing the benchmark report it
  reads. They are aliases onto `internal/bench`'s own types now, type-only. It had
  already drifted: the report grew `toolchains` and the copy did not.
- That coupling found a live bug. The `schemaVersion` guard in `extract/bench.ts`
  read the field through a type the harness declares as the literal `1`, so the
  mismatch branch narrowed to `never` and the guard was statically dead.
- `ShutdownAware` in `@dunx/core` replaces three identical copies of
  `enableShutdownHooks` over an identical `#hooks` field. `shutdown()` is abstract,
  so a subclass without one is a compile error.
- `driveUnits` in `internal/bench` replaces the bring-up, warmup and round-robin
  sampling loop that `db-modes`, `logging` and `validation` each carried. The loop
  was byte-identical in all three. Verified by running all three; nothing there has
  a test.
- `HandlerMethod` and `inertInstance` move to `@dunx/core`, which already owns the
  idioms they use.
- `embedJson` on `@dunx/http/internal` replaces the escape/embed pair the dashboard
  and openapi shells both carried.

`bun run ci` green at each commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared dependency-injection utilities for prototype-based discovery and handler typing.
  * Added safe JSON embedding for HTML documents.
  * Added a common shutdown lifecycle base for applications and workers.

* **Improvements**
  * Improved consistency and safety across dashboard, HTTP, and OpenAPI HTML generation.
  * Standardized benchmark execution, reporting, and configuration handling.
  * Improved benchmark schema validation and type consistency.
  * Clarified module documentation for scope-based option and duplicate bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->