### PR TITLE
fix(queue): construct the reconnect socket, or a queue consumes nothing

### DIFF
--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -54,6 +54,30 @@ Three findings that shaped the code:
   unhandled `error`. Shutdown would fail on its last step. The adapter gets a no-op
   `error` listener at construction.
 
+### A reconnect has to construct, not duplicate
+
+Bun fires `onconnect` on a constructed client and not on one returned by
+`duplicate()`. bullmq's `_scheduleReconnect` wires that callback and then calls
+`connect()`, so it is the only thing that runs `_handleConnected()` on a
+replacement socket. Without it the adapter never re-sends `CLIENT SETNAME`,
+never flips `ready` and never resolves `readying`, while the socket underneath
+answers `PING` perfectly well.
+
+A worker awaiting that readiness issues no further `BZPOPMIN`, so its queue
+stops consuming. Nothing on the path rejects, so no `error` is emitted and
+`Worker error on <queue>` never prints.
+
+Measured on bullmq 6.3.4 + Bun 1.4.0 + Redis 8.4.0: a connection at
+`tot-cmds=1 cmd=hello` idle for 20 hours, jobs accumulating in `wait` with
+`active=0` and `failed=0`, and the stalled-check timer still refreshing every
+30 s, so the worker looked alive throughout. A restart drained the backlog and
+wedged again on the next dropped socket.
+
+6.0.5 rebuilt the socket with `new (this.raw.constructor)(this.raw.url)`, which
+is why `boundClientClass` began as a constructor fix. 6.3.4 rebuilds by
+duplication instead, and the caret on bullmq's peer range is enough to land an
+app on it. The class overrides `duplicate()` to construct, which covers both.
+
 `@dunx/infra/queue` is **not re-exported from the package barrel**,
 unlike every other area. `src/index.ts` re-exporting it would put bullmq's static
 `ioredis` import behind `import '@dunx/infra'` for every consumer, queue or no

--- a/packages/infra/src/queue/connection.test.ts
+++ b/packages/infra/src/queue/connection.test.ts
@@ -54,3 +54,51 @@ describe('the duplicate wrapper', () => {
     source.onShutdown();
   });
 });
+
+describe('the raw client bullmq reconnects with', () => {
+  it('duplicates by construction, so the reconnect keeps its onconnect callback', async () => {
+    // bullmq's `_duplicateRaw` prefers `src.duplicate()` over construction, and
+    // Bun does not fire `onconnect` on a natively duplicated client. Its
+    // `_scheduleReconnect` wires `onconnect` and calls `connect()`, so a native
+    // duplicate leaves `_handleConnected()` unrun: no `CLIENT SETNAME`, `ready`
+    // never flips, and the worker awaiting readiness never blocks on the marker
+    // again. Silently - nothing on that path rejects.
+    const source = connection();
+    const adapter = source.client() as unknown as { raw: Bun.RedisClient };
+    const raw = adapter.raw;
+
+    const duplicated = await raw.duplicate();
+
+    // Constructed, not natively duplicated: same bound class, same target.
+    expect(duplicated).toBeInstanceOf(
+      raw.constructor as new (url?: string) => Bun.RedisClient,
+    );
+    expect((duplicated as { url?: string }).url).toBe('redis://127.0.0.1:1');
+
+    duplicated.close();
+    source.onShutdown();
+  });
+
+  it('survives a second reconnect, which is where a socket drop lands twice', async () => {
+    // One dropped socket is not the failure - the replacement has to be able to
+    // drop and be replaced too. A natively duplicated client is a plain
+    // `Bun.RedisClient`, so the override is gone from it and the *next*
+    // reconnect is the one that wedges. Measured in production: the first drop
+    // recovered, the second left the queue silent until a restart.
+    const source = connection();
+    const adapter = source.client() as unknown as { raw: Bun.RedisClient };
+    const bound = adapter.raw.constructor as new (
+      url?: string,
+    ) => Bun.RedisClient;
+
+    const first = await adapter.raw.duplicate();
+    const second = await first.duplicate();
+
+    expect(second).toBeInstanceOf(bound);
+    expect((second as { url?: string }).url).toBe('redis://127.0.0.1:1');
+
+    second.close();
+    first.close();
+    source.onShutdown();
+  });
+});

--- a/packages/infra/src/queue/connection.ts
+++ b/packages/infra/src/queue/connection.ts
@@ -21,6 +21,40 @@ const boundClientClass = (
     constructor(given?: string) {
       super(given ?? url, connection);
     }
+
+    /**
+     * A newly **constructed** client, rather than the one Bun's native
+     * `duplicate()` returns, because Bun does not fire `onconnect` on a natively
+     * duplicated client:
+     *
+     * ```
+     * fresh client   -> onconnect fired: true
+     * duplicated raw -> onconnect fired: false | connected: true
+     * ```
+     *
+     * Which decides whether a dropped socket ever comes back. bullmq 6.0.5 built
+     * its replacement with `new (this.raw.constructor)(this.raw.url)`, so the
+     * constructor above was the whole fix; 6.3.4 rebuilds through `_duplicateRaw`,
+     * which prefers `src.duplicate()`, and the caret on its peer range is enough
+     * to land an app on that.
+     *
+     * The initial connection survives either way - the adapter's `connect()` calls
+     * `_handleConnected()` itself. `_scheduleReconnect` does not: it wires
+     * `onconnect` and calls `connect()` on the raw client, so with a native
+     * duplicate `_handleConnected()` never runs. The adapter never re-sends
+     * `CLIENT SETNAME`, never flips `ready`, and never resolves `readying`, while
+     * the socket underneath is fine - measured against a real Redis as a
+     * connection sitting at `tot-cmds=1 cmd=hello`, idle for 20 hours, with the
+     * worker awaiting readiness and never issuing another `BZPOPMIN`.
+     *
+     * Nothing on that path rejects, so no `error` is emitted and no `Worker error
+     * on <queue>` is logged: the queue stops consuming silently and stays that way
+     * until the process restarts, which drains the backlog and then wedges again
+     * on the next dropped socket.
+     */
+    override duplicate(): Promise<Bun.RedisClient> {
+      return Promise.resolve(new BoundRedisClient(url));
+    }
   };
 };
 

--- a/packages/infra/src/queue/connection.ts
+++ b/packages/infra/src/queue/connection.ts
@@ -24,33 +24,13 @@ const boundClientClass = (
 
     /**
      * A newly **constructed** client, rather than the one Bun's native
-     * `duplicate()` returns, because Bun does not fire `onconnect` on a natively
-     * duplicated client:
-     *
-     * ```
-     * fresh client   -> onconnect fired: true
-     * duplicated raw -> onconnect fired: false | connected: true
-     * ```
-     *
-     * Which decides whether a dropped socket ever comes back. bullmq 6.0.5 built
-     * its replacement with `new (this.raw.constructor)(this.raw.url)`, so the
-     * constructor above was the whole fix; 6.3.4 rebuilds through `_duplicateRaw`,
-     * which prefers `src.duplicate()`, and the caret on its peer range is enough
-     * to land an app on that.
-     *
-     * The initial connection survives either way - the adapter's `connect()` calls
-     * `_handleConnected()` itself. `_scheduleReconnect` does not: it wires
-     * `onconnect` and calls `connect()` on the raw client, so with a native
-     * duplicate `_handleConnected()` never runs. The adapter never re-sends
-     * `CLIENT SETNAME`, never flips `ready`, and never resolves `readying`, while
-     * the socket underneath is fine - measured against a real Redis as a
-     * connection sitting at `tot-cmds=1 cmd=hello`, idle for 20 hours, with the
-     * worker awaiting readiness and never issuing another `BZPOPMIN`.
-     *
-     * Nothing on that path rejects, so no `error` is emitted and no `Worker error
-     * on <queue>` is logged: the queue stops consuming silently and stays that way
-     * until the process restarts, which drains the backlog and then wedges again
-     * on the next dropped socket.
+     * `duplicate()` returns, because Bun fires `onconnect` on the first and not
+     * on the second. bullmq rebuilds a dropped socket through `_duplicateRaw`,
+     * which prefers `duplicate()`, and that callback is the only thing that runs
+     * `_handleConnected()` on the replacement: without it the adapter never
+     * re-sends `CLIENT SETNAME`, never flips `ready`, and a worker awaiting
+     * readiness issues no further `BZPOPMIN`. Silently, since nothing on that
+     * path rejects. See docs/architecture/queues.md.
      */
     override duplicate(): Promise<Bun.RedisClient> {
       return Promise.resolve(new BoundRedisClient(url));


### PR DESCRIPTION
## The symptom

A queue stops consuming. Jobs pile up in `wait` with `active=0` and `failed=0`, the worker's stalled-check keeps refreshing every 30s so it looks alive, and **nothing is logged** — no `Worker error on <queue>`, no connection error. A restart drains the backlog and then it wedges again on the next dropped socket.

Found in a production app: notifications silently undelivered for ~20 hours.

## The cause

Bun does not fire `onconnect` on a client returned by `raw.duplicate()`:

```
fresh client   -> onconnect fired: true
duplicated raw -> onconnect fired: false | connected: true
```

The socket is healthy — it completes its `HELLO` and answers `PING`. But that callback is the only thing that runs `_handleConnected()` on a replacement socket, because `_scheduleReconnect` wires `onconnect` and then calls `connect()` on the raw client. Without it the adapter never re-sends `CLIENT SETNAME`, never flips `ready`, and never resolves `readying`, so a worker awaiting readiness issues no further `BZPOPMIN`.

Nothing on that path rejects, which is why it is completely silent.

Measured against a real Redis, the wedged connection looks like this — 20 hours old, idle the whole time, one command ever sent:

```
id=347813 age=74072 idle=74072 cmd=hello tot-cmds=1
id=347817 age=74072 idle=74072 cmd=hello tot-cmds=1
```

The initial connection is unaffected: the adapter's own `connect()` calls `_handleConnected()` directly. That confines this to the reconnect path, and out of every test that opens a worker and enqueues.

## Why now

`boundClientClass` exists because bullmq 6.0.5 rebuilt the client with `new (this.raw.constructor)(this.raw.url)`, dropping the url and the options. 6.3.4 rebuilds through `_duplicateRaw`, which prefers `src.duplicate()` — so the constructor stopped covering the case it was written for. dunx dev-depends on 6.0.5 exactly, so the suite here never saw it; the consumer that hit this had floated to 6.3.4 through the peer range.

## The change

`duplicate()` on the bound class returns a freshly constructed client, which keeps the url and the options **and** leaves `onconnect` intact. Correct for both versions: 6.0.5 constructs anyway, 6.3.4 now gets a construction through the duplicate path.

Two tests, both failing without the change. The second duplicates twice — a native duplicate loses the override, so the *next* reconnect is the one that wedges, which matches production: the first drop recovered, the second did not.

The argument lives in `docs/architecture/queues.md` as a fourth finding beside the ioredis boundary, per the `no-slop` comment budget.

## Verification

- `packages/infra`: 613 pass, 0 fail
- `scripts/`: `no-slop` and the rest pass
- `oxlint` and `oxfmt` clean on the changed files

One caveat: the end-to-end wedge could not be reproduced in isolation — standalone repros recover via `connect()` or bullmq's error-carrying retry path, both of which heal the adapter. The fix is derived from the mechanism above and pinned by the tests; deployment is the real confirmation.

## Not proposing a version pin

An earlier draft of this description suggested pinning `bullmq` exactly instead of `^6.0.5`. That is wrong: `exact-versions.test.ts` requires `peerDependencies` to stay ranges, on purpose, and a peer states what a consumer may bring. A tighter upper bound would still be a range and so still allowed, but it trades a real cost (blocking consumers from patch releases) against a regression this change already handles in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved queue connection recovery after socket disruptions.
  - Reconnected clients now consistently preserve configured connection behavior and callbacks, including after repeated reconnects.

- **Documentation**
  - Added guidance explaining queue reconnect behavior and connection recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->