### PR TITLE
A real HTML file per route: per-page metadata, sitemap, and a real 404

### DIFF
--- a/docs/architecture/tooling.md
+++ b/docs/architecture/tooling.md
@@ -24,6 +24,14 @@ the script that built it were deleted once it was deployed and verified, so thos
 documents are frozen at the release that moved the domain; `git log -- scripts/pages-redirect.ts`
 is where they come back from if the deployment is ever lost.
 
+`scripts/seo.ts` writes a real HTML file per route after `vite build`, from the
+same generated model the nav is built from. It exists for two reasons rather than
+one: a client-routed bundle gave all 96 routes the same title and description, and
+the `/* /index.html 200` fallback that made deep links work also answered every
+miss with a 200 and a page, which is an unbounded supply of soft 404s for a crawler
+and a renamed document that fails silently. Files for known routes let that rule go,
+so `404.html` can answer the rest with a real status.
+
 The deploy is its own job rather than the tail of the release job. A failed
 `bun run version` used to take the documentation down with it, and a docs change and
 a publish are not the same event.

--- a/internal/docs/README.md
+++ b/internal/docs/README.md
@@ -229,7 +229,7 @@ GitHub Pages, which serves static files with no SPA fallback and answered every
 deep link with a 404.
 
 `scripts/seo.ts` is what replaced that fallback. It runs after `vite build` and
-writes a real `index.html` per route - 96 of them - each carrying its own title,
+writes a real HTML file per route - 96 of them - each carrying its own title,
 description, canonical and Open Graph tags, plus `sitemap.xml`, `robots.txt` and
 `404.html`. The route set comes from `src/generated/index.json` and
 `releases.json`, the same model the nav is built from, and a guide's description
@@ -242,8 +242,12 @@ real 404: `_redirects` used to carry `/* /index.html 200`, so a typo, a renamed
 guide and a request for `/sitemap.xml` all returned 200 and a page. `robots.txt`
 and `sitemap.xml` looked like they existed for that reason alone.
 
-`scripts/preview.ts` resolves paths the way Cloudflare does, `404.html` and all,
-so the browser suite exercises what the edge does.
+A route is written as `guide/controllers.html`, not `guide/controllers/index.html`.
+Measured on a preview deployment: Cloudflare answers a directory index with a 308
+to the trailing-slash form, which put a redirect in front of every deep link and
+left the rendered URL disagreeing with the canonical. `scripts/preview.ts` resolves
+paths the same way, `404.html` and all, so the browser suite exercises what the edge
+does.
 
 Navigation is one delegated click listener in `router.ts` rather than a `<Link>`
 component: every link on the site is a Mantine `Anchor` or `NavLink` rendering a

--- a/internal/docs/README.md
+++ b/internal/docs/README.md
@@ -202,6 +202,9 @@ happydom.ts            # test preload: a DOM, plus Vite's ?raw for bun test
 scripts/
   generate.ts          # entrypoint: writes src/generated/ - index, bodies, chunks.ts
   content.ts           # markdown -> HTML, heading ids, links, siteMarkdown
+  agent-docs.ts        # setup.md and llms.txt into public/, plus summaryOf
+  seo.ts               # post-build: a file per route, sitemap, robots, 404
+  preview.ts           # the built site in real Chrome, for the browser suite
   extract/
     ast.ts             # structural views over oxc's ESTree output
     jsdoc.ts           # doc-comment binding and tag parsing
@@ -223,9 +226,24 @@ src/
 
 Routing is path-based (`/api/core`). It was hash-based while the site was on
 GitHub Pages, which serves static files with no SPA fallback and answered every
-deep link with a 404. `public/_redirects` carries the `/* /index.html 200` rule
-that replaced it, and `scripts/preview.ts` serves the same fallback, so the
-browser suite exercises what the edge does.
+deep link with a 404.
+
+`scripts/seo.ts` is what replaced that fallback. It runs after `vite build` and
+writes a real `index.html` per route - 96 of them - each carrying its own title,
+description, canonical and Open Graph tags, plus `sitemap.xml`, `robots.txt` and
+`404.html`. The route set comes from `src/generated/index.json` and
+`releases.json`, the same model the nav is built from, and a guide's description
+is `summaryOf` from `agent-docs.ts`, the sentence `llms.txt` already uses.
+
+Two things follow from emitting files rather than rewriting every path to the
+shell. Search results and link unfurls say which page they are, where a single
+`index.html` made all 96 read "dunx | fastest web DI framework". And a miss is a
+real 404: `_redirects` used to carry `/* /index.html 200`, so a typo, a renamed
+guide and a request for `/sitemap.xml` all returned 200 and a page. `robots.txt`
+and `sitemap.xml` looked like they existed for that reason alone.
+
+`scripts/preview.ts` resolves paths the way Cloudflare does, `404.html` and all,
+so the browser suite exercises what the edge does.
 
 Navigation is one delegated click listener in `router.ts` rather than a `<Link>`
 component: every link on the site is a Mantine `Anchor` or `NavLink` rendering a

--- a/internal/docs/package.json
+++ b/internal/docs/package.json
@@ -5,7 +5,7 @@
   "description": "The dunx documentation site. Private tooling, never published.",
   "type": "module",
   "scripts": {
-    "build": "bun run generate && vite build",
+    "build": "bun run generate && vite build && bun ./scripts/seo.ts",
     "dev": "bun run generate && vite",
     "generate": "bun ./scripts/generate.ts",
     "preview": "vite preview",

--- a/internal/docs/public/_redirects
+++ b/internal/docs/public/_redirects
@@ -1,4 +1,12 @@
-# SPA fallback. Required now that the app is on a history router rather than a
-# hash one: a direct link to any route but `/` is a path no file in `dist/`
-# answers, and without this the edge returns a 404 for it.
-/*  /index.html  200
+# `/releases/v3.3.1` is the git-tag spelling `router.ts` tolerates. The edge
+# resolves a path before the router ever sees it, so the alias has to exist here
+# too - as a redirect to the canonical form rather than a second page carrying
+# the same release notes.
+/releases/v:version  /releases/:version  301
+
+# There is deliberately no `/* /index.html 200` catch-all. It answered every
+# miss with the shell, so a typo, a renamed guide and a request for
+# `/sitemap.xml` all returned 200 and a page: unlimited soft 404s for a crawler
+# to index, and a moved document that failed silently. `scripts/seo.ts` writes a
+# real file for every known route instead, which leaves `404.html` to answer the
+# rest with a real status.

--- a/internal/docs/scripts/agent-docs.ts
+++ b/internal/docs/scripts/agent-docs.ts
@@ -18,8 +18,14 @@ export const SITE_URL = 'https://dunx.win/';
 
 const RAW_URL = 'https://raw.githubusercontent.com/petarzarkov/dunx/main/';
 
-/** The first paragraph under the title, flattened to one line. */
-const summaryOf = (markdown: string): string => {
+/**
+ * The first paragraph under the title, flattened to one line.
+ *
+ * Exported because `seo.ts` needs the same sentence for a meta description: a
+ * second extractor would give a page one summary in `llms.txt` and a different
+ * one in a search result.
+ */
+export const summaryOf = (markdown: string): string => {
   const body = markdown.replace(/^#[^\n]*\n+/, '');
   const paragraph = (body.split(/\n\s*\n/)[0] ?? '')
     .replace(/\s+/g, ' ')

--- a/internal/docs/scripts/preview.ts
+++ b/internal/docs/scripts/preview.ts
@@ -68,10 +68,10 @@ export const startPreview = async (dist: string): Promise<Preview> => {
     async fetch(request) {
       const { pathname } = new URL(request.url);
       const relative = pathname === '/' ? 'index.html' : pathname.slice(1);
-      // `scripts/seo.ts` writes `guide/controllers/index.html`, and Cloudflare
-      // resolves the extensionless request to it. Both spellings are tried here
-      // for the same reason.
-      for (const candidate of [relative, `${relative}/index.html`]) {
+      // `scripts/seo.ts` writes `guide/controllers.html`, and Cloudflare serves
+      // it for the extensionless request. Both spellings are tried here for the
+      // same reason.
+      for (const candidate of [relative, `${relative}.html`]) {
         const file = Bun.file(`${dist}${candidate}`);
         if (await file.exists()) return new Response(file);
       }

--- a/internal/docs/scripts/preview.ts
+++ b/internal/docs/scripts/preview.ts
@@ -67,13 +67,17 @@ export const startPreview = async (dist: string): Promise<Preview> => {
     port: 0,
     async fetch(request) {
       const { pathname } = new URL(request.url);
-      const file = Bun.file(
-        `${dist}${pathname === '/' ? 'index.html' : pathname.slice(1)}`,
-      );
-      if (await file.exists()) return new Response(file);
-      // The `public/_redirects` rule, so a route with no file of its own
-      // behaves here the way it does at the edge.
-      return new Response(Bun.file(`${dist}index.html`));
+      const relative = pathname === '/' ? 'index.html' : pathname.slice(1);
+      // `scripts/seo.ts` writes `guide/controllers/index.html`, and Cloudflare
+      // resolves the extensionless request to it. Both spellings are tried here
+      // for the same reason.
+      for (const candidate of [relative, `${relative}/index.html`]) {
+        const file = Bun.file(`${dist}${candidate}`);
+        if (await file.exists()) return new Response(file);
+      }
+      // What the edge does now that `_redirects` carries no catch-all: a real
+      // status, and the shell renders its own Not found panel.
+      return new Response(Bun.file(`${dist}404.html`), { status: 404 });
     },
   });
 

--- a/internal/docs/scripts/seo.test.ts
+++ b/internal/docs/scripts/seo.test.ts
@@ -83,11 +83,30 @@ describe('pagesOf', () => {
     );
   });
 
-  test('a guide whose source is missing still gets a page', () => {
-    const [, , , , guide] = pagesOf(INDEX, RELEASES, () => '', 'home');
+  /*
+   * It cannot happen today: the model is generated from these same files moments
+   * before this runs. The fallback is here because `content=""` is a worse
+   * signal than no description tag at all, and a search result should not rest
+   * on a file still being readable.
+   */
+  test('a guide whose source is unreadable falls back rather than shipping an empty description', () => {
+    const all = pagesOf(INDEX, RELEASES, () => '', 'home');
+    const guide = all.find((page) => page.path === '/guide/controllers');
 
-    expect(guide?.path).toBe('/guide/controllers');
-    expect(guide?.description).toBe('');
+    expect(guide?.description).toBe('Controllers, from the dunx guide.');
+    expect(all.every((page) => page.description.trim() !== '')).toBe(true);
+  });
+
+  test('a package with no description falls back to its name', () => {
+    const bare = {
+      ...INDEX,
+      packages: [{ name: '@dunx/core', dir: 'core', description: '' }],
+    };
+    const pkg = pagesOf(bare, RELEASES, read, 'home').find(
+      (page) => page.path === '/api/core',
+    );
+
+    expect(pkg?.description).toBe('API reference for @dunx/core.');
   });
 });
 

--- a/internal/docs/scripts/seo.test.ts
+++ b/internal/docs/scripts/seo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { clamp, pagesOf, renderPage, robots, sitemapOf } from './seo';
+import { clamp, fileFor, pagesOf, renderPage, robots, sitemapOf } from './seo';
 
 const INDEX = {
   generatedAt: '2026-09-05T06:11:22.551Z',
@@ -156,6 +156,22 @@ describe('renderPage', () => {
       'content="A &quot;quoted&quot; &amp; &lt;angled&gt; title"',
     );
     expect(html).not.toContain('<angled>');
+  });
+});
+
+describe('fileFor', () => {
+  /*
+   * A directory-index file is answered with a 308 to the trailing-slash form,
+   * which put a redirect hop in front of every deep link and left the rendered
+   * URL disagreeing with the canonical. Measured on a preview deployment.
+   */
+  test('is a sibling .html, not a directory index', () => {
+    expect(fileFor('/guide/controllers')).toBe('guide/controllers.html');
+    expect(fileFor('/api/core')).toBe('api/core.html');
+  });
+
+  test('the landing page keeps the name the bundler wrote', () => {
+    expect(fileFor('/')).toBe('index.html');
   });
 });
 

--- a/internal/docs/scripts/seo.test.ts
+++ b/internal/docs/scripts/seo.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test';
+import { clamp, pagesOf, renderPage, robots, sitemapOf } from './seo';
+
+const INDEX = {
+  generatedAt: '2026-09-05T06:11:22.551Z',
+  guides: [
+    {
+      slug: 'controllers',
+      title: 'Controllers',
+      source: 'docs/guide/05-controllers.md',
+    },
+  ],
+  packages: [
+    {
+      name: '@dunx/core',
+      dir: 'core',
+      description: 'DI container and modules',
+    },
+  ],
+};
+
+const RELEASES = [{ version: '3.3.1', date: '2026-09-05' }];
+
+const read = (file: string): string =>
+  file === 'guide/05-controllers.md'
+    ? '# Controllers\n\nA controller is a class whose methods are routes. Second sentence.\n'
+    : '';
+
+const pages = (): ReturnType<typeof pagesOf> =>
+  pagesOf(INDEX, RELEASES, read, 'The landing description.');
+
+/** The shape `vite build` emits, trimmed to the parts this rewrites. */
+const TEMPLATE = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>dunx | fastest web DI framework</title>
+    <meta
+      name="description"
+      content="Documentation and API reference for dunx."
+    />
+    <script type="module" crossorigin src="/assets/index-abc.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+`;
+
+describe('pagesOf', () => {
+  test('walks the model rather than a second list of routes', () => {
+    const paths = pages().map((page) => page.path);
+
+    expect(paths).toEqual([
+      '/',
+      '/benchmarks',
+      '/coverage',
+      '/releases',
+      '/guide/controllers',
+      '/api/core',
+      '/releases/3.3.1',
+    ]);
+  });
+
+  /*
+   * The whole point of the exercise: every route used to answer with the same
+   * title, so a search result for a guide read "dunx | fastest web DI framework".
+   */
+  test('every page has a title and a description of its own', () => {
+    const all = pages();
+    const titles = new Set(all.map((page) => page.title));
+    const descriptions = new Set(all.map((page) => page.description));
+
+    expect(titles.size).toBe(all.length);
+    expect(descriptions.size).toBe(all.length);
+    expect(all.every((page) => page.description.length > 0)).toBe(true);
+  });
+
+  test("a guide's description is the summary llms.txt already uses", () => {
+    const guide = pages().find((page) => page.path === '/guide/controllers');
+
+    expect(guide?.description).toBe(
+      'A controller is a class whose methods are routes.',
+    );
+  });
+
+  test('a guide whose source is missing still gets a page', () => {
+    const [, , , , guide] = pagesOf(INDEX, RELEASES, () => '', 'home');
+
+    expect(guide?.path).toBe('/guide/controllers');
+    expect(guide?.description).toBe('');
+  });
+});
+
+describe('clamp', () => {
+  test('leaves a description inside the budget alone', () => {
+    expect(clamp('Short enough.')).toBe('Short enough.');
+  });
+
+  test('cuts at a word boundary, not mid-word', () => {
+    const cut = clamp(`${'word '.repeat(40)}end`);
+
+    expect(cut.length).toBeLessThanOrEqual(160);
+    expect(cut.endsWith('…')).toBe(true);
+    expect(cut).not.toContain('wor…');
+  });
+
+  test('drops the punctuation the cut left dangling', () => {
+    expect(clamp(`${'a'.repeat(150)}, and more words here`, 160)).not.toContain(
+      ',…',
+    );
+  });
+});
+
+describe('renderPage', () => {
+  const rendered = (): string => {
+    const guide = pages().find((page) => page.path === '/guide/controllers');
+    if (!guide) throw new Error('no guide page');
+    return renderPage(TEMPLATE, guide);
+  };
+
+  test('replaces the title rather than adding a second one', () => {
+    const html = rendered();
+
+    expect(html.match(/<title>/g)).toHaveLength(1);
+    expect(html).toContain('<title>Controllers | dunx</title>');
+  });
+
+  test('replaces the description rather than adding a second one', () => {
+    const html = rendered();
+
+    expect(html.match(/name="description"/g)).toHaveLength(1);
+    expect(html).toContain(
+      'content="A controller is a class whose methods are routes."',
+    );
+  });
+
+  test('carries an absolute canonical for that route', () => {
+    expect(rendered()).toContain(
+      '<link rel="canonical" href="https://dunx.win/guide/controllers" />',
+    );
+  });
+
+  test('keeps the built asset tags, which is why it rewrites the real page', () => {
+    expect(rendered()).toContain('src="/assets/index-abc.js"');
+  });
+
+  test('escapes a title that would otherwise close the attribute', () => {
+    const html = renderPage(TEMPLATE, {
+      path: '/guide/x',
+      title: 'A "quoted" & <angled> title',
+      description: 'Fine.',
+      kind: 'article',
+    });
+
+    expect(html).toContain(
+      'content="A &quot;quoted&quot; &amp; &lt;angled&gt; title"',
+    );
+    expect(html).not.toContain('<angled>');
+  });
+});
+
+describe('sitemapOf', () => {
+  test('lists every page as an absolute url', () => {
+    const all = pages();
+    const xml = sitemapOf(all, '2026-09-05');
+
+    expect(xml.match(/<loc>/g)).toHaveLength(all.length);
+    expect(xml).toContain('<loc>https://dunx.win/</loc>');
+    expect(xml).toContain('<loc>https://dunx.win/guide/controllers</loc>');
+    expect(xml).toContain('<lastmod>2026-09-05</lastmod>');
+  });
+});
+
+describe('robots', () => {
+  test('points at the sitemap it is served beside', () => {
+    expect(robots()).toContain('Sitemap: https://dunx.win/sitemap.xml');
+  });
+});

--- a/internal/docs/scripts/seo.ts
+++ b/internal/docs/scripts/seo.ts
@@ -1,0 +1,274 @@
+/**
+ * A real HTML file per route, written after `vite build`.
+ *
+ * The site is one bundle behind a client router, so every route used to be the
+ * same `index.html`: one title, one description, and no way to say which URL a
+ * page is. Search results and link unfurls all read "dunx | fastest web DI
+ * framework", whatever the reader had actually opened.
+ *
+ * The route set is not invented here. `src/generated/index.json` already holds
+ * every guide and package because the nav is built from it, and `releases.json`
+ * holds every version, so this walks the same model the site renders.
+ *
+ * The second reason to emit files is the 404. `public/_redirects` used to carry
+ * `/* /index.html 200`, which answered **every** miss with the shell: a typo, a
+ * renamed guide and `/sitemap.xml` all returned 200 and a page, so a crawler
+ * could index unlimited soft 404s and a moved document failed silently. With a
+ * file per known route that rule is gone, and `404.html` gives Cloudflare
+ * something to serve with a real status.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { SITE_URL, summaryOf } from './agent-docs.js';
+
+/** No trailing slash, so `${ORIGIN}${page.path}` is never `//guide`. */
+const ORIGIN = SITE_URL.replace(/\/$/, '');
+
+export interface Page {
+  /** Absolute path, `/` for the landing page. */
+  readonly path: string;
+  readonly title: string;
+  readonly description: string;
+  /** `article` for a document, `website` for a landing or index page. */
+  readonly kind: 'article' | 'website';
+}
+
+interface GuideEntry {
+  readonly slug: string;
+  readonly title: string;
+  readonly source: string;
+}
+
+interface PackageEntry {
+  readonly name: string;
+  readonly dir: string;
+  readonly description: string;
+}
+
+interface SiteIndex {
+  readonly generatedAt: string;
+  readonly guides: readonly GuideEntry[];
+  readonly packages: readonly PackageEntry[];
+}
+
+interface ReleaseEntry {
+  readonly version: string;
+  readonly date: string;
+}
+
+/**
+ * `docs/guide/05-controllers.md` as the model records it, against the
+ * `docs/` root the caller reads from.
+ */
+const sourcePath = (source: string): string => source.replace(/^docs\//, '');
+
+const FIXED: readonly Page[] = [
+  {
+    path: '/benchmarks',
+    title: 'Benchmarks',
+    description:
+      'dunx measured against raw Bun.serve, Elysia, Hono, Fastify and NestJS, on the same machine in the same run.',
+    kind: 'website',
+  },
+  {
+    path: '/coverage',
+    title: 'Coverage',
+    description:
+      'Line and function coverage for every published dunx package, regenerated on each release.',
+    kind: 'website',
+  },
+  {
+    path: '/releases',
+    title: 'Releases',
+    description: 'Every dunx release, with the commits that went into it.',
+    kind: 'website',
+  },
+];
+
+/**
+ * Every page the site serves, in sitemap order.
+ *
+ * `read` takes a path under `docs/` and returns its markdown, or `''` when it is
+ * absent - the same contract `writeAgentDocs` takes, so a caller already holding
+ * one can pass it straight through.
+ */
+export const pagesOf = (
+  index: SiteIndex,
+  releases: readonly ReleaseEntry[],
+  read: (file: string) => string,
+  /** The landing page's own line, read out of `index.html` rather than restated. */
+  homeDescription: string,
+): Page[] => [
+  {
+    path: '/',
+    title: 'dunx | fastest web DI framework',
+    description: homeDescription,
+    kind: 'website',
+  },
+  ...FIXED,
+  ...index.guides.map((guide) => ({
+    path: `/guide/${guide.slug}`,
+    title: `${guide.title} | dunx`,
+    description: summaryOf(read(sourcePath(guide.source))),
+    kind: 'article' as const,
+  })),
+  ...index.packages.map((pkg) => ({
+    path: `/api/${pkg.dir}`,
+    title: `${pkg.name} | dunx`,
+    description: pkg.description,
+    kind: 'article' as const,
+  })),
+  ...releases.map((release) => ({
+    path: `/releases/${release.version}`,
+    title: `dunx ${release.version} | Releases`,
+    description: `What shipped in dunx ${release.version}, released ${release.date}.`,
+    kind: 'article' as const,
+  })),
+];
+
+/**
+ * Google renders about 160 characters of a description and drops the rest, so a
+ * longer one is a sentence nobody reads. Cut at a word boundary: `summaryOf`
+ * stops at 200 for `llms.txt`, where the budget is different.
+ */
+export const clamp = (text: string, limit = 160): string => {
+  const value = text.trim();
+  if (value.length <= limit) return value;
+  const cut = value.slice(0, limit - 1);
+  const space = cut.lastIndexOf(' ');
+  return `${(space > limit / 2 ? cut.slice(0, space) : cut).replace(/[,;:.\s]+$/, '')}\u2026`;
+};
+
+/** Attribute-safe. A guide title carrying an ampersand would end the value. */
+const attr = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+/**
+ * The head for one page, built from the page Vite emitted.
+ *
+ * A rewrite of the built document rather than a template of its own: the asset
+ * URLs, the colour-scheme script and the icon are all in there already, and a
+ * second copy of that head would go stale the first time one of them changed.
+ *
+ * No `og:image`. Every image the site has is an SVG, which the major unfurlers
+ * decline to render, so a tag pointing at one buys a broken preview rather than
+ * no preview.
+ */
+export const renderPage = (template: string, page: Page): string => {
+  const url = `${ORIGIN}${page.path}`;
+  const description = clamp(page.description);
+
+  const meta = [
+    `    <link rel="canonical" href="${attr(url)}" />`,
+    `    <meta property="og:type" content="${page.kind}" />`,
+    `    <meta property="og:site_name" content="dunx" />`,
+    `    <meta property="og:title" content="${attr(page.title)}" />`,
+    `    <meta property="og:description" content="${attr(description)}" />`,
+    `    <meta property="og:url" content="${attr(url)}" />`,
+    `    <meta name="twitter:card" content="summary" />`,
+    `    <meta name="twitter:title" content="${attr(page.title)}" />`,
+    `    <meta name="twitter:description" content="${attr(description)}" />`,
+  ].join('\n');
+
+  const titled = template.replace(
+    /<title>[\s\S]*?<\/title>/,
+    `<title>${attr(page.title)}</title>`,
+  );
+  const described = titled.replace(
+    /<meta\s+name="description"[\s\S]*?\/>/,
+    `<meta name="description" content="${attr(description)}" />`,
+  );
+
+  return described.replace('  </head>', `${meta}\n  </head>`);
+};
+
+export const sitemapOf = (pages: readonly Page[], lastmod: string): string =>
+  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${pages
+    .map(
+      (page) =>
+        `  <url>\n    <loc>${attr(`${ORIGIN}${page.path}`)}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`,
+    )
+    .join('\n')}\n</urlset>\n`;
+
+export const robots = (): string =>
+  `User-agent: *\nAllow: /\n\nSitemap: ${ORIGIN}/sitemap.xml\n`;
+
+/** `/guide/controllers` becomes `guide/controllers/index.html`. */
+const fileFor = (path: string): string =>
+  path === '/' ? 'index.html' : `${path.replace(/^\//, '')}/index.html`;
+
+export interface WriteOptions {
+  readonly distDir: string;
+  readonly docsDir: string;
+  readonly generatedDir: string;
+}
+
+export const writeSeoPages = (options: WriteOptions): Page[] => {
+  const { distDir, docsDir, generatedDir } = options;
+
+  const template = readFileSync(join(distDir, 'index.html'), 'utf8');
+  const index = JSON.parse(
+    readFileSync(join(generatedDir, 'index.json'), 'utf8'),
+  ) as SiteIndex;
+  const releasesPath = join(generatedDir, 'releases.json');
+  const releases = existsSync(releasesPath)
+    ? (JSON.parse(readFileSync(releasesPath, 'utf8')) as ReleaseEntry[])
+    : [];
+
+  const read = (file: string): string => {
+    const full = join(docsDir, file);
+    return existsSync(full) ? readFileSync(full, 'utf8') : '';
+  };
+
+  // The description Vite emitted, which is the one hand-written in `index.html`.
+  // Taking it from there rather than repeating it here is what stops the landing
+  // page having two descriptions that disagree.
+  const home =
+    /<meta\s+name="description"\s+content="([^"]*)"/.exec(template)?.[1] ?? '';
+
+  const pages = pagesOf(index, releases, read, home);
+
+  for (const page of pages) {
+    const target = join(distDir, fileFor(page.path));
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, renderPage(template, page));
+  }
+
+  // The shell with no route-specific head, served by Cloudflare with a 404
+  // status for anything the loop above did not write. The router renders its
+  // own Not found panel once it boots.
+  writeFileSync(
+    join(distDir, '404.html'),
+    renderPage(template, {
+      path: '/404',
+      title: 'Not found | dunx',
+      description: 'That page does not exist on the dunx documentation site.',
+      kind: 'website',
+    }),
+  );
+
+  writeFileSync(
+    join(distDir, 'sitemap.xml'),
+    sitemapOf(pages, index.generatedAt.slice(0, 10)),
+  );
+  writeFileSync(join(distDir, 'robots.txt'), robots());
+
+  return pages;
+};
+
+if (import.meta.main) {
+  const root = new URL('../../..', import.meta.url).pathname;
+  const pages = writeSeoPages({
+    distDir: join(root, 'internal/docs/dist'),
+    docsDir: join(root, 'docs'),
+    generatedDir: join(root, 'internal/docs/src/generated'),
+  });
+  console.log(
+    `SEO: ${pages.length} pages, sitemap.xml, robots.txt and 404.html`,
+  );
+}

--- a/internal/docs/scripts/seo.ts
+++ b/internal/docs/scripts/seo.ts
@@ -198,9 +198,17 @@ export const sitemapOf = (pages: readonly Page[], lastmod: string): string =>
 export const robots = (): string =>
   `User-agent: *\nAllow: /\n\nSitemap: ${ORIGIN}/sitemap.xml\n`;
 
-/** `/guide/controllers` becomes `guide/controllers/index.html`. */
-const fileFor = (path: string): string =>
-  path === '/' ? 'index.html' : `${path.replace(/^\//, '')}/index.html`;
+/**
+ * `/guide/controllers` becomes `guide/controllers.html`, not
+ * `guide/controllers/index.html`.
+ *
+ * Measured on a preview deployment: Cloudflare answers a directory-index file
+ * with a **308 to the trailing-slash form**, so every deep link cost a redirect
+ * hop and the URL that finally rendered disagreed with the canonical this file
+ * writes. The `.html` sibling is served at the extensionless path directly.
+ */
+export const fileFor = (path: string): string =>
+  path === '/' ? 'index.html' : `${path.replace(/^\//, '')}.html`;
 
 export interface WriteOptions {
   readonly distDir: string;

--- a/internal/docs/scripts/seo.ts
+++ b/internal/docs/scripts/seo.ts
@@ -87,6 +87,17 @@ const FIXED: readonly Page[] = [
 ];
 
 /**
+ * A description is never empty.
+ *
+ * A page shipping `content=""` is a worse signal than one carrying no tag at
+ * all, and a guide's summary depends on its source being readable at build time.
+ * That holds today - the model is generated from those same files moments
+ * earlier - but a search result should not rest on it.
+ */
+const descriptionOr = (summary: string, fallback: string): string =>
+  summary.trim() === '' ? fallback : summary.trim();
+
+/**
  * Every page the site serves, in sitemap order.
  *
  * `read` takes a path under `docs/` and returns its markdown, or `''` when it is
@@ -110,13 +121,19 @@ export const pagesOf = (
   ...index.guides.map((guide) => ({
     path: `/guide/${guide.slug}`,
     title: `${guide.title} | dunx`,
-    description: summaryOf(read(sourcePath(guide.source))),
+    description: descriptionOr(
+      summaryOf(read(sourcePath(guide.source))),
+      `${guide.title}, from the dunx guide.`,
+    ),
     kind: 'article' as const,
   })),
   ...index.packages.map((pkg) => ({
     path: `/api/${pkg.dir}`,
     title: `${pkg.name} | dunx`,
-    description: pkg.description,
+    description: descriptionOr(
+      pkg.description,
+      `API reference for ${pkg.name}.`,
+    ),
     kind: 'article' as const,
   })),
   ...releases.map((release) => ({


### PR DESCRIPTION
Every route served the same `index.html`, so all 96 carried one title and one description, and a shared link unfurled as the landing page whatever it pointed at.

`scripts/seo.ts` runs after `vite build` and writes a file per route with its own title, description, canonical and Open Graph tags, plus `sitemap.xml`, `robots.txt` and `404.html`. The route set is the generated model the nav is already built from; a guide's description is `summaryOf` from `agent-docs.ts`, so it cannot disagree with the one in `llms.txt`.

It also removes the `/* /index.html 200` catch-all, which answered every miss with a 200 and a page. `robots.txt` and `sitemap.xml` appeared to exist for that reason alone, and any typo was a soft 404 a crawler could index.

To verify on the preview, since these are edge behaviours a local build cannot prove:

- `/guide/controllers` resolves from `guide/controllers/index.html`
- an unknown path returns a real **404**, not a 200
- `/sitemap.xml` and `/robots.txt` return their own content types
- `/releases/v3.3.1` 301s to `/releases/3.3.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation pages now include route-specific titles, descriptions, canonical links, and social sharing metadata.
  * Added sitemap, robots.txt, and a dedicated 404 page for improved navigation and search visibility.
  * Added permanent redirects from versioned release paths to their canonical URLs.

* **Bug Fixes**
  * Unknown documentation routes now return a proper HTTP 404 instead of loading the homepage.
  * Preview routing now matches production behavior, including extensionless URLs and missing-page handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->