### PR TITLE
chore: move to Bun 1.4.2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: 1.4.1
+        bun-version: 1.4.2
 
     - name: Cache Bun dependencies
       uses: actions/cache@v4

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -63,6 +63,70 @@ Use the links in the table to jump to the associated documentation.
 | Parsing & Formatting             | [`Bun.semver`](/docs/runtime/semver), [`Bun.TOML.parse`](/docs/runtime/toml), [`Bun.markdown`](/docs/runtime/markdown), [`Bun.color`](/docs/runtime/color), [`Bun.Image`](/docs/runtime/image)                                                                                                                                             |
 | Low-level / Internals            | `Bun.mmap`, `Bun.gc`, `Bun.generateHeapSnapshot`, [`bun:jsc`](https://bun.com/reference/bun/jsc)                                                                                                                                                                                                                                           |
 
+## Re-probed on Bun 1.4.2 (rev 744846f84)
+
+A patch release, so only the findings its release notes touch were re-run, each
+against 1.4.1 rev `4661e494f` on the same machine.
+
+| Finding                                                                       | On 1.4.2                                                               |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| A nested `run()` retains the enclosing store while a timer or promise is live | **fixed** - and `AsyncRequestContext` is the shape that needed it      |
+| `Bun.Image` fails a 4-component CMYK JPEG with `ERR_IMAGE_DECODE_FAILED`      | **fixed** - decodes to RGB, so every transform and output format works |
+| `bun build` renames a nested `var` onto a `let` in the same block             | **fixed** - 1.4.1 emitted `let exports2` beside `var exports2`         |
+| `.json()` on invalid JSON throws a generic `Failed to parse JSON`             | **fixed** - `SyntaxError: JSON Parse error: Expected '}'`              |
+| `Bun.file(path).writer()` does not truncate or create parents                 | reproduces                                                             |
+| `fetch` with `protocol: 'http2'` throws against a cleartext peer              | reproduces                                                             |
+| `internal/docs` under `bun test --parallel`                                   | reproduces - 38 of 92 fail, so the `docs` phase keeps its exclusion    |
+
+`engines.bun` stays `>=1.4.1`. Nothing dunx ships depends on 1.4.2 behaviour; CI
+pins it and the deployment guide's image names it.
+
+### A nested `AsyncLocalStorage.run()` held the enclosing store
+
+`AsyncRequestContext.runWithContext` reads the enclosing store and calls
+`storage.run` with a merge of it, so every scope after the outermost is a nested
+`run()`. That is the shape 1.4.1 leaked: a timer, immediate or pending promise
+opened inside one kept the **outer** store alive for as long as it existed.
+`getStore()` returned the right value throughout, so retention was the only symptom.
+
+Probed with a `WeakRef` to the outer store, a one-hour timer opened inside the
+nested scope, and `Bun.gc(true)`:
+
+```
+1.4.1  nested run(): RETAINED    exit(): RETAINED
+1.4.2  nested run(): collected   exit(): collected
+```
+
+In dunx that object is a request's `RequestFields`, held by whatever the handler
+left pending.
+
+The fix has a price, and it falls on the scope entry `runWithContext` pays at least
+once per request. Nine interleaved rounds of 50,000 iterations, medians, both
+runtimes on this machine:
+
+| Step                          | 1.4.1   | 1.4.2   |
+| ----------------------------- | ------- | ------- |
+| `als.run(v, fn)`, synchronous | 11.4 ns | 15.6 ns |
+| three nested `run()`s         | 42.1 ns | 59.2 ns |
+| store cost across 16 awaits   | 14.9 ns | 15.3 ns |
+
+The flat entry cost 1.4.1 introduced holds: sixteen awaits still charge about 1 ns
+each against 1.4.0's 6.5 ns. The entry moved instead, +4 ns for one scope and
++17 ns across three, against the 47.2 ns per scope `AsyncRequestContext` records
+and a request measured in microseconds. No published figure moves.
+
+### `Bun.Image` decodes CMYK JPEGs
+
+A 64x48 CMYK JPEG through `resize(32, 24).webp()`:
+
+```
+1.4.1  Error: Image: decode failed (ERR_IMAGE_DECODE_FAILED)
+1.4.2  64x48 jpeg -> 82 bytes of webp
+```
+
+`metadata()` reported `64x48 jpeg` on both, which is the header-only read recorded
+below rather than a decode.
+
 ## Re-probed on Bun 1.4.1 (rev 4661e494f)
 
 Run against 1.4.0 rev `34cbb9a40` side by side, on the same machine, rather than

--- a/docs/guide/19-deployment.md
+++ b/docs/guide/19-deployment.md
@@ -158,7 +158,7 @@ running service returning 500s. See [Configuration](./12-configuration.md).
 ## Container image
 
 ```dockerfile
-FROM oven/bun:1.4.1-alpine
+FROM oven/bun:1.4.2-alpine
 WORKDIR /app
 
 # Dependencies first, so a source change does not reinstall them.
@@ -171,8 +171,11 @@ EXPOSE 3000
 CMD ["bun", "src/main.ts"]
 ```
 
-Two details worth getting right:
+Three details worth getting right:
 
+- **Pin the patch, not `1.4-alpine`.** 1.4.2 fixes a crash on musl that
+  `Array.prototype.splice`, `shift` or a shrinking `length` on an array of objects
+  could hit while the collector was marking.
 - **`--frozen-lockfile`**, so a deploy can never silently resolve a different
   version than the one that was tested.
 - **`bunfig.toml` must be in the image.** It is easy to miss because it is not

--- a/packages/http/src/client/module.test.ts
+++ b/packages/http/src/client/module.test.ts
@@ -237,9 +237,11 @@ describe('named clients', () => {
     @Module({
       imports: [
         HttpModule.forRoot({ baseUrl: base }),
-        HttpModule.forRoot({ name: 'stripe', baseUrl: base, timeoutMs: 11 }),
+        // Distinct per client, and long enough to survive a loaded `--parallel`
+        // worker: at 11 ms and 22 ms the live requests below aborted.
+        HttpModule.forRoot({ name: 'stripe', baseUrl: base, timeoutMs: 1_100 }),
         HttpModule.forRootAsync(
-          () => ({ baseUrl: base, timeoutMs: 22 }),
+          () => ({ baseUrl: base, timeoutMs: 2_200 }),
           'billing',
         ),
       ],


### PR DESCRIPTION
Runtime pin, plus the re-probe of the findings 1.4.2's release notes touch. Each was run against 1.4.1 rev `4661e494f` on the same machine; the record is the new section at the top of `docs/bun-apis.md`.

The one that reaches dunx code: the AsyncLocalStorage leak. `AsyncRequestContext.runWithContext` merges an enclosing scope by nesting `run()`, which is the shape 1.4.1 retained, holding a request's `RequestFields` for the life of any timer or promise opened inside. Fixed, at about +4 ns on the scope entry every request pays.

`engines.bun` stays `>=1.4.1` - nothing dunx ships depends on 1.4.2 behaviour. `@types/bun` stays 1.4.1, the newest published. The deployment guide's Alpine image moves, since 1.4.2 fixes a GC crash on musl.

Second commit is unrelated to the upgrade: a named-client test gave a live request an 11 ms timeout and lost that race once in three `bun run ci` runs.

`bun run ci` green, 12/12 steps, with valkey, postgres and MinIO up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the runtime to Bun 1.4.2, including fixes for nested state handling, CMYK JPEG decoding, invalid JSON errors, and a musl-related crash.
  - CMYK JPEG images can now be converted successfully to WebP.

- **Documentation**
  - Added Bun 1.4.2 compatibility findings, performance measurements, and deployment guidance.
  - Updated container deployment examples to use Bun 1.4.2 Alpine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->