### PR TITLE
docs: show the destructured handler shape, and the Nest side-by-side

### DIFF
--- a/docs/MIGRATION-FROM-NEST.md
+++ b/docs/MIGRATION-FROM-NEST.md
@@ -147,13 +147,55 @@ keeps refusing.
 | Per-controller / per-route middleware   | `@UseGuards`                                                            | done         |
 | `@SetMetadata` + `Reflector`            | `meta` / `metaKey` + `ctx.get`                                          | done         |
 | `@UseGuards` / `@Roles` / `@Public`     | same names                                                              | done         |
-| `@Body` / `@Query` / `@Param`           | [schemas on the route decorator](./guide/06-validation.md)              | done         |
-| `createParamDecorator` (`@CurrentUser`) | -                                                                       | undesigned   |
+| `@Body` / `@Query` / `@Param`           | [one input object, typed by the schema](#handler-parameters)            | done         |
+| `createParamDecorator` (`@CurrentUser`) | [no successor, two answers](#custom-param-decorators)                   | n/a          |
 | `setGlobalPrefix`                       | `app.setGlobalPrefix()`                                                 | done         |
 | `enableCors`                            | `app.enableCors()`                                                      | done         |
 | `app.getUrl()`                          | `listen()` returns the URL                                              | done         |
 | `app.use(expressMiddleware)`            | -                                                                       | out of scope |
 | `@HttpCode` / `@Header` / `@Redirect`   | `status` in the options, `Response`                                     | n/a          |
+
+### Handler parameters
+
+Nest names each part of a request with its own parameter decorator. dunx passes
+one object, typed by the schema on the route decorator:
+
+```ts
+// Nest
+@Post()
+create(@Body() dto: CreateUserDto): Promise<User> {
+  return this.users.create(dto.name);
+}
+
+// dunx
+@Post('/', createUser)
+create({ body }: Input<typeof createUser>): Promise<User> {
+  return this.users.create(body.name);
+}
+```
+
+| Nest                      | dunx                                    |
+| ------------------------- | --------------------------------------- |
+| `@Body() dto: CreateUser` | `{ body }: Input<typeof createUser>`    |
+| `@Query() q: ListQuery`   | `{ query }: Input<typeof listUsers>`    |
+| `@Param('id') id: string` | `{ params }: Input<typeof oneUser>`     |
+| `@Req() req: Request`     | `{ req }: Input<RouteSchemas>`          |
+| `@Res() res: Response`    | return a `Response`                     |
+| `@Headers('x-trace') v`   | `req.headers.get('x-trace')`            |
+| `@Ip() ip: string`        | `ClientAddress`, then `address.of(req)` |
+
+Destructuring at the parameter is the usual shape; naming the whole object types
+the same. One schema constant covers what Nest splits between a DTO class,
+`ValidationPipe` and `@ApiProperty`: it validates the request, types the handler,
+and describes the route in the OpenAPI document.
+
+`@Res()` has no counterpart. A handler returns a `Response` when it wants to set
+the status, headers or body directly, and a route that does so keeps its
+middleware, guards and error handling.
+
+TC39 standard decorators have no parameter position.
+[Custom param decorators](#custom-param-decorators) covers the two classes of
+`createParamDecorator` usage and what each becomes.
 
 ## Ecosystem
 

--- a/docs/guide/02-first-steps.md
+++ b/docs/guide/02-first-steps.md
@@ -452,8 +452,8 @@ export class GreetingsController {
   }
 
   @Get('/:name')
-  one(input: Input<RouteSchemas>): { greeting: string; served: number } {
-    return this.greetings.greet(input.req.params['name'] ?? 'world');
+  one({ req }: Input<RouteSchemas>): { greeting: string; served: number } {
+    return this.greetings.greet(req.params['name'] ?? 'world');
   }
 }
 ```
@@ -466,7 +466,7 @@ There is no `res` to forget to send, and returning a `Response` yourself passes
 through untouched when you need the escape hatch.
 
 `@Get('/:name')` declares no schemas, so the path parameter stays on
-`input.req.params` as a string. `noUncheckedIndexedAccess` is why the `?? 'world'`
+`req.params` as a string. `noUncheckedIndexedAccess` is why the `?? 'world'`
 is there. Declaring a `params` schema is what makes it typed and coerced, and
 [Controllers](./05-controllers.md) shows that.
 
@@ -576,13 +576,16 @@ export class GreetingsController {
   constructor(private readonly greetings: GreetingsService) {}
 
   @Get('/:name', oneGreeting)
-  one(input: Input<typeof oneGreeting>): { greeting: string; served: number } {
-    return this.greetings.greet(input.params.name);
+  one({ params }: Input<typeof oneGreeting>): {
+    greeting: string;
+    served: number;
+  } {
+    return this.greetings.greet(params.name);
   }
 }
 ```
 
-`input.params.name` is now a `string` the schema has already checked, and the
+`params.name` is now a `string` the schema has already checked, and the
 `?? 'world'` is gone because the field cannot be missing. A request that fails the
 schema never reaches the handler; it gets a 400 whose body carries every issue.
 

--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -23,13 +23,13 @@ export class UsersController {
   }
 
   @Get('/:id', oneUser)
-  one(input: Input<typeof oneUser>): Promise<User | null> {
-    return this.users.find(input.params.id);
+  one({ params }: Input<typeof oneUser>): Promise<User | null> {
+    return this.users.find(params.id);
   }
 
   @Post('/', createUser)
-  create(input: Input<typeof createUser>): Promise<User> {
-    return this.users.create(input.body.name);
+  create({ body }: Input<typeof createUser>): Promise<User> {
+    return this.users.create(body.name);
   }
 }
 ```
@@ -172,27 +172,27 @@ CORS preflight handler.
 ## Path parameters
 
 Bun's own syntax, because Bun does the matching. Without a `params` schema they
-arrive as strings on `input.req.params`:
+arrive as strings on `req.params`:
 
 ```ts
 @Get('/:name')
-one(input: Input<RouteSchemas>): { greeting: string } {
-  return { greeting: `hello, ${input.req.params['name'] ?? 'world'}` };
+one({ req }: Input<RouteSchemas>): { greeting: string } {
+  return { greeting: `hello, ${req.params['name'] ?? 'world'}` };
 }
 ```
 
 Declare a `params` schema and they arrive typed, validated and coerced on
-`input.params`:
+`params`:
 
 ```ts
 const oneUser = { params: z.object({ id: z.coerce.number().int().min(1) }) } as const;
 
 @Get('/:id', oneUser)
-async one(input: Input<typeof oneUser>): Promise<User> {
+async one({ params }: Input<typeof oneUser>): Promise<User> {
   // Already a number. The schema coerced it before this ran.
-  const user = await this.users.find(input.params.id);
+  const user = await this.users.find(params.id);
   if (user === null) {
-    throw new HttpError(HttpStatusCode.NOT_FOUND, `No user ${input.params.id}`);
+    throw new HttpError(HttpStatusCode.NOT_FOUND, `No user ${params.id}`);
   }
   return user;
 }
@@ -218,12 +218,27 @@ export interface RouteSchemas {
 }
 ```
 
-| Field          | Source                                   | Present when      |
-| -------------- | ---------------------------------------- | ----------------- |
-| `input.req`    | the `BunRequest`                         | always            |
-| `input.body`   | parsed by `content-type`, then validated | `body` declared   |
-| `input.query`  | the query string, then validated         | `query` declared  |
-| `input.params` | `req.params`, then validated             | `params` declared |
+| Field    | Source                                   | Present when      |
+| -------- | ---------------------------------------- | ----------------- |
+| `req`    | the `BunRequest`                         | always            |
+| `body`   | parsed by `content-type`, then validated | `body` declared   |
+| `query`  | the query string, then validated         | `query` declared  |
+| `params` | `req.params`, then validated             | `params` declared |
+
+The parameter takes either shape. Destructuring is the usual one, and a handler
+that passes the request on names the whole object instead:
+
+```ts
+@Post('/', createNote)
+create({ body }: Input<typeof createNote>): Note {
+  return this.notes.add(body.text);
+}
+
+@Post('/', createNote)
+record(input: Input<typeof createNote>): Note {
+  return this.audit.write(input);
+}
+```
 
 Validation targets the **Standard Schema** spec (`~standard.validate`), restated
 in `@dunx/http`'s own types rather than depended on: the spec is an interface and
@@ -248,11 +263,12 @@ mismatched `V`, but it has no way to contextually type an unannotated parameter.
 Decorators observe; they do not type. Measured with `tsc`, because this is a
 type-level claim `bun` cannot answer:
 
-| Handler                       | Result                                                   |
-| ----------------------------- | -------------------------------------------------------- |
-| annotated correctly           | compiles                                                 |
-| unannotated parameter         | `TS7006: Parameter 'input' implicitly has an 'any' type` |
-| annotated with the wrong type | `TS1241` + `TS1270`, naming the mismatched property      |
+| Handler                       | Result                                                        |
+| ----------------------------- | ------------------------------------------------------------- |
+| annotated correctly           | compiles                                                      |
+| unannotated parameter         | `TS7006: Parameter 'input' implicitly has an 'any' type`      |
+| unannotated destructured      | `TS7031: Binding element 'body' implicitly has an 'any' type` |
+| annotated with the wrong type | `TS1241` + `TS1270`, naming the mismatched property           |
 
 So the annotation is required. What makes it cheap is that `Input<O>` is a
 type-level function over the options object, so every field type still comes from
@@ -262,8 +278,8 @@ the schema and nothing is declared twice:
 const createNote = { body: CreateNote, status: HttpStatusCode.CREATED } as const;
 
 @Post('/', createNote)
-create(input: Input<typeof createNote>): Note {
-  return this.notes.add(input.body.text); // input.body.text is string
+create({ body }: Input<typeof createNote>): Note {
+  return this.notes.add(body.text); // body.text is string
 }
 ```
 
@@ -272,7 +288,7 @@ not do is annotate that constant as `RouteSchemas`:
 
 ```ts
 // Wrong. RouteSchemas.body is optional, so Input<typeof createNote> degrades to
-// bare { req } and input.body is a compile error at every handler.
+// bare { req } and body is a compile error at every handler.
 const createNote: RouteSchemas = { body: CreateNote };
 
 // Right. `satisfies` checks the shape without replacing the type.
@@ -281,7 +297,7 @@ const createNote = { body: CreateNote } as const satisfies RouteSchemas;
 
 `as const satisfies RouteSchemas` is the convention throughout the codebase.
 `satisfies` catches a misspelled field at the declaration rather than as a missing
-`input` field in the handler, and `as const` keeps `status` a literal. Options
+field in the handler, and `as const` keeps `status` a literal. Options
 passed inline need neither, because the decorator's own `const O` type parameter
 stops them widening on the way in.
 
@@ -292,7 +308,7 @@ at all.
 
 Only when `body` is declared, and by media type:
 
-| `content-type`                      | `input.body` before validation          |
+| `content-type`                      | `body` before validation                |
 | ----------------------------------- | --------------------------------------- |
 | `application/json`, `*+json`, none  | `req.json()`                            |
 | `application/x-www-form-urlencoded` | fields; a repeated key becomes an array |
@@ -559,8 +575,8 @@ export class ReportsController {
 
   @UseGuards(RolesGuard)
   @Post('/', createReport)
-  create(input: Input<typeof createReport>): readonly string[] {
-    return this.reports.add(input.body.title);
+  create({ body }: Input<typeof createReport>): readonly string[] {
+    return this.reports.add(body.title);
   }
 }
 ```

--- a/docs/guide/06-validation.md
+++ b/docs/guide/06-validation.md
@@ -21,13 +21,13 @@ export class UsersController {
   constructor(private readonly users: UsersService) {}
 
   @Post('/', createUser)
-  create(input: Input<typeof createUser>): Promise<User> {
-    return this.users.create(input.body.name);
+  create({ body }: Input<typeof createUser>): Promise<User> {
+    return this.users.create(body.name);
   }
 }
 ```
 
-The body arrives parsed and validated: `input.body.name` is already a `string`,
+The body arrives parsed and validated: `body.name` is already a `string`,
 and a POST answers 201, all without writing `await req.json()`, `Response.json()`
 or a status code by hand. A request that fails the schema never reaches the
 handler.
@@ -123,7 +123,7 @@ instead, so this does not compile:
 
 ```ts
 @Get('/:id', oneUser)
-one(input: Input<typeof oneUser>): { id: number } {
+one({ params }: Input<typeof oneUser>): { id: number } {
   //                                ^ TS1241: property 'name' is missing
 }
 ```
@@ -166,15 +166,14 @@ a `params` schema validates that object and replaces it with the schema's output
 
 ```ts
 @Get('/:id', oneUser)
-async one(input: Input<typeof oneUser>): Promise<User> {
-  const user = await this.users.find(input.params.id);
+async one({ params }: Input<typeof oneUser>): Promise<User> {
+  const user = await this.users.find(params.id);
   ...
 }
 ```
 
-Without a `params` schema the raw values are still reachable at
-`input.req.params`. The framework does not hide them; it just does not type or
-check them.
+Without a `params` schema the raw values are still reachable at `req.params`. The
+framework does not hide them; it just does not type or check them.
 
 ### Query strings
 
@@ -226,17 +225,17 @@ export const UserIndex = z.object({ id: z.coerce.number().int().min(1) });
 ```
 
 `z.coerce.number()` turns `"42"` into `42` before `.int().min(1)` runs, so by the
-time the handler executes `input.params.id` is a `number` at runtime **and** in
+time the handler executes `params.id` is a `number` at runtime **and** in
 the type, because `Input<>` reads the schema's _output_ type rather than its
 input:
 
 ```ts
 @Get('/:id', oneUser)
-async one(input: Input<typeof oneUser>): Promise<User> {
+async one({ params }: Input<typeof oneUser>): Promise<User> {
   // Already a number. The params schema coerced it before this ran.
-  const user = await this.users.find(input.params.id);
+  const user = await this.users.find(params.id);
   if (user === null) {
-    throw new HttpError(HttpStatusCode.NOT_FOUND, `No user ${input.params.id}`);
+    throw new HttpError(HttpStatusCode.NOT_FOUND, `No user ${params.id}`);
   }
   return user;
 }
@@ -296,8 +295,8 @@ A route with no schemas at all still gets the request:
 
 ```ts
 @Get('/whoami')
-whoami(input: Input<RouteSchemas>): { ip: string | undefined } {
-  return { ip: this.address.of(input.req) };
+whoami({ req }: Input<RouteSchemas>): { ip: string | undefined } {
+  return { ip: this.address.of(req) };
 }
 ```
 
@@ -436,8 +435,8 @@ it used to be level.
 - **`as const` is not optional.** Drop it and the handler's `input` silently
   becomes `{ req }`. `satisfies RouteSchemas` is what catches a typo in a key
   name without re-widening the object.
-- **A `params` schema replaces `req.params` on `input` only.**
-  `input.req.params` is still the raw string record.
+- **A `params` schema replaces `req.params` on the input object only.**
+  `req.params` is still the raw string record.
 - **The framework validates input and never output.** A handler's return value is
   serialised as it is, `response` schemas included: they document the answer for
   `@dunx/openapi` and nothing checks them at runtime. If a response shape matters,

--- a/docs/guide/10-openapi.md
+++ b/docs/guide/10-openapi.md
@@ -230,8 +230,8 @@ export class NotesController {
     deprecated: true,
   })
   @Get('/whoami')
-  whoami(input: Input<RouteSchemas>): { ip: string | undefined } {
-    return { ip: this.address.of(input.req) };
+  whoami({ req }: Input<RouteSchemas>): { ip: string | undefined } {
+    return { ip: this.address.of(req) };
   }
 }
 ```

--- a/docs/guide/14-database.md
+++ b/docs/guide/14-database.md
@@ -629,11 +629,11 @@ const pageQuery = z.object({
 const paged = { query: pageQuery } as const;
 
 @Get('/page', paged)
-page(input: Input<typeof paged>): Promise<Page<Entry>> {
+page({ query }: Input<typeof paged>): Promise<Page<Entry>> {
   return paginate<typeof ledger, Entry>({
     db: this.db,
     table: ledger,
-    options: input.query,
+    options: query,
   });
 }
 ```

--- a/examples/full/src/cache/cache.controller.ts
+++ b/examples/full/src/cache/cache.controller.ts
@@ -42,33 +42,35 @@ export class CacheController {
   }
 
   @Get('/:id', oneSession)
-  async read(
-    input: Input<typeof oneSession>,
-  ): Promise<{ id: string; data: unknown; ttl: number }> {
-    const found = await this.degrades(() =>
-      this.sessions.read(input.params.id),
-    );
+  async read({ params }: Input<typeof oneSession>): Promise<{
+    id: string;
+    data: unknown;
+    ttl: number;
+  }> {
+    const found = await this.degrades(() => this.sessions.read(params.id));
     if (found === null) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No session "${input.params.id}"`,
+        `No session "${params.id}"`,
       );
     }
     return found;
   }
 
   @Put('/:id', putSession)
-  store(
-    input: Input<typeof putSession>,
-  ): Promise<{ id: string; ttl: number; visits: number }> {
+  store({ body, params }: Input<typeof putSession>): Promise<{
+    id: string;
+    ttl: number;
+    visits: number;
+  }> {
     return this.degrades(() =>
-      this.sessions.store(input.params.id, input.body.data, input.body.ttl),
+      this.sessions.store(params.id, body.data, body.ttl),
     );
   }
 
   @Delete('/:id', oneSession)
-  remove(input: Input<typeof oneSession>): Promise<{ removed: number }> {
-    return this.degrades(() => this.sessions.remove(input.params.id));
+  remove({ params }: Input<typeof oneSession>): Promise<{ removed: number }> {
+    return this.degrades(() => this.sessions.remove(params.id));
   }
 
   private async degrades<T>(run: () => Promise<T>): Promise<T> {

--- a/examples/full/src/database/ledger.controller.ts
+++ b/examples/full/src/database/ledger.controller.ts
@@ -78,12 +78,12 @@ export class LedgerController {
   constructor(private readonly ledger: Ledger) {}
 
   @Get('/', listEntries)
-  list(input: Input<typeof listEntries>): {
+  list({ query }: Input<typeof listEntries>): {
     entries: readonly Entry[];
     balance: number;
   } {
     return {
-      entries: this.ledger.list(input.query.limit),
+      entries: this.ledger.list(query.limit),
       balance: this.ledger.balance(),
     };
   }
@@ -91,34 +91,34 @@ export class LedgerController {
   /** Walked by cursor. Declared before `/:id` for readability only: `Bun.serve`
    * matches a static segment ahead of a parameter. */
   @Get('/page', pagedEntries)
-  page(input: Input<typeof pagedEntries>): Page<Entry> {
-    return this.ledger.page(input.query);
+  page({ query }: Input<typeof pagedEntries>): Page<Entry> {
+    return this.ledger.page(query);
   }
 
   @Get('/:id', oneEntry)
-  one(input: Input<typeof oneEntry>): Entry {
-    const entry = this.ledger.find(input.params.id);
+  one({ params }: Input<typeof oneEntry>): Entry {
+    const entry = this.ledger.find(params.id);
     if (entry === undefined) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No ledger entry ${input.params.id}`,
+        `No ledger entry ${params.id}`,
       );
     }
     return entry;
   }
 
   @Post('/', createEntry)
-  create(input: Input<typeof createEntry>): Entry {
-    return this.ledger.add(input.body.memo, input.body.amount);
+  create({ body }: Input<typeof createEntry>): Entry {
+    return this.ledger.add(body.memo, body.amount);
   }
 
   /** `"fail": true` throws between the two inserts; the 409's unchanged `rows`
    * is proof the first leg rolled back. */
   @Post('/transfer', transfer)
-  async transfer(
-    input: Input<typeof transfer>,
-  ): Promise<{ balance: number; rows: number }> {
-    const { from, to, amount, fail } = input.body;
+  async transfer({
+    body,
+  }: Input<typeof transfer>): Promise<{ balance: number; rows: number }> {
+    const { from, to, amount, fail } = body;
     try {
       const balance = await this.ledger.transfer(from, to, amount, fail);
       return { balance, rows: this.ledger.rows() };
@@ -136,11 +136,11 @@ export class LedgerController {
    * what allows it - `transactionSync` will not compile against the async handle.
    */
   @Post('/transfer-sync', transfer)
-  transferSync(input: Input<typeof transfer>): {
+  transferSync({ body }: Input<typeof transfer>): {
     balance: number;
     rows: number;
   } {
-    const { from, to, amount, fail } = input.body;
+    const { from, to, amount, fail } = body;
     try {
       const balance = this.ledger.transferSync(from, to, amount, fail);
       return { balance, rows: this.ledger.rows() };
@@ -153,12 +153,12 @@ export class LedgerController {
   }
 
   @Delete('/:id', oneEntry)
-  remove(input: Input<typeof oneEntry>): { deleted: boolean } {
-    const deleted = this.ledger.remove(input.params.id);
+  remove({ params }: Input<typeof oneEntry>): { deleted: boolean } {
+    const deleted = this.ledger.remove(params.id);
     if (!deleted) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No ledger entry ${input.params.id}`,
+        `No ledger entry ${params.id}`,
       );
     }
     return { deleted };

--- a/examples/full/src/guards/reports.controller.ts
+++ b/examples/full/src/guards/reports.controller.ts
@@ -55,15 +55,15 @@ export class ReportsController {
   // Method-scoped guard, reading the class-level @Roles('admin').
   @UseGuards(RolesGuard)
   @Post('/', createReport)
-  create(input: Input<typeof createReport>): readonly string[] {
-    return this.reports.add(input.body.title);
+  create({ body }: Input<typeof createReport>): readonly string[] {
+    return this.reports.add(body.title);
   }
 
   // A method-level @Roles wins over the class-level one.
   @Roles('editor')
   @UseGuards(RolesGuard)
   @Patch('/:id', renameReport)
-  rename(input: Input<typeof renameReport>): readonly string[] {
-    return this.reports.rename(input.params.id, input.body.title);
+  rename({ body, params }: Input<typeof renameReport>): readonly string[] {
+    return this.reports.rename(params.id, body.title);
   }
 }

--- a/examples/full/src/http/trace.controller.ts
+++ b/examples/full/src/http/trace.controller.ts
@@ -14,7 +14,7 @@ export class TraceController {
   constructor(private readonly context: RequestContext) {}
 
   @Get('/')
-  current(input: Input<RouteSchemas>): {
+  current({ req }: Input<RouteSchemas>): {
     traceId: string | undefined;
     spanId: string | undefined;
     parentSpanId: string | undefined;
@@ -28,7 +28,7 @@ export class TraceController {
       spanId: spanId as string | undefined,
       parentSpanId: parentSpanId as string | undefined,
       traceFlags: traceFlags as string | undefined,
-      inbound: input.req.headers.get('traceparent'),
+      inbound: req.headers.get('traceparent'),
     };
   }
 }

--- a/examples/full/src/jobs/jobs.controller.ts
+++ b/examples/full/src/jobs/jobs.controller.ts
@@ -33,11 +33,13 @@ export class JobsController {
   constructor(private readonly publisher: JobPublisher) {}
 
   @Post('/thumbnails', enqueue)
-  async enqueue(
-    input: Input<typeof enqueue>,
-  ): Promise<{ id: string; queue: string; state: string }> {
+  async enqueue({ body }: Input<typeof enqueue>): Promise<{
+    id: string;
+    queue: string;
+    state: string;
+  }> {
     const job = await this.degrades(() =>
-      this.publisher.publish(THUMBNAIL_QUEUE, 'render', input.body),
+      this.publisher.publish(THUMBNAIL_QUEUE, 'render', body),
     );
 
     return {
@@ -50,24 +52,24 @@ export class JobsController {
   /** `returnvalue` is whatever the handler returned, so this is how the web
    * process reads a result computed elsewhere. */
   @Get('/thumbnails/:id', oneJob)
-  async status(input: Input<typeof oneJob>): Promise<{
+  async status({ params }: Input<typeof oneJob>): Promise<{
     id: string;
     state: string;
     result: RenderResult | null;
     failedReason: string | null;
   }> {
     const job = await this.degrades(() =>
-      this.publisher.queue(THUMBNAIL_QUEUE).getJob(input.params.id),
+      this.publisher.queue(THUMBNAIL_QUEUE).getJob(params.id),
     );
     if (job === undefined) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No job ${input.params.id} on "${THUMBNAIL_QUEUE}"`,
+        `No job ${params.id} on "${THUMBNAIL_QUEUE}"`,
       );
     }
 
     return {
-      id: job.id ?? input.params.id,
+      id: job.id ?? params.id,
       state: await job.getState(),
       result: (job.returnvalue as RenderResult | null) ?? null,
       failedReason: job.failedReason ?? null,

--- a/examples/full/src/notes/notes.controller.ts
+++ b/examples/full/src/notes/notes.controller.ts
@@ -46,7 +46,10 @@ export class NotesController {
     return this.notes.rows();
   }
 
-  // No schemas declared, so the request is all `input` carries.
+  // Destructuring at the parameter is the usual shape, and it is what every other
+  // handler here does. The whole object has a name when a handler wants to pass it
+  // on: `whoami(input: Input<RouteSchemas>)` types the same. No schemas are
+  // declared on this route, so `req` is all it carries.
   @ApiDoc({
     summary: 'Echo the caller’s address',
     description:
@@ -54,12 +57,12 @@ export class NotesController {
     deprecated: true,
   })
   @Get('/whoami')
-  whoami(input: Input<RouteSchemas>): { ip: string | undefined } {
-    return { ip: this.address.of(input.req) };
+  whoami({ req }: Input<RouteSchemas>): { ip: string | undefined } {
+    return { ip: this.address.of(req) };
   }
 
   @Post('/', createNote)
-  create(input: Input<typeof createNote>): readonly string[] {
-    return this.notes.add(input.body.text);
+  create({ body }: Input<typeof createNote>): readonly string[] {
+    return this.notes.add(body.text);
   }
 }

--- a/examples/full/src/pictures/images.controller.ts
+++ b/examples/full/src/pictures/images.controller.ts
@@ -33,8 +33,8 @@ export class ImagesController {
 
   /** Returns the encoded image itself, so a browser renders it inline. */
   @Get('/render', render)
-  async render(input: Input<typeof render>): Promise<Response> {
-    const encoded = await this.thumbnails.render(input.query);
+  async render({ query }: Input<typeof render>): Promise<Response> {
+    const encoded = await this.thumbnails.render(query);
     return new Response(encoded.bytes, {
       headers: {
         'content-type': encoded.mimeType,
@@ -45,14 +45,14 @@ export class ImagesController {
 
   /** The same render, described rather than returned - easier to read in swagger. */
   @Get('/metadata', render)
-  async metadata(input: Input<typeof render>): Promise<{
+  async metadata({ query }: Input<typeof render>): Promise<{
     width: number;
     height: number;
     format: string;
     mimeType: string;
     bytes: number;
   }> {
-    const encoded = await this.thumbnails.render(input.query);
+    const encoded = await this.thumbnails.render(query);
     return {
       width: encoded.width,
       height: encoded.height,
@@ -67,11 +67,11 @@ export class ImagesController {
    * is a header read rather than a decode, so a truncated file still answers.
    */
   @Post('/describe', describe)
-  describe(input: Input<typeof describe>): Promise<{
+  describe({ body }: Input<typeof describe>): Promise<{
     width: number;
     height: number;
     format: string;
   }> {
-    return this.thumbnails.describe(input.body.base64);
+    return this.thumbnails.describe(body.base64);
   }
 }

--- a/examples/full/src/storage/files.controller.ts
+++ b/examples/full/src/storage/files.controller.ts
@@ -40,13 +40,14 @@ export class FilesController {
   constructor(private readonly storage: Storage) {}
 
   @Get('/', listFiles)
-  async list(
-    input: Input<typeof listFiles>,
-  ): Promise<{ root: string; keys: readonly string[] }> {
+  async list({ query }: Input<typeof listFiles>): Promise<{
+    root: string;
+    keys: readonly string[];
+  }> {
     const keys: string[] = [];
     for await (const entry of this.storage.list({
-      prefix: input.query.prefix,
-      glob: input.query.glob,
+      prefix: query.prefix,
+      glob: query.glob,
     })) {
       keys.push(entry.key);
     }
@@ -57,10 +58,13 @@ export class FilesController {
   }
 
   @Get('/object', objectKey)
-  async read(
-    input: Input<typeof objectKey>,
-  ): Promise<{ key: string; size: number; type: string; content: string }> {
-    const { key } = input.query;
+  async read({ query }: Input<typeof objectKey>): Promise<{
+    key: string;
+    size: number;
+    type: string;
+    content: string;
+  }> {
+    const { key } = query;
     await this.present(key);
     const stat = await this.storage.stat(key);
     return {
@@ -72,12 +76,13 @@ export class FilesController {
   }
 
   @Put('/object', writeFile)
-  async write(
-    input: Input<typeof writeFile>,
-  ): Promise<{ key: string; bytes: number }> {
-    const { key } = input.query;
+  async write({
+    body,
+    query,
+  }: Input<typeof writeFile>): Promise<{ key: string; bytes: number }> {
+    const { key } = query;
     try {
-      return { key, bytes: await this.storage.write(key, input.body.content) };
+      return { key, bytes: await this.storage.write(key, body.content) };
     } catch (error) {
       if (!(error instanceof PathTraversalError)) throw error;
       throw new HttpError(HttpStatusCode.BAD_REQUEST, error.message);
@@ -85,8 +90,10 @@ export class FilesController {
   }
 
   @Delete('/object', objectKey)
-  async remove(input: Input<typeof objectKey>): Promise<{ deleted: boolean }> {
-    const { key } = input.query;
+  async remove({
+    query,
+  }: Input<typeof objectKey>): Promise<{ deleted: boolean }> {
+    const { key } = query;
     await this.present(key);
     await this.storage.delete(key);
     return { deleted: true };
@@ -95,8 +102,8 @@ export class FilesController {
   /** Nothing signs bytes on a local disk, so this refuses rather than hand back
    * a URL that cannot work. */
   @Get('/presign', objectKey)
-  async presign(input: Input<typeof objectKey>): Promise<{ url: string }> {
-    const { key } = input.query;
+  async presign({ query }: Input<typeof objectKey>): Promise<{ url: string }> {
+    const { key } = query;
     await this.present(key);
     try {
       return { url: this.storage.presign(key) };

--- a/examples/full/src/users/users.controller.ts
+++ b/examples/full/src/users/users.controller.ts
@@ -24,21 +24,18 @@ export class UsersController {
   // accepted against a schema inferring `User[]` - mutability does not survive
   // serialisation.
   @Get('/', listUsers)
-  list(input: Input<typeof listUsers>): Promise<readonly User[]> {
-    return this.users.findAll(input.query.limit, input.query.q);
+  list({ query }: Input<typeof listUsers>): Promise<readonly User[]> {
+    return this.users.findAll(query.limit, query.q);
   }
 
   // Only the success status is checked - the 404 in `oneUser.response` leaves via
   // a thrown HttpError, which no return type can describe.
   @Get('/:id', oneUser)
-  async one(input: Input<typeof oneUser>): Promise<User> {
+  async one({ params }: Input<typeof oneUser>): Promise<User> {
     // Already a number: the params schema coerced it before this ran.
-    const user = await this.users.find(input.params.id);
+    const user = await this.users.find(params.id);
     if (user === null) {
-      throw new HttpError(
-        HttpStatusCode.NOT_FOUND,
-        `No user ${input.params.id}`,
-      );
+      throw new HttpError(HttpStatusCode.NOT_FOUND, `No user ${params.id}`);
     }
     return user;
   }
@@ -46,10 +43,10 @@ export class UsersController {
   // No req.json(), no Response.json(), no status - the body arrives validated and
   // typed, and 201 is the POST default.
   @Post('/', createUser)
-  create(input: Input<typeof createUser>): Promise<User> {
+  create({ body }: Input<typeof createUser>): Promise<User> {
     return this.users.create(
-      input.body.name,
-      input.body.tags.map((tag) => tag.label),
+      body.name,
+      body.tags.map((tag) => tag.label),
     );
   }
 }

--- a/tools/create-app/templates/features/cache/cache.controller.ts
+++ b/tools/create-app/templates/features/cache/cache.controller.ts
@@ -42,33 +42,35 @@ export class CacheController {
   }
 
   @Get('/:id', oneSession)
-  async read(
-    input: Input<typeof oneSession>,
-  ): Promise<{ id: string; data: unknown; ttl: number }> {
-    const found = await this.degrades(() =>
-      this.sessions.read(input.params.id),
-    );
+  async read({ params }: Input<typeof oneSession>): Promise<{
+    id: string;
+    data: unknown;
+    ttl: number;
+  }> {
+    const found = await this.degrades(() => this.sessions.read(params.id));
     if (found === null) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No session "${input.params.id}"`,
+        `No session "${params.id}"`,
       );
     }
     return found;
   }
 
   @Put('/:id', putSession)
-  store(
-    input: Input<typeof putSession>,
-  ): Promise<{ id: string; ttl: number; visits: number }> {
+  store({ body, params }: Input<typeof putSession>): Promise<{
+    id: string;
+    ttl: number;
+    visits: number;
+  }> {
     return this.degrades(() =>
-      this.sessions.store(input.params.id, input.body.data, input.body.ttl),
+      this.sessions.store(params.id, body.data, body.ttl),
     );
   }
 
   @Delete('/:id', oneSession)
-  remove(input: Input<typeof oneSession>): Promise<{ removed: number }> {
-    return this.degrades(() => this.sessions.remove(input.params.id));
+  remove({ params }: Input<typeof oneSession>): Promise<{ removed: number }> {
+    return this.degrades(() => this.sessions.remove(params.id));
   }
 
   private async degrades<T>(run: () => Promise<T>): Promise<T> {

--- a/tools/create-app/templates/features/database/ledger.controller.ts
+++ b/tools/create-app/templates/features/database/ledger.controller.ts
@@ -78,12 +78,12 @@ export class LedgerController {
   constructor(private readonly ledger: Ledger) {}
 
   @Get('/', listEntries)
-  list(input: Input<typeof listEntries>): {
+  list({ query }: Input<typeof listEntries>): {
     entries: readonly Entry[];
     balance: number;
   } {
     return {
-      entries: this.ledger.list(input.query.limit),
+      entries: this.ledger.list(query.limit),
       balance: this.ledger.balance(),
     };
   }
@@ -91,34 +91,34 @@ export class LedgerController {
   /** Walked by cursor. Declared before `/:id` for readability only: `Bun.serve`
    * matches a static segment ahead of a parameter. */
   @Get('/page', pagedEntries)
-  page(input: Input<typeof pagedEntries>): Page<Entry> {
-    return this.ledger.page(input.query);
+  page({ query }: Input<typeof pagedEntries>): Page<Entry> {
+    return this.ledger.page(query);
   }
 
   @Get('/:id', oneEntry)
-  one(input: Input<typeof oneEntry>): Entry {
-    const entry = this.ledger.find(input.params.id);
+  one({ params }: Input<typeof oneEntry>): Entry {
+    const entry = this.ledger.find(params.id);
     if (entry === undefined) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No ledger entry ${input.params.id}`,
+        `No ledger entry ${params.id}`,
       );
     }
     return entry;
   }
 
   @Post('/', createEntry)
-  create(input: Input<typeof createEntry>): Entry {
-    return this.ledger.add(input.body.memo, input.body.amount);
+  create({ body }: Input<typeof createEntry>): Entry {
+    return this.ledger.add(body.memo, body.amount);
   }
 
   /** `"fail": true` throws between the two inserts; the 409's unchanged `rows`
    * is proof the first leg rolled back. */
   @Post('/transfer', transfer)
-  async transfer(
-    input: Input<typeof transfer>,
-  ): Promise<{ balance: number; rows: number }> {
-    const { from, to, amount, fail } = input.body;
+  async transfer({
+    body,
+  }: Input<typeof transfer>): Promise<{ balance: number; rows: number }> {
+    const { from, to, amount, fail } = body;
     try {
       const balance = await this.ledger.transfer(from, to, amount, fail);
       return { balance, rows: this.ledger.rows() };
@@ -136,11 +136,11 @@ export class LedgerController {
    * what allows it - `transactionSync` will not compile against the async handle.
    */
   @Post('/transfer-sync', transfer)
-  transferSync(input: Input<typeof transfer>): {
+  transferSync({ body }: Input<typeof transfer>): {
     balance: number;
     rows: number;
   } {
-    const { from, to, amount, fail } = input.body;
+    const { from, to, amount, fail } = body;
     try {
       const balance = this.ledger.transferSync(from, to, amount, fail);
       return { balance, rows: this.ledger.rows() };
@@ -153,12 +153,12 @@ export class LedgerController {
   }
 
   @Delete('/:id', oneEntry)
-  remove(input: Input<typeof oneEntry>): { deleted: boolean } {
-    const deleted = this.ledger.remove(input.params.id);
+  remove({ params }: Input<typeof oneEntry>): { deleted: boolean } {
+    const deleted = this.ledger.remove(params.id);
     if (!deleted) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No ledger entry ${input.params.id}`,
+        `No ledger entry ${params.id}`,
       );
     }
     return { deleted };

--- a/tools/create-app/templates/features/guards/reports.controller.ts
+++ b/tools/create-app/templates/features/guards/reports.controller.ts
@@ -55,15 +55,15 @@ export class ReportsController {
   // Method-scoped guard, reading the class-level @Roles('admin').
   @UseGuards(RolesGuard)
   @Post('/', createReport)
-  create(input: Input<typeof createReport>): readonly string[] {
-    return this.reports.add(input.body.title);
+  create({ body }: Input<typeof createReport>): readonly string[] {
+    return this.reports.add(body.title);
   }
 
   // A method-level @Roles wins over the class-level one.
   @Roles('editor')
   @UseGuards(RolesGuard)
   @Patch('/:id', renameReport)
-  rename(input: Input<typeof renameReport>): readonly string[] {
-    return this.reports.rename(input.params.id, input.body.title);
+  rename({ body, params }: Input<typeof renameReport>): readonly string[] {
+    return this.reports.rename(params.id, body.title);
   }
 }

--- a/tools/create-app/templates/features/http/trace.controller.ts
+++ b/tools/create-app/templates/features/http/trace.controller.ts
@@ -14,7 +14,7 @@ export class TraceController {
   constructor(private readonly context: RequestContext) {}
 
   @Get('/')
-  current(input: Input<RouteSchemas>): {
+  current({ req }: Input<RouteSchemas>): {
     traceId: string | undefined;
     spanId: string | undefined;
     parentSpanId: string | undefined;
@@ -28,7 +28,7 @@ export class TraceController {
       spanId: spanId as string | undefined,
       parentSpanId: parentSpanId as string | undefined,
       traceFlags: traceFlags as string | undefined,
-      inbound: input.req.headers.get('traceparent'),
+      inbound: req.headers.get('traceparent'),
     };
   }
 }

--- a/tools/create-app/templates/features/jobs/jobs.controller.ts
+++ b/tools/create-app/templates/features/jobs/jobs.controller.ts
@@ -33,11 +33,13 @@ export class JobsController {
   constructor(private readonly publisher: JobPublisher) {}
 
   @Post('/thumbnails', enqueue)
-  async enqueue(
-    input: Input<typeof enqueue>,
-  ): Promise<{ id: string; queue: string; state: string }> {
+  async enqueue({ body }: Input<typeof enqueue>): Promise<{
+    id: string;
+    queue: string;
+    state: string;
+  }> {
     const job = await this.degrades(() =>
-      this.publisher.publish(THUMBNAIL_QUEUE, 'render', input.body),
+      this.publisher.publish(THUMBNAIL_QUEUE, 'render', body),
     );
 
     return {
@@ -50,24 +52,24 @@ export class JobsController {
   /** `returnvalue` is whatever the handler returned, so this is how the web
    * process reads a result computed elsewhere. */
   @Get('/thumbnails/:id', oneJob)
-  async status(input: Input<typeof oneJob>): Promise<{
+  async status({ params }: Input<typeof oneJob>): Promise<{
     id: string;
     state: string;
     result: RenderResult | null;
     failedReason: string | null;
   }> {
     const job = await this.degrades(() =>
-      this.publisher.queue(THUMBNAIL_QUEUE).getJob(input.params.id),
+      this.publisher.queue(THUMBNAIL_QUEUE).getJob(params.id),
     );
     if (job === undefined) {
       throw new HttpError(
         HttpStatusCode.NOT_FOUND,
-        `No job ${input.params.id} on "${THUMBNAIL_QUEUE}"`,
+        `No job ${params.id} on "${THUMBNAIL_QUEUE}"`,
       );
     }
 
     return {
-      id: job.id ?? input.params.id,
+      id: job.id ?? params.id,
       state: await job.getState(),
       result: (job.returnvalue as RenderResult | null) ?? null,
       failedReason: job.failedReason ?? null,

--- a/tools/create-app/templates/features/notes/notes.controller.ts
+++ b/tools/create-app/templates/features/notes/notes.controller.ts
@@ -46,7 +46,10 @@ export class NotesController {
     return this.notes.rows();
   }
 
-  // No schemas declared, so the request is all `input` carries.
+  // Destructuring at the parameter is the usual shape, and it is what every other
+  // handler here does. The whole object has a name when a handler wants to pass it
+  // on: `whoami(input: Input<RouteSchemas>)` types the same. No schemas are
+  // declared on this route, so `req` is all it carries.
   @ApiDoc({
     summary: 'Echo the caller’s address',
     description:
@@ -54,12 +57,12 @@ export class NotesController {
     deprecated: true,
   })
   @Get('/whoami')
-  whoami(input: Input<RouteSchemas>): { ip: string | undefined } {
-    return { ip: this.address.of(input.req) };
+  whoami({ req }: Input<RouteSchemas>): { ip: string | undefined } {
+    return { ip: this.address.of(req) };
   }
 
   @Post('/', createNote)
-  create(input: Input<typeof createNote>): readonly string[] {
-    return this.notes.add(input.body.text);
+  create({ body }: Input<typeof createNote>): readonly string[] {
+    return this.notes.add(body.text);
   }
 }

--- a/tools/create-app/templates/features/pictures/images.controller.ts
+++ b/tools/create-app/templates/features/pictures/images.controller.ts
@@ -33,8 +33,8 @@ export class ImagesController {
 
   /** Returns the encoded image itself, so a browser renders it inline. */
   @Get('/render', render)
-  async render(input: Input<typeof render>): Promise<Response> {
-    const encoded = await this.thumbnails.render(input.query);
+  async render({ query }: Input<typeof render>): Promise<Response> {
+    const encoded = await this.thumbnails.render(query);
     return new Response(encoded.bytes, {
       headers: {
         'content-type': encoded.mimeType,
@@ -45,14 +45,14 @@ export class ImagesController {
 
   /** The same render, described rather than returned - easier to read in swagger. */
   @Get('/metadata', render)
-  async metadata(input: Input<typeof render>): Promise<{
+  async metadata({ query }: Input<typeof render>): Promise<{
     width: number;
     height: number;
     format: string;
     mimeType: string;
     bytes: number;
   }> {
-    const encoded = await this.thumbnails.render(input.query);
+    const encoded = await this.thumbnails.render(query);
     return {
       width: encoded.width,
       height: encoded.height,
@@ -67,11 +67,11 @@ export class ImagesController {
    * is a header read rather than a decode, so a truncated file still answers.
    */
   @Post('/describe', describe)
-  describe(input: Input<typeof describe>): Promise<{
+  describe({ body }: Input<typeof describe>): Promise<{
     width: number;
     height: number;
     format: string;
   }> {
-    return this.thumbnails.describe(input.body.base64);
+    return this.thumbnails.describe(body.base64);
   }
 }

--- a/tools/create-app/templates/features/storage/files.controller.ts
+++ b/tools/create-app/templates/features/storage/files.controller.ts
@@ -40,13 +40,14 @@ export class FilesController {
   constructor(private readonly storage: Storage) {}
 
   @Get('/', listFiles)
-  async list(
-    input: Input<typeof listFiles>,
-  ): Promise<{ root: string; keys: readonly string[] }> {
+  async list({ query }: Input<typeof listFiles>): Promise<{
+    root: string;
+    keys: readonly string[];
+  }> {
     const keys: string[] = [];
     for await (const entry of this.storage.list({
-      prefix: input.query.prefix,
-      glob: input.query.glob,
+      prefix: query.prefix,
+      glob: query.glob,
     })) {
       keys.push(entry.key);
     }
@@ -57,10 +58,13 @@ export class FilesController {
   }
 
   @Get('/object', objectKey)
-  async read(
-    input: Input<typeof objectKey>,
-  ): Promise<{ key: string; size: number; type: string; content: string }> {
-    const { key } = input.query;
+  async read({ query }: Input<typeof objectKey>): Promise<{
+    key: string;
+    size: number;
+    type: string;
+    content: string;
+  }> {
+    const { key } = query;
     await this.present(key);
     const stat = await this.storage.stat(key);
     return {
@@ -72,12 +76,13 @@ export class FilesController {
   }
 
   @Put('/object', writeFile)
-  async write(
-    input: Input<typeof writeFile>,
-  ): Promise<{ key: string; bytes: number }> {
-    const { key } = input.query;
+  async write({
+    body,
+    query,
+  }: Input<typeof writeFile>): Promise<{ key: string; bytes: number }> {
+    const { key } = query;
     try {
-      return { key, bytes: await this.storage.write(key, input.body.content) };
+      return { key, bytes: await this.storage.write(key, body.content) };
     } catch (error) {
       if (!(error instanceof PathTraversalError)) throw error;
       throw new HttpError(HttpStatusCode.BAD_REQUEST, error.message);
@@ -85,8 +90,10 @@ export class FilesController {
   }
 
   @Delete('/object', objectKey)
-  async remove(input: Input<typeof objectKey>): Promise<{ deleted: boolean }> {
-    const { key } = input.query;
+  async remove({
+    query,
+  }: Input<typeof objectKey>): Promise<{ deleted: boolean }> {
+    const { key } = query;
     await this.present(key);
     await this.storage.delete(key);
     return { deleted: true };
@@ -95,8 +102,8 @@ export class FilesController {
   /** Nothing signs bytes on a local disk, so this refuses rather than hand back
    * a URL that cannot work. */
   @Get('/presign', objectKey)
-  async presign(input: Input<typeof objectKey>): Promise<{ url: string }> {
-    const { key } = input.query;
+  async presign({ query }: Input<typeof objectKey>): Promise<{ url: string }> {
+    const { key } = query;
     await this.present(key);
     try {
       return { url: this.storage.presign(key) };

--- a/tools/create-app/templates/features/users/users.controller.ts
+++ b/tools/create-app/templates/features/users/users.controller.ts
@@ -24,21 +24,18 @@ export class UsersController {
   // accepted against a schema inferring `User[]` - mutability does not survive
   // serialisation.
   @Get('/', listUsers)
-  list(input: Input<typeof listUsers>): Promise<readonly User[]> {
-    return this.users.findAll(input.query.limit, input.query.q);
+  list({ query }: Input<typeof listUsers>): Promise<readonly User[]> {
+    return this.users.findAll(query.limit, query.q);
   }
 
   // Only the success status is checked - the 404 in `oneUser.response` leaves via
   // a thrown HttpError, which no return type can describe.
   @Get('/:id', oneUser)
-  async one(input: Input<typeof oneUser>): Promise<User> {
+  async one({ params }: Input<typeof oneUser>): Promise<User> {
     // Already a number: the params schema coerced it before this ran.
-    const user = await this.users.find(input.params.id);
+    const user = await this.users.find(params.id);
     if (user === null) {
-      throw new HttpError(
-        HttpStatusCode.NOT_FOUND,
-        `No user ${input.params.id}`,
-      );
+      throw new HttpError(HttpStatusCode.NOT_FOUND, `No user ${params.id}`);
     }
     return user;
   }
@@ -46,10 +43,10 @@ export class UsersController {
   // No req.json(), no Response.json(), no status - the body arrives validated and
   // typed, and 201 is the POST default.
   @Post('/', createUser)
-  create(input: Input<typeof createUser>): Promise<User> {
+  create({ body }: Input<typeof createUser>): Promise<User> {
     return this.users.create(
-      input.body.name,
-      input.body.tags.map((tag) => tag.label),
+      body.name,
+      body.tags.map((tag) => tag.label),
     );
   }
 }


### PR DESCRIPTION
No framework change. Handlers already accept a destructured parameter; nothing in the examples or guides showed it, so the docs presented more distance from Nest than exists.

- 28 handlers in `examples/full` destructure at the parameter, carried into the nine vendored create-app features by `sync:templates`. Rewritten with oxc, not a regex.
- `MIGRATION-FROM-NEST.md` gains a `Handler parameters` section with the Nest snippet above the dunx one and a table for `@Body`/`@Query`/`@Param`/`@Req`/`@Res`/`@Headers`/`@Ip`. Two HTTP-table rows were wrong: `@Body` pointed at the validation guide rather than the handler shape, and `createParamDecorator` said `undesigned` although the doc designs it two sections later.
- `05-controllers.md` names both parameter shapes and gains a measured row: an unannotated destructured parameter is `TS7031`, not the `TS7006` the named form gives.

`bun run ci` green, 12/12, with valkey, postgres and MinIO up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated migration guidance to explain typed handler parameters, request data mappings, response handling, and decorator alternatives.
  - Refreshed guides with clearer examples for accessing validated request data, including body, query, route parameters, and request metadata.

- **Examples**
  - Updated sample applications and generated project templates to demonstrate direct access to validated handler inputs.
  - Existing validation, responses, error handling, and runtime behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->