### PR TITLE
Soak the full example, and fix the four defects it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,40 @@ jobs:
   examples:
     name: Examples, tour and scaffolds
     runs-on: ubuntu-latest
+    # This job had no services, so every part of `examples/full` that needs one
+    # printed that it was skipping and CI went green on the rest: the websocket
+    # relay's cross-node fan-out, the queue workers, the Redis cache and the
+    # rate limiter's shared store. The end-to-end job was exercising the paths
+    # that need nothing, which is the opposite of what it is for.
+    #
+    # The coverage job still owns the *gate*'s services and its denominator;
+    # nothing here is measured for coverage, so the two do not interact.
+    env:
+      REDIS_URL: redis://localhost:6379
+      DUNX_DB_TEST_URL: postgres://dunx:dunx@localhost:5432/dunx
+    services:
+      valkey:
+        image: valkey/valkey:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: dunx
+          POSTGRES_PASSWORD: dunx
+          POSTGRES_DB: dunx
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dunx"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,32 +65,16 @@ jobs:
     env:
       REDIS_URL: redis://localhost:6379
       DUNX_DB_TEST_URL: postgres://dunx:dunx@localhost:5432/dunx
-    services:
-      valkey:
-        image: valkey/valkey:8-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "valkey-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-      postgres:
-        image: postgres:17-alpine
-        env:
-          POSTGRES_USER: dunx
-          POSTGRES_PASSWORD: dunx
-          POSTGRES_DB: dunx
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U dunx"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+
+      # `examples/full/compose.yml` rather than a `services:` block, so what the
+      # example needs is described once and the same command brings it up on a
+      # laptop. It also gets the images from public.ecr.aws, which a `services:`
+      # block would too but nobody would notice was load bearing.
+      - name: Start the services the example needs
+        run: bun run --filter '@dunx/example-full' services:up
 
       - name: Build
         run: bun run ci build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,8 +607,16 @@ then not cover it.
   `docker run` step, since a `services:` block cannot pass the command MinIO needs.
   `@dunx/infra`'s suites skip when their service does not answer, so without them
   the gate measures a different denominator than the machine that set it. **A new
-  live-service suite adds its service there, and nowhere else** - declaring them on
-  two jobs is what once left the release job running the gate with none.
+  live-service suite adds its service to the `coverage` job** - the release job
+  taking the model as an artifact, rather than re-declaring the services and
+  running the gate again, is what fixed it once running with none.
+- **`examples` declares valkey and postgres too, and that is not a second copy of
+  the gate.** It measures no coverage, so it cannot move the denominator. It had no
+  services at all, which meant the end-to-end job silently skipped the websocket
+  relay's cross-node fan-out, the queue workers, the Redis cache and the shared
+  throttle store on every run: the job that exists to exercise the whole framework
+  was exercising only the parts that need nothing. MinIO is still coverage-only,
+  since no example asserts against a bucket.
 - `unit` deliberately has **no** services: those suites skip without one, `coverage`
   runs the same files with all of them, and `unit` is the fast signal.
 - `S3_ENDPOINT` is **not** exported, even though `Bun.S3Client` reads it for every

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -77,9 +77,15 @@ against 1.4.1 rev `4661e494f` on the same machine.
 | `Bun.file(path).writer()` does not truncate or create parents                 | reproduces                                                             |
 | `fetch` with `protocol: 'http2'` throws against a cleartext peer              | reproduces                                                             |
 | `internal/docs` under `bun test --parallel`                                   | reproduces - 38 of 92 fail, so the `docs` phase keeps its exclusion    |
+| A compound assignment to a private field beside a decorated member            | reproduces - `SyntaxError: Left side of assignment is not a reference` |
 
 `engines.bun` stays `>=1.4.1`. Nothing dunx ships depends on 1.4.2 behaviour; CI
 pins it and the deployment guide's image names it.
+
+The last row was not on the release notes' list; it turned up by writing
+`this.#inFlight += 1` in a class that already had a decorated method, in the one
+example file whose header warns about exactly that. `Gauge` from `@dunx/core` is
+the way around it and is what `ChatGateway` already uses.
 
 ### A nested `AsyncLocalStorage.run()` held the enclosing store
 

--- a/examples/full/compose.yml
+++ b/examples/full/compose.yml
@@ -1,0 +1,48 @@
+# The services `examples/full` degrades without: a broker for the cache, the queue,
+# the rate limiter's shared store and the websocket relay, and Postgres for the
+# relay's LISTEN/NOTIFY backend.
+#
+# Images come from **public.ecr.aws** rather than Docker Hub, which rate limits
+# anonymous pulls by IP. A CI runner shares its IP with every other runner on the
+# host, so a Hub pull is a coin toss that fails as a red build with nothing wrong
+# in the change. ECR throttles anonymous pulls too and it is not a free pass -
+# three rapid pulls while writing this hit `toomanyrequests` - but its budget is
+# far larger and it is not shared with every anonymous puller on the internet.
+#
+# MinIO publishes to neither ECR nor a mirror, which is why S3 is absent here: the
+# example's storage is `LocalStorageOptions` on a temp dir, and the one suite that
+# needs a bucket runs in the coverage job against MinIO from Hub.
+#
+#   bun run services:up      start and wait for both to answer
+#   bun run services:down    stop and remove them, volumes included
+#
+# The same file is what CI's examples job brings up, so there is one description
+# of what this example needs rather than one here and one in `ci.yml`.
+name: dunx-example-full
+
+services:
+  valkey:
+    image: public.ecr.aws/valkey/valkey:8-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'valkey-cli', 'ping']
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 2s
+
+  postgres:
+    image: public.ecr.aws/docker/library/postgres:17-alpine
+    environment:
+      POSTGRES_USER: dunx
+      POSTGRES_PASSWORD: dunx
+      POSTGRES_DB: dunx
+    ports:
+      - '5432:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U dunx']
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 2s

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -6,11 +6,13 @@
   "type": "module",
   "scripts": {
     "dev": "bun --watch src/main.ts",
+    "services:down": "docker compose down -v",
+    "services:up": "docker compose up -d --wait",
+    "soak": "bun src/soak/soak.ts",
     "start": "bun src/main.ts",
     "test": "bun test",
     "tour": "bun src/tour.ts",
-    "typecheck": "tsc --noEmit",
-    "soak": "bun src/soak/soak.ts"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bull-board/api": "8.6.0",

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -9,7 +9,8 @@
     "start": "bun src/main.ts",
     "test": "bun test",
     "tour": "bun src/tour.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "soak": "bun src/soak/soak.ts"
   },
   "dependencies": {
     "@bull-board/api": "8.6.0",

--- a/examples/full/src/chat/chat.demo.ts
+++ b/examples/full/src/chat/chat.demo.ts
@@ -2,60 +2,9 @@ import { Logger, Module } from '@dunx/core';
 import { HttpFactory, PubSub, type HttpApp } from '@dunx/http';
 import { isConnectionError, RedisConnection } from '@dunx/infra/redis';
 import { RELAY_CHANNEL } from '../config.js';
+import { connect, type Client } from './ws-client.js';
 import { ChatGateway } from './chat.gateway.js';
 import { Lobby } from './lobby.service.js';
-
-interface Client {
-  next(): Promise<string>;
-  send(event: string, data: unknown): void;
-  close(): void;
-  /** Every frame this socket ever received, so a *second* delivery is visible. */
-  readonly received: readonly string[];
-}
-
-/** A real `new WebSocket()`, with a deadline so a stall fails instead of hanging. */
-const connect = async (base: string): Promise<Client> => {
-  const socket = new WebSocket(
-    new URL('chat', base).href.replace('http', 'ws'),
-  );
-  const frames: string[] = [];
-  const received: string[] = [];
-  const waiting: ((frame: string) => void)[] = [];
-
-  socket.addEventListener('message', (event: MessageEvent) => {
-    const frame = String(event.data);
-    received.push(frame);
-    const waiter = waiting.shift();
-    if (waiter) waiter(frame);
-    else frames.push(frame);
-  });
-  await new Promise<void>((resolve, reject) => {
-    socket.addEventListener('open', () => resolve(), { once: true });
-    setTimeout(() => reject(new Error('the socket never opened')), 2000);
-  });
-
-  return {
-    next: () =>
-      new Promise<string>((resolve, reject) => {
-        const queued = frames.shift();
-        if (queued !== undefined) {
-          resolve(queued);
-          return;
-        }
-        const timer = setTimeout(
-          () => reject(new Error('no frame arrived')),
-          2000,
-        );
-        waiting.push((frame) => {
-          clearTimeout(timer);
-          resolve(frame);
-        });
-      }),
-    send: (event, data) => socket.send(JSON.stringify({ event, data })),
-    close: () => socket.close(),
-    received,
-  };
-};
 
 /**
  * A second node in-process: two `Bun.serve` instances, two containers, two

--- a/examples/full/src/chat/chat.module.ts
+++ b/examples/full/src/chat/chat.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@dunx/core';
 import { CacheModule } from '../cache/cache.module.js';
 import { ChatDemo } from './chat.demo.js';
+import { PostgresRelayDemo } from './postgres-relay.demo.js';
 import { ChatGateway } from './chat.gateway.js';
 import { Lobby } from './lobby.service.js';
 
@@ -9,7 +10,7 @@ import { Lobby } from './lobby.service.js';
 @Module({
   // `RedisConnection`, for cross-process fan-out.
   imports: [CacheModule],
-  providers: [ChatGateway, Lobby, ChatDemo],
-  exports: [Lobby, ChatDemo],
+  providers: [ChatGateway, Lobby, ChatDemo, PostgresRelayDemo],
+  exports: [Lobby, ChatDemo, PostgresRelayDemo],
 })
 export class ChatModule {}

--- a/examples/full/src/chat/postgres-relay.demo.ts
+++ b/examples/full/src/chat/postgres-relay.demo.ts
@@ -1,0 +1,148 @@
+import { Logger, Module, provide } from '@dunx/core';
+import {
+  HttpFactory,
+  HttpOptionsProvider,
+  PubSub,
+  WsRelay,
+  WsRelayModule,
+  type PubSubRelay,
+} from '@dunx/http';
+import { RELAY_CHANNEL } from '../config.js';
+import { ChatGateway } from './chat.gateway.js';
+import { Lobby } from './lobby.service.js';
+import { connect } from './ws-client.js';
+
+/**
+ * Read here rather than injected: the module is declared at file scope, so it
+ * cannot reach `ConfigService`. The default matches `compose.yml` and the schema's.
+ */
+const POSTGRES_URL =
+  Bun.env['POSTGRES_URL'] ?? 'postgres://dunx:dunx@localhost:5432/dunx';
+
+/**
+ * The same fan-out as the Redis relay, over `Bun.SQL`'s `LISTEN`/`NOTIFY`, for an
+ * app that already has Postgres and would rather not run a broker.
+ *
+ * Two nodes, each with its own `WsRelayModule.forPostgres` and its own `PubSub`
+ * origin. Neither shares a container with the other, which is what makes the
+ * delivery real rather than a same-process shortcut.
+ */
+/**
+ * Binding the relay is not the same as using it. `WsRelayModule` puts a `WsRelay`
+ * in the container; what attaches it to `PubSub` is an `HttpOptionsProvider`
+ * answering `relay`, exactly as `AppHttpOptions` does for the app itself. Without
+ * this the nodes come up, the sockets work, and every publish stays local.
+ */
+class NodeHttpOptions extends HttpOptionsProvider {
+  constructor(private readonly bus: WsRelay) {
+    super();
+  }
+
+  override get relay(): PubSubRelay {
+    return this.bus;
+  }
+
+  override readonly relayChannel = RELAY_CHANNEL;
+}
+
+@Module({
+  imports: [WsRelayModule.forPostgres({ url: POSTGRES_URL })],
+  providers: [
+    ChatGateway,
+    Lobby,
+    // Bound to the token `HttpFactory` asks for, not registered as itself:
+    // the factory looks up `HttpOptionsProvider` and promotes a default when
+    // nothing answers it, so a bare subclass in `providers` is never consulted.
+    provide(HttpOptionsProvider, { useClass: NodeHttpOptions }),
+  ],
+})
+class PostgresNode {}
+
+/** Postgres caps a `NOTIFY` payload at 7999 bytes, envelope included. */
+const OVER_THE_NOTIFY_CAP = 9000;
+
+export class PostgresRelayDemo {
+  constructor(private readonly logger: Logger) {}
+
+  async demonstrate(): Promise<void> {
+    const { logger } = this;
+    if (!(await this.#postgresUp())) {
+      logger.warn(
+        `skipping the Postgres relay demo: nothing answering at ${POSTGRES_URL}`,
+      );
+      logger.info('`bun run services:up` starts it, and CI runs the same file');
+      return;
+    }
+
+    const [a, b] = await Promise.all([this.#node(), this.#node()]);
+    try {
+      logger.info(
+        `two nodes on LISTEN/NOTIFY, origins …${a.pubsub.origin.slice(-6)} / …${b.pubsub.origin.slice(-6)}`,
+      );
+
+      const [onA, onB] = await Promise.all([connect(a.url), connect(b.url)]);
+      await Promise.all([onA.next(), onB.next()]);
+
+      const said = 'across nodes, over Postgres';
+      a.pubsub.publishEvent(Lobby.TOPIC, 'said', said);
+      logger.info(
+        `node B's client <- ${await onB.next()} (relayed via NOTIFY)`,
+      );
+
+      await Bun.sleep(250);
+      const seen = (frames: readonly string[]): number =>
+        frames.filter((frame) => frame.includes(said)).length;
+      logger.info(
+        `deliveries: A ${seen(onA.received)}, B ${seen(onB.received)} ` +
+          '(one each, so the publisher did not fan its own frame out twice)',
+      );
+
+      // Postgres refuses the NOTIFY rather than truncating it. The publish is
+      // reported and fan-out stays local, which is the documented degradation.
+      const huge = 'x'.repeat(OVER_THE_NOTIFY_CAP);
+      a.pubsub.publishEvent(Lobby.TOPIC, 'said', huge);
+      await Bun.sleep(400);
+      const huge_ = (frames: readonly string[]): number =>
+        frames.filter((frame) => frame.includes(huge)).length;
+      logger.info(
+        `a ${OVER_THE_NOTIFY_CAP}-byte frame: A ${huge_(onA.received)}, B ${huge_(onB.received)} ` +
+          '(over the 7999-byte NOTIFY cap, so the publishing node still delivers ' +
+          'it and the relay reports one warn)',
+      );
+
+      onA.close();
+      onB.close();
+      await Bun.sleep(20);
+    } finally {
+      await Promise.all([a.app.shutdown(), b.app.shutdown()]);
+    }
+  }
+
+  async #node(): Promise<{
+    app: Awaited<ReturnType<typeof HttpFactory.create>>;
+    url: string;
+    pubsub: PubSub;
+  }> {
+    const app = await HttpFactory.create(PostgresNode, {
+      requestLogging: false,
+    });
+    const url = await app.listen(0);
+    return { app, url, pubsub: app.get(PubSub) };
+  }
+
+  /** A relay demo needs its backend; an absent one is a skip, not a failure. */
+  async #postgresUp(): Promise<boolean> {
+    const sql = new Bun.SQL(POSTGRES_URL, {
+      max: 1,
+      connectionTimeout: 2,
+    });
+    try {
+      await sql`select 1`;
+      return true;
+    } catch {
+      return false;
+    } finally {
+      await sql.close().catch(() => undefined);
+    }
+  }
+}

--- a/examples/full/src/chat/postgres-relay.demo.ts
+++ b/examples/full/src/chat/postgres-relay.demo.ts
@@ -19,6 +19,16 @@ import { connect } from './ws-client.js';
 const POSTGRES_URL =
   Bun.env['POSTGRES_URL'] ?? 'postgres://dunx:dunx@localhost:5432/dunx';
 
+/** Host and database only. The url carries a password and a log outlives it. */
+const where = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return 'the configured Postgres';
+  }
+};
+
 /**
  * The same fan-out as the Redis relay, over `Bun.SQL`'s `LISTEN`/`NOTIFY`, for an
  * app that already has Postgres and would rather not run a broker.
@@ -58,6 +68,12 @@ class NodeHttpOptions extends HttpOptionsProvider {
 })
 class PostgresNode {}
 
+interface Node {
+  readonly app: Awaited<ReturnType<typeof HttpFactory.create>>;
+  readonly url: string;
+  readonly pubsub: PubSub;
+}
+
 /** Postgres caps a `NOTIFY` payload at 7999 bytes, envelope included. */
 const OVER_THE_NOTIFY_CAP = 9000;
 
@@ -68,14 +84,19 @@ export class PostgresRelayDemo {
     const { logger } = this;
     if (!(await this.#postgresUp())) {
       logger.warn(
-        `skipping the Postgres relay demo: nothing answering at ${POSTGRES_URL}`,
+        `skipping the Postgres relay demo: nothing answering at ${where(POSTGRES_URL)}`,
       );
       logger.info('`bun run services:up` starts it, and CI runs the same file');
       return;
     }
 
-    const [a, b] = await Promise.all([this.#node(), this.#node()]);
+    // Started one at a time and collected as they come up. `Promise.all` rejects
+    // on the first failure and abandons a peer that had already bound a port,
+    // which keeps the process alive after the demo has given up.
+    const nodes: Node[] = [];
     try {
+      nodes.push(await this.#node(), await this.#node());
+      const [a, b] = nodes as [Node, Node];
       logger.info(
         `two nodes on LISTEN/NOTIFY, origins …${a.pubsub.origin.slice(-6)} / …${b.pubsub.origin.slice(-6)}`,
       );
@@ -114,20 +135,22 @@ export class PostgresRelayDemo {
       onB.close();
       await Bun.sleep(20);
     } finally {
-      await Promise.all([a.app.shutdown(), b.app.shutdown()]);
+      await Promise.all(nodes.map((node) => node.app.shutdown()));
     }
   }
 
-  async #node(): Promise<{
-    app: Awaited<ReturnType<typeof HttpFactory.create>>;
-    url: string;
-    pubsub: PubSub;
-  }> {
+  async #node(): Promise<Node> {
     const app = await HttpFactory.create(PostgresNode, {
       requestLogging: false,
     });
-    const url = await app.listen(0);
-    return { app, url, pubsub: app.get(PubSub) };
+    try {
+      const url = await app.listen(0);
+      return { app, url, pubsub: app.get(PubSub) };
+    } catch (error) {
+      // The container is up even when the port is not, so it is ours to close.
+      await app.shutdown();
+      throw error;
+    }
   }
 
   /** A relay demo needs its backend; an absent one is a skip, not a failure. */

--- a/examples/full/src/chat/ws-client.ts
+++ b/examples/full/src/chat/ws-client.ts
@@ -1,0 +1,59 @@
+/**
+ * A real `new WebSocket()` against the chat gateway, with a deadline so a stall
+ * fails instead of hanging.
+ *
+ * Shared rather than copied: both relay demos and the soak workload open sockets
+ * the same way, and a second copy of the frame-queue handling is where the two
+ * would drift.
+ */
+export interface Client {
+  next(): Promise<string>;
+  send(event: string, data: unknown): void;
+  close(): void;
+  /** Every frame this socket ever received, so a *second* delivery is visible. */
+  readonly received: readonly string[];
+}
+
+/** A real `new WebSocket()`, with a deadline so a stall fails instead of hanging. */
+export const connect = async (base: string): Promise<Client> => {
+  const socket = new WebSocket(
+    new URL('chat', base).href.replace('http', 'ws'),
+  );
+  const frames: string[] = [];
+  const received: string[] = [];
+  const waiting: ((frame: string) => void)[] = [];
+
+  socket.addEventListener('message', (event: MessageEvent) => {
+    const frame = String(event.data);
+    received.push(frame);
+    const waiter = waiting.shift();
+    if (waiter) waiter(frame);
+    else frames.push(frame);
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener('open', () => resolve(), { once: true });
+    setTimeout(() => reject(new Error('the socket never opened')), 2000);
+  });
+
+  return {
+    next: () =>
+      new Promise<string>((resolve, reject) => {
+        const queued = frames.shift();
+        if (queued !== undefined) {
+          resolve(queued);
+          return;
+        }
+        const timer = setTimeout(
+          () => reject(new Error('no frame arrived')),
+          2000,
+        );
+        waiting.push((frame) => {
+          clearTimeout(timer);
+          resolve(frame);
+        });
+      }),
+    send: (event, data) => socket.send(JSON.stringify({ event, data })),
+    close: () => socket.close(),
+    received,
+  };
+};

--- a/examples/full/src/chat/ws-client.ts
+++ b/examples/full/src/chat/ws-client.ts
@@ -43,14 +43,20 @@ export const connect = async (base: string): Promise<Client> => {
           resolve(queued);
           return;
         }
-        const timer = setTimeout(
-          () => reject(new Error('no frame arrived')),
-          2000,
-        );
-        waiting.push((frame) => {
+        const waiter = (frame: string): void => {
           clearTimeout(timer);
           resolve(frame);
-        });
+        };
+        // Dropped from the queue before rejecting, or the next frame is handed to
+        // this dead promise and discarded, and every later `next()` waits one
+        // frame behind. Only shows up after a timeout, which is when the test is
+        // already trying to explain itself.
+        const timer = setTimeout(() => {
+          const at = waiting.indexOf(waiter);
+          if (at !== -1) waiting.splice(at, 1);
+          reject(new Error('no frame arrived'));
+        }, 2000);
+        waiting.push(waiter);
       }),
     send: (event, data) => socket.send(JSON.stringify({ event, data })),
     close: () => socket.close(),

--- a/examples/full/src/database/ledger.controller.ts
+++ b/examples/full/src/database/ledger.controller.ts
@@ -7,7 +7,14 @@ import {
   Post,
   type Input,
 } from '@dunx/http';
-import { PAGINATION, type Page } from '@dunx/infra/pagination';
+import {
+  decodeCursor,
+  encodeCursor,
+  PAGINATION,
+  pageOf,
+  parsePageOptions,
+  type Page,
+} from '@dunx/infra/pagination';
 import { z } from 'zod';
 import { Ledger } from './ledger.service.js';
 import type { Entry } from './schema.js';
@@ -69,6 +76,18 @@ const pageQuery = z
   });
 
 const pagedEntries = { query: pageQuery } as const;
+const keyset = {
+  query: z.object({
+    take: z.coerce
+      .number()
+      .int()
+      .min(PAGINATION.MIN_TAKE)
+      .max(PAGINATION.MAX_TAKE)
+      .optional(),
+    cursor: z.string().max(PAGINATION.MAX_CURSOR).optional(),
+  }),
+} as const;
+
 const oneEntry = { params: EntryIndex } as const;
 const createEntry = { body: CreateEntry } as const;
 const transfer = { body: Transfer } as const;
@@ -150,6 +169,62 @@ export class LedgerController {
         `${(error as Error).message} - rolled back, still ${this.ledger.rows()} rows`,
       );
     }
+  }
+
+  /**
+   * Keyset pagination without the service: `parsePageOptions` reads the query the
+   * way the module's own docs suggest a schema does, `pageOf` shapes the envelope
+   * from rows the caller already has, and a cursor round-trips through
+   * `encodeCursor`/`decodeCursor`.
+   *
+   * The cursor is opaque on purpose and every malformed one collapses to the same
+   * `CursorError`, so `?cursor=not-a-cursor` answers 400 rather than telling the
+   * caller which layer rejected it.
+   */
+  @Get('/keyset', keyset)
+  keyset({ query }: Input<typeof keyset>): {
+    options: { take: number; direction: string; order: string };
+    page: Page<Entry>;
+    roundTrip: { encoded: string; decoded: { s: string; i: string } } | null;
+  } {
+    // Throws PageOptionsError on a take outside the range, which the framework
+    // renders as a 400 because the class carries the status.
+    const options = parsePageOptions(query as Record<string, unknown>);
+    // A cursor handed back in is decoded first, which is where a hand-written one
+    // fails, and it is what the next page is keyed from.
+    const roundTrip =
+      query.cursor === undefined
+        ? null
+        : { encoded: query.cursor, decoded: decodeCursor(query.cursor) };
+
+    const cursorOf = (row: Entry): string =>
+      // No timestamp on this table, so the id is both sort value and tiebreak.
+      encodeCursor(row.id, String(row.id));
+
+    // Descending ids, so the page after a cursor is everything below it. One row
+    // more than asked for is what answers `hasNextPage` without a second count.
+    const after = roundTrip === null ? undefined : Number(roundTrip.decoded.i);
+    const scanned = this.ledger
+      .list(PAGINATION.MAX_TAKE)
+      .filter((row) => after === undefined || row.id < after);
+    const rows = scanned.slice(0, options.take);
+
+    const page = pageOf(rows, {
+      take: options.take,
+      hasNextPage: scanned.length > options.take,
+      hasPreviousPage: after !== undefined,
+      cursorOf,
+    });
+
+    return {
+      options: {
+        take: options.take,
+        direction: options.direction,
+        order: options.order,
+      },
+      page,
+      roundTrip,
+    };
   }
 
   @Delete('/:id', oneEntry)

--- a/examples/full/src/http/request-trail.ts
+++ b/examples/full/src/http/request-trail.ts
@@ -1,9 +1,26 @@
 import type { BunRequest } from 'bun';
 import type { Middleware, Next, RouteContext } from '@dunx/http';
 
-/** The observable side effect: whatever the middleware saw is readable after. */
+/**
+ * The observable side effect: whatever the middleware saw is readable after.
+ *
+ * Capped, because this grows by one entry on **every request** and this folder is
+ * vendored into `@dunx/create-app`'s `http` feature. Unbounded it put 46 MiB on
+ * the heap across 3.1 million requests in the soak run and read as a framework
+ * leak until a heap census named the strings. A demo that keeps the last few
+ * hundred shows the same thing and survives production traffic.
+ */
+const KEEP = 500;
+
 export class RequestTrail {
   readonly entries: string[] = [];
+
+  record(entry: string): void {
+    this.entries.push(entry);
+    if (this.entries.length > KEEP) {
+      this.entries.splice(0, this.entries.length - KEEP);
+    }
+  }
 }
 
 /**
@@ -23,7 +40,7 @@ export class RequestTrailMiddleware implements Middleware {
     next: Next,
   ): Promise<Response> {
     const response = await next();
-    this.trail.entries.push(
+    this.trail.record(
       `${req.method} ${new URL(req.url).pathname} -> ${response.status} ` +
         `(${ctx.controller}.${ctx.handler})`,
     );

--- a/examples/full/src/notes/notes.service.ts
+++ b/examples/full/src/notes/notes.service.ts
@@ -1,6 +1,17 @@
 import { Logger } from '@dunx/core';
 import type { OnInit } from '@dunx/core';
 
+/**
+ * The list is capped, and the cap is the point.
+ *
+ * An in-memory demo store that only ever grows is a leak the moment anyone runs
+ * real traffic through it, and this folder is vendored into `@dunx/create-app`'s
+ * `notes` feature, so an unbounded array would ship into every scaffold. The soak
+ * run found it: 42,000 posts a minute put 250,000 retained strings on the heap and
+ * read as a framework leak until the census named them.
+ */
+const KEEP = 200;
+
 export class NotesService implements OnInit {
   readonly #rows = ['read the architecture doc', 'measure before deciding'];
 
@@ -16,6 +27,9 @@ export class NotesService implements OnInit {
 
   add(text: string): readonly string[] {
     this.#rows.push(text);
+    if (this.#rows.length > KEEP) {
+      this.#rows.splice(0, this.#rows.length - KEEP);
+    }
     return this.#rows;
   }
 }

--- a/examples/full/src/schedule/maintenance.service.ts
+++ b/examples/full/src/schedule/maintenance.service.ts
@@ -1,5 +1,5 @@
-import { Counter, Logger } from '@dunx/core';
-import { Cron, Interval, OnceOnBoot } from '@dunx/infra/schedule';
+import { Counter, Gauge, Logger } from '@dunx/core';
+import { Cron, Interval, OnceOnBoot, Overlap } from '@dunx/infra/schedule';
 
 /**
  * The three schedule decorators on one class, discovered off the prototype chain
@@ -41,6 +41,44 @@ export class Maintenance {
     await Bun.sleep(1);
     this.#compactions.inc();
     return this.#compactions.value;
+  }
+
+  readonly #slow = new Counter();
+  /**
+   * A `Gauge`, not `#inFlight += 1`. A compound assignment to a private field in
+   * a class that also has a decorated member is a `SyntaxError` in Bun's parser,
+   * still on 1.4.2 - which is what the note at the top of this class is about,
+   * and which this method walked straight into before it was written this way.
+   */
+  readonly #inFlight = new Gauge();
+  readonly #peak = new Gauge();
+
+  /**
+   * `overlap: Overlap.CONCURRENT`, which is the half `skip` hides.
+   *
+   * The default refuses to start a run while the last one is still going, so a
+   * handler that outlives its own cadence quietly runs at the rate it can finish.
+   * `concurrent` starts anyway, and `maxInFlight` is how you can tell: triggered
+   * twice inside its own sleep it reaches 2, where the sweep above stays at 1.
+   */
+  @Interval(600_000, {
+    name: 'maintenance.overlapping',
+    overlap: Overlap.CONCURRENT,
+  })
+  async overlappingWork(): Promise<number> {
+    this.#inFlight.inc();
+    this.#peak.set(Math.max(this.#peak.value, this.#inFlight.value));
+    try {
+      await Bun.sleep(40);
+      this.#slow.inc();
+      return this.#slow.value;
+    } finally {
+      this.#inFlight.dec();
+    }
+  }
+
+  get overlapping(): { runs: number; maxInFlight: number } {
+    return { runs: this.#slow.value, maxInFlight: this.#peak.value };
   }
 
   get counts(): { sweeps: number; compactions: number; warmed: boolean } {

--- a/examples/full/src/schedule/schedule.demo.ts
+++ b/examples/full/src/schedule/schedule.demo.ts
@@ -41,6 +41,18 @@ export class ScheduleDemo {
         'neither waited for a clock',
     );
 
+    // Two triggers inside one run's own sleep. `concurrent` lets the second start,
+    // so both are in flight at once; the default would have skipped it.
+    await Promise.all([
+      this.registry.trigger('maintenance.overlapping'),
+      this.registry.trigger('maintenance.overlapping'),
+    ]);
+    const overlapping = this.maintenance.overlapping;
+    this.logger.info(
+      `overlap: concurrent -> ${overlapping.runs} runs, ` +
+        `${overlapping.maxInFlight} in flight at once (skip would hold it at 1)`,
+    );
+
     const entry = this.registry.get('maintenance.compact');
     this.logger.info(
       `runs recorded on the entry -> ${entry?.runs ?? 0}, lastError ` +

--- a/examples/full/src/service.test.ts
+++ b/examples/full/src/service.test.ts
@@ -149,6 +149,52 @@ it('walks the ledger by cursor', async () => {
   }
 });
 
+/**
+ * `/ledger/page` goes through the service; this goes through the primitives the
+ * module exports and nothing else used: `parsePageOptions`, `pageOf`, and a cursor
+ * round-tripped by `encodeCursor`/`decodeCursor`. Writing it found `take` reverting
+ * to the default whenever a validator had already turned it into a number.
+ */
+it('pages the ledger with the cursor primitives, and refuses a forged cursor', async () => {
+  interface Keyset {
+    options: { take: number };
+    page: { data: { id: number }[]; meta: { nextCursor: string | null } };
+    roundTrip: { decoded: { i: string } } | null;
+  }
+
+  // Seeds its own rows: this file shares one app, and the tests above it delete
+  // ledger entries, so paging cannot assume what the seeder left behind.
+  for (const memo of [
+    'keyset one',
+    'keyset two',
+    'keyset three',
+    'keyset four',
+  ]) {
+    expect((await json('ledger', post({ memo, amount: 1 }))).status).toBe(201);
+  }
+
+  const first = await json<Keyset>('ledger/keyset?take=2');
+  expect(first.status).toBe(200);
+  // The take asked for, not the default, which is the part that regressed.
+  expect(first.body.options.take).toBe(2);
+  expect(first.body.page.data).toHaveLength(2);
+
+  const cursor = first.body.page.meta.nextCursor;
+  expect(cursor).not.toBeNull();
+  const second = await json<Keyset>(
+    `ledger/keyset?take=2&cursor=${encodeURIComponent(cursor as string)}`,
+  );
+  expect(second.status).toBe(200);
+  // A real keyset step: every id on page two is below every id on page one.
+  const highest = Math.min(...first.body.page.data.map((row) => row.id));
+  expect(second.body.page.data.every((row) => row.id < highest)).toBe(true);
+  expect(second.body.roundTrip?.decoded.i).toBe(String(highest));
+
+  // Every malformed cursor collapses to one 400, naming no internal layer.
+  const forged = await json('ledger/keyset?cursor=not-a-cursor');
+  expect(forged.status).toBe(400);
+});
+
 it('rolls a transfer back as one unit, observably', async () => {
   const entries = async (): Promise<number> =>
     (await json<{ entries: unknown[] }>('ledger')).body.entries.length;

--- a/examples/full/src/soak/sampler.ts
+++ b/examples/full/src/soak/sampler.ts
@@ -1,0 +1,146 @@
+/**
+ * Samples the process while the workload runs, and decides afterwards whether
+ * anything grew that should not have.
+ *
+ * A leak does not show up as a big number, it shows up as a **slope**. RSS climbs
+ * during warmup on any runtime and settles; what matters is whether the settled
+ * window still trends upward once the allocator has stopped growing the heap. So
+ * the verdict comes from a least-squares fit over the post-warmup samples rather
+ * than from first-against-last, which any GC timing can flip either way.
+ */
+export interface Sample {
+  readonly at: number;
+  readonly rss: number;
+  readonly heapUsed: number;
+  readonly external: number;
+  readonly cpuMs: number;
+  readonly lagMs: number;
+}
+
+export interface Trend {
+  readonly name: string;
+  /** Bytes (or ms) per second over the measured window. */
+  readonly slope: number;
+  readonly first: number;
+  readonly last: number;
+  readonly peak: number;
+}
+
+const MB = 1024 * 1024;
+
+/** Least squares over (seconds, value), returning the per-second slope. */
+const slopeOf = (points: readonly (readonly [number, number])[]): number => {
+  const n = points.length;
+  if (n < 3) return 0;
+  let sx = 0;
+  let sy = 0;
+  let sxy = 0;
+  let sxx = 0;
+  for (const [x, y] of points) {
+    sx += x;
+    sy += y;
+    sxy += x * y;
+    sxx += x * x;
+  }
+  const divisor = n * sxx - sx * sx;
+  return divisor === 0 ? 0 : (n * sxy - sx * sy) / divisor;
+};
+
+export class Sampler {
+  readonly #samples: Sample[] = [];
+  #timer: ReturnType<typeof setInterval> | undefined;
+  #lastCpu = process.cpuUsage();
+  #startedAt = 0;
+  #expectedTick = 0;
+
+  constructor(private readonly everyMs = 250) {}
+
+  get samples(): readonly Sample[] {
+    return this.#samples;
+  }
+
+  start(): void {
+    this.#startedAt = Date.now();
+    this.#expectedTick = this.#startedAt + this.everyMs;
+    this.#lastCpu = process.cpuUsage();
+    this.#timer = setInterval(() => this.#tick(), this.everyMs);
+    // The sampler must not be the reason the process stays alive.
+    this.#timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.#timer !== undefined) clearInterval(this.#timer);
+    this.#timer = undefined;
+  }
+
+  #tick(): void {
+    const now = Date.now();
+    // Timer drift is the cheapest event-loop lag signal there is: the interval
+    // fired late by exactly as much as the loop was blocked.
+    const lagMs = Math.max(0, now - this.#expectedTick);
+    this.#expectedTick = now + this.everyMs;
+
+    const mem = process.memoryUsage();
+    const cpu = process.cpuUsage(this.#lastCpu);
+    this.#lastCpu = process.cpuUsage();
+    this.#samples.push({
+      at: now - this.#startedAt,
+      rss: mem.rss,
+      heapUsed: mem.heapUsed,
+      external: mem.external,
+      cpuMs: (cpu.user + cpu.system) / 1000,
+      lagMs,
+    });
+  }
+
+  /**
+   * Drops the first `warmupMs` of samples, then fits each series. A run shorter
+   * than three post-warmup samples yields a zero slope rather than a guess.
+   */
+  trends(warmupMs: number): readonly Trend[] {
+    const window = this.#samples.filter((s) => s.at >= warmupMs);
+    if (window.length === 0) return [];
+    const series: readonly (readonly [string, (s: Sample) => number])[] = [
+      ['rss', (s) => s.rss],
+      ['heapUsed', (s) => s.heapUsed],
+      ['external', (s) => s.external],
+      ['lagMs', (s) => s.lagMs],
+    ];
+    return series.map(([name, read]) => {
+      const points = window.map(
+        (s) => [s.at / 1000, read(s)] as readonly [number, number],
+      );
+      const values = points.map(([, y]) => y);
+      return {
+        name,
+        slope: slopeOf(points),
+        first: values[0] ?? 0,
+        last: values[values.length - 1] ?? 0,
+        peak: Math.max(...values),
+      };
+    });
+  }
+
+  /** Total CPU milliseconds burned across the whole run. */
+  cpuMs(): number {
+    return this.#samples.reduce((total, s) => total + s.cpuMs, 0);
+  }
+
+  /** The worst single event-loop stall observed. */
+  maxLagMs(): number {
+    return this.#samples.reduce((worst, s) => Math.max(worst, s.lagMs), 0);
+  }
+
+  static format(t: Trend): string {
+    const unit = t.name === 'lagMs' ? '' : ' MiB';
+    const scale = t.name === 'lagMs' ? 1 : MB;
+    const digits = t.name === 'lagMs' ? 2 : 1;
+    const per = t.name === 'lagMs' ? 'ms/s' : 'MiB/min';
+    const perValue = t.name === 'lagMs' ? t.slope : (t.slope * 60) / MB;
+    return (
+      `${t.name.padEnd(9)} ${(t.first / scale).toFixed(digits)}${unit} -> ` +
+      `${(t.last / scale).toFixed(digits)}${unit}, peak ${(t.peak / scale).toFixed(digits)}${unit}, ` +
+      `slope ${perValue >= 0 ? '+' : ''}${perValue.toFixed(3)} ${per}`
+    );
+  }
+}

--- a/examples/full/src/soak/soak.ts
+++ b/examples/full/src/soak/soak.ts
@@ -1,0 +1,238 @@
+import { Logger } from '@dunx/core';
+import { PubSub, type HttpApp } from '@dunx/http';
+import { createApp } from '../main.js';
+import { Lobby } from '../chat/lobby.service.js';
+import { Sampler } from './sampler.js';
+import { Workload } from './workload.js';
+
+/**
+ * A long-running process under sustained mixed load, watched for the things a
+ * request-per-test suite cannot see: memory that never comes back, an event loop
+ * that stalls, and per-connection state that outlives the connection.
+ *
+ * `bun run soak` for the default 30 seconds, `bun run soak -- --seconds 600` for
+ * a real one. The bounded version in `soak.test.ts` is what CI runs.
+ */
+export interface SoakOptions {
+  readonly seconds: number;
+  readonly concurrency: number;
+  /** Samples before this mark are dropped from the trend fit. */
+  readonly warmupMs: number;
+}
+
+export interface SoakVerdict {
+  readonly ok: boolean;
+  readonly failures: readonly string[];
+  readonly calls: number;
+  readonly report: readonly string[];
+}
+
+const MB = 1024 * 1024;
+
+/**
+ * The verdict comes from **settled** heap, not from the in-flight series.
+ *
+ * An in-flight slope measures the allocator as much as the program: RSS climbed
+ * 11 MiB/min on a run whose `heapUsed` was falling and whose settled RSS came back
+ * 20 MiB below its own peak, because an arena grows under load and is returned
+ * lazily. So the run is split into rounds, each ending with a forced GC and a
+ * quiet sample, and the fit is over those. A leak survives a GC; an arena does not.
+ *
+ * 2 MiB/min is roughly 3 GiB a day, which is a pod restarting on a memory limit
+ * inside a week.
+ */
+const SETTLED_HEAP_LIMIT_PER_MIN = 2 * MB;
+/** RSS is reported rather than judged, for the reason above. */
+const MAX_LAG_MS = 750;
+/** Below this the settled series is noise, so the run reports without judging. */
+const MIN_VERDICT_MINUTES = 3;
+/** One settled reading's GC noise, measured across runs at about +/-2.5 MiB. */
+const NOISE_FLOOR = 5 * MB;
+
+export class Soak {
+  constructor(private readonly options: SoakOptions) {}
+
+  async run(): Promise<SoakVerdict> {
+    const app = await createApp();
+    const url = await app.listen(0);
+    const logger = app.get(Logger);
+    const pubsub = app.get(PubSub);
+    const failures: string[] = [];
+    const report: string[] = [];
+
+    const before = pubsub.subscriberCount(Lobby.TOPIC);
+    const workload = new Workload(url);
+    const sampler = new Sampler(250);
+
+    logger.info(
+      `soak: ${this.options.seconds}s at concurrency ${this.options.concurrency} against ${url}`,
+    );
+    sampler.start();
+    const startedAt = Date.now();
+    const rounds = Math.min(
+      16,
+      Math.max(4, Math.round(this.options.seconds / 30)),
+    );
+    const roundMs = (this.options.seconds * 1000) / rounds;
+    /** One quiet reading per round: [minutes elapsed, settled heap bytes]. */
+    const settledPoints: (readonly [number, number])[] = [];
+    let settled = process.memoryUsage();
+
+    for (let round = 0; round < rounds; round += 1) {
+      await workload.run(Date.now() + roundMs, this.options.concurrency);
+      // Let in-flight sockets close, then take the reading with the heap quiet.
+      await Bun.sleep(200);
+      Bun.gc(true);
+      await Bun.sleep(200);
+      settled = process.memoryUsage();
+      settledPoints.push([(Date.now() - startedAt) / 60_000, settled.heapUsed]);
+      report.push(
+        `round ${round + 1}/${rounds} settled heap ${(settled.heapUsed / MB).toFixed(1)} MiB, ` +
+          `rss ${(settled.rss / MB).toFixed(1)} MiB`,
+      );
+    }
+    sampler.stop();
+
+    const totals = workload.totals();
+    const elapsed = (Date.now() - startedAt) / 1000;
+    report.push(
+      `${totals.calls} calls in ${elapsed.toFixed(1)}s, ` +
+        `${(totals.calls / elapsed).toFixed(0)}/s, ${totals.failures} failed`,
+    );
+    report.push(...workload.rows());
+    const trends = sampler.trends(this.options.warmupMs);
+    report.push(...trends.map((trend) => Sampler.format(trend)));
+    report.push(
+      `cpu ${sampler.cpuMs().toFixed(0)}ms over ${elapsed.toFixed(1)}s ` +
+        `(${((sampler.cpuMs() / (elapsed * 1000)) * 100).toFixed(0)}% of one core), ` +
+        `max loop stall ${sampler.maxLagMs().toFixed(0)}ms`,
+    );
+    report.push(
+      `settled heap ${(settled.heapUsed / MB).toFixed(1)} MiB, rss ${(settled.rss / MB).toFixed(1)} MiB`,
+    );
+
+    if (totals.failures > 0) {
+      for (const [name, s] of workload.stats) {
+        if (s.failures > 0) {
+          failures.push(
+            `${name}: ${s.failures}/${s.calls} failed, last: ${s.lastDetail}`,
+          );
+        }
+      }
+    }
+
+    const growth = Soak.settledSlope(settledPoints);
+    const rise =
+      (settledPoints[settledPoints.length - 1]?.[1] ?? 0) -
+      (settledPoints[0]?.[1] ?? 0);
+    const minutes = elapsed / 60;
+    /**
+     * A settled reading carries about +/-2.5 MiB of GC noise, so a one-minute run
+     * cannot resolve 2 MiB/min from nothing and saying otherwise would be a coin
+     * toss dressed as a gate. Both the fitted slope and the raw first-to-last rise
+     * have to clear the noise before this fails, and a window too short to judge
+     * says so instead of guessing.
+     */
+    const judgeable =
+      minutes >= MIN_VERDICT_MINUTES && settledPoints.length >= 4;
+    report.push(
+      `settled heap trend ${growth >= 0 ? '+' : ''}${(growth / MB).toFixed(2)} MiB/min, ` +
+        `rise ${rise >= 0 ? '+' : ''}${(rise / MB).toFixed(1)} MiB over ${settledPoints.length} rounds` +
+        (judgeable
+          ? ' (the leak verdict)'
+          : ` (window under ${MIN_VERDICT_MINUTES} min, reported not judged)`),
+    );
+    if (
+      judgeable &&
+      growth > SETTLED_HEAP_LIMIT_PER_MIN &&
+      rise > NOISE_FLOOR
+    ) {
+      failures.push(
+        `settled heap grew ${(growth / MB).toFixed(2)} MiB/min and rose ` +
+          `${(rise / MB).toFixed(1)} MiB across ${settledPoints.length} rounds, ` +
+          'which a forced GC did not reclaim',
+      );
+    }
+    if (sampler.maxLagMs() > MAX_LAG_MS) {
+      failures.push(
+        `event loop stalled for ${sampler.maxLagMs().toFixed(0)}ms`,
+      );
+    }
+
+    // Every socket the workload opened has closed by now, cleanly or not.
+    await Bun.sleep(250);
+    const after = pubsub.subscriberCount(Lobby.TOPIC);
+    report.push(`chat subscribers: ${before} before, ${after} after`);
+    if (after > before) {
+      failures.push(
+        `${after - before} chat subscriber(s) outlived their sockets (was ${before})`,
+      );
+    }
+
+    await this.#shutdown(app, failures);
+    return { ok: failures.length === 0, failures, calls: totals.calls, report };
+  }
+
+  /** Least squares over the per-round quiet readings, in bytes per minute. */
+  static settledSlope(points: readonly (readonly [number, number])[]): number {
+    if (points.length < 3) return 0;
+    const n = points.length;
+    let sx = 0;
+    let sy = 0;
+    let sxy = 0;
+    let sxx = 0;
+    for (const [x, y] of points) {
+      sx += x;
+      sy += y;
+      sxy += x * y;
+      sxx += x * x;
+    }
+    const divisor = n * sxx - sx * sx;
+    return divisor === 0 ? 0 : (n * sxy - sx * sy) / divisor;
+  }
+
+  /** Shutdown is itself under test: it has to finish, and it has to be quiet. */
+  async #shutdown(app: HttpApp, failures: string[]): Promise<void> {
+    const started = performance.now();
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), 15_000),
+    );
+    const outcome = await Promise.race([
+      app.shutdown().then(() => 'done' as const),
+      timeout,
+    ]);
+    if (outcome === 'timeout') {
+      failures.push('shutdown did not finish within 15s');
+      return;
+    }
+    const ms = performance.now() - started;
+    if (ms > 10_000) failures.push(`shutdown took ${ms.toFixed(0)}ms`);
+  }
+}
+
+const parse = (argv: readonly string[]): SoakOptions => {
+  const read = (flag: string, fallback: number): number => {
+    const at = argv.indexOf(flag);
+    if (at === -1) return fallback;
+    const raw = Number(argv[at + 1]);
+    return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+  };
+  const seconds = read('--seconds', 30);
+  return {
+    seconds,
+    concurrency: read('--concurrency', 24),
+    // A tenth of the run, floored at a second, so a short run still drops boot.
+    warmupMs: Math.max(1000, (seconds * 1000) / 10),
+  };
+};
+
+if (import.meta.main) {
+  const verdict = await new Soak(parse(Bun.argv)).run();
+  for (const line of verdict.report) console.log(line);
+  if (!verdict.ok) {
+    console.log('');
+    for (const line of verdict.failures) console.log(`FAIL ${line}`);
+    process.exit(1);
+  }
+  console.log('\nno leak signal, no failures');
+}

--- a/examples/full/src/soak/soak.ts
+++ b/examples/full/src/soak/soak.ts
@@ -194,13 +194,22 @@ export class Soak {
   /** Shutdown is itself under test: it has to finish, and it has to be quiet. */
   async #shutdown(app: HttpApp, failures: string[]): Promise<void> {
     const started = performance.now();
-    const timeout = new Promise<'timeout'>((resolve) =>
-      setTimeout(() => resolve('timeout'), 15_000),
-    );
-    const outcome = await Promise.race([
-      app.shutdown().then(() => 'done' as const),
-      timeout,
-    ]);
+    // The handle is kept and cleared: the loser of the race is still a live timer,
+    // and leaving it pending held the process open for 15 seconds after a clean
+    // shutdown, which is 15 seconds on every CI run.
+    let handle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      handle = setTimeout(() => resolve('timeout'), 15_000);
+    });
+    let outcome: 'done' | 'timeout';
+    try {
+      outcome = await Promise.race([
+        app.shutdown().then(() => 'done' as const),
+        timeout,
+      ]);
+    } finally {
+      if (handle !== undefined) clearTimeout(handle);
+    }
     if (outcome === 'timeout') {
       failures.push('shutdown did not finish within 15s');
       return;

--- a/examples/full/src/soak/workload.ts
+++ b/examples/full/src/soak/workload.ts
@@ -203,6 +203,99 @@ const OPS: readonly Op[] = [
     weight: 3,
     run: (b) => socketChurn(b, true),
   },
+  /**
+   * The rest of the surface. Each accepts 503 as well, since an absent service is
+   * the app degrading rather than failing: the same run has to be meaningful on a
+   * laptop with nothing up and in CI with valkey and postgres.
+   */
+  {
+    name: 'images.render',
+    weight: 2,
+    run: (b) =>
+      call(
+        b,
+        'api/images/render?width=32&format=webp',
+        okStatuses(200, 429, 503),
+      ),
+  },
+  {
+    name: 'images.metadata',
+    weight: 1,
+    run: (b) =>
+      call(b, 'api/images/metadata?width=32', okStatuses(200, 429, 503)),
+  },
+  {
+    name: 'files.rw',
+    weight: 2,
+    run: async (b) => {
+      const key = `soak/${Math.floor(Math.random() * 32)}.txt`;
+      const q = `key=${encodeURIComponent(key)}`;
+      await call(
+        b,
+        `api/files/object?${q}`,
+        okStatuses(200, 201, 204, 429, 503),
+        {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ content: 'soak' }),
+        },
+      );
+      return call(b, `api/files/object?${q}`, okStatuses(200, 404, 429, 503));
+    },
+  },
+  {
+    name: 'files.list',
+    weight: 1,
+    run: (b) => call(b, 'api/files?prefix=soak', okStatuses(200, 429, 503)),
+  },
+  {
+    name: 'jobs.enqueue',
+    weight: 2,
+    run: (b) =>
+      call(
+        b,
+        'api/jobs/thumbnails',
+        okStatuses(200, 201, 202, 429, 503),
+        json({ width: 64, format: 'webp' }),
+      ),
+  },
+  {
+    name: 'upstream.flaky',
+    weight: 2,
+    run: (b) =>
+      call(b, 'api/upstream/flaky', okStatuses(200, 429, 502, 503, 504)),
+  },
+  {
+    name: 'upstream.missing',
+    weight: 1,
+    run: (b) =>
+      call(b, 'api/upstream/missing', okStatuses(200, 404, 429, 502, 503, 504)),
+  },
+  {
+    name: 'guards.reports',
+    weight: 2,
+    run: (b) => call(b, 'api/reports', okStatuses(200, 401, 403, 429)),
+  },
+  {
+    name: 'auth.profile',
+    weight: 2,
+    run: (b) => call(b, 'api/profile', okStatuses(200, 401, 403, 429)),
+  },
+  {
+    name: 'wiring',
+    weight: 1,
+    run: (b) => call(b, 'api/wiring', okStatuses(200, 429)),
+  },
+  {
+    name: 'dashboard',
+    weight: 1,
+    run: (b) => call(b, 'api/_dunx', okStatuses(200, 404, 429)),
+  },
+  {
+    name: 'docs',
+    weight: 1,
+    run: (b) => call(b, 'api/docs', okStatuses(200, 429)),
+  },
 ];
 
 export class Workload {

--- a/examples/full/src/soak/workload.ts
+++ b/examples/full/src/soak/workload.ts
@@ -1,0 +1,280 @@
+/**
+ * The traffic the soak run puts through the app.
+ *
+ * Every operation names the statuses it accepts, because a soak that treats a
+ * 429 or a 404 as a failure cannot exercise the rate limiter or the unmatched
+ * path, and those are two of the four places that hold per-request state. An
+ * unexpected status is recorded against the operation rather than thrown, so one
+ * broken route does not end the run and hide everything behind it.
+ */
+export interface OpResult {
+  readonly name: string;
+  readonly ok: boolean;
+  readonly ms: number;
+  readonly detail?: string;
+}
+
+export interface OpStats {
+  calls: number;
+  failures: number;
+  totalMs: number;
+  maxMs: number;
+  lastDetail: string | undefined;
+}
+
+interface Op {
+  readonly name: string;
+  /** Relative share of the traffic. */
+  readonly weight: number;
+  run(base: string): Promise<string>;
+}
+
+const okStatuses = (...codes: readonly number[]): ReadonlySet<number> =>
+  new Set(codes);
+
+/** A fetch that names the route in its failure, since `fetch` alone does not. */
+const call = async (
+  base: string,
+  path: string,
+  accept: ReadonlySet<number>,
+  init?: RequestInit,
+): Promise<string> => {
+  const res = await fetch(new URL(path, base), init);
+  // The body must be drained or the socket is held until GC.
+  await res.arrayBuffer();
+  if (!accept.has(res.status)) {
+    throw new Error(`${init?.method ?? 'GET'} ${path} -> ${res.status}`);
+  }
+  return String(res.status);
+};
+
+const json = (body: unknown): RequestInit => ({
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+/**
+ * A websocket that opens, exchanges a frame and closes. Connection churn is the
+ * leak-prone half of a gateway: a subscriber map that is added to on open and
+ * only tidied on a clean close grows on every aborted connection.
+ */
+const socketChurn = async (base: string, abort: boolean): Promise<string> => {
+  const url = new URL('chat', base).href.replace('http', 'ws');
+  const socket = new WebSocket(url);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('socket never opened')),
+      4000,
+    );
+    socket.addEventListener(
+      'open',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+    socket.addEventListener(
+      'error',
+      () => {
+        clearTimeout(timer);
+        reject(new Error('socket errored'));
+      },
+      { once: true },
+    );
+  });
+  if (abort) {
+    // No close frame: the half that a clean-close-only cleanup path misses.
+    socket.terminate?.();
+    socket.close();
+    return 'aborted';
+  }
+  socket.send(JSON.stringify({ event: 'say', data: 'soak' }));
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  socket.close();
+  return 'closed';
+};
+
+const OPS: readonly Op[] = [
+  {
+    name: 'notes.list',
+    weight: 8,
+    run: (b) => call(b, 'api/notes', okStatuses(200, 429)),
+  },
+  {
+    name: 'notes.create',
+    weight: 4,
+    run: (b) =>
+      call(b, 'api/notes', okStatuses(201, 429), json({ text: 'soak note' })),
+  },
+  {
+    name: 'users.list',
+    weight: 6,
+    run: (b) => call(b, 'api/users?limit=5', okStatuses(200, 429)),
+  },
+  {
+    name: 'users.one',
+    weight: 4,
+    run: (b) => call(b, 'api/users/1', okStatuses(200, 404, 429)),
+  },
+  {
+    name: 'ledger.write',
+    weight: 5,
+    run: (b) =>
+      call(
+        b,
+        'api/ledger',
+        okStatuses(201, 429, 503),
+        json({ account: 'soak', amount: 1, memo: 'soak' }),
+      ),
+  },
+  {
+    name: 'ledger.page',
+    weight: 4,
+    run: (b) => call(b, 'api/ledger/page?take=5', okStatuses(200, 429, 503)),
+  },
+  {
+    name: 'cache.rw',
+    weight: 4,
+    run: async (b) => {
+      const key = `soak-${Math.floor(Math.random() * 64)}`;
+      await call(b, `api/cache/${key}`, okStatuses(200, 204, 429, 503), {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ data: { soak: true }, ttl: 60 }),
+      });
+      return call(b, `api/cache/${key}`, okStatuses(200, 404, 429, 503));
+    },
+  },
+  {
+    name: 'trace',
+    weight: 3,
+    run: (b) =>
+      call(b, 'api/trace', okStatuses(200, 429), {
+        headers: {
+          traceparent:
+            '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        },
+      }),
+  },
+  {
+    name: 'health.ready',
+    weight: 2,
+    run: (b) => call(b, 'api/health/ready', okStatuses(200, 503)),
+  },
+  {
+    name: 'health.live',
+    weight: 2,
+    run: (b) => call(b, 'api/health/live', okStatuses(200, 503)),
+  },
+  {
+    name: 'validation.400',
+    weight: 3,
+    run: (b) => call(b, 'api/notes', okStatuses(400, 429), json({ text: '' })),
+  },
+  {
+    name: 'unmatched.404',
+    weight: 3,
+    run: (b) =>
+      call(
+        b,
+        `api/nothing-here-${Math.random().toString(36).slice(2, 8)}`,
+        okStatuses(404, 429),
+      ),
+  },
+  {
+    name: 'throttle.burst',
+    weight: 4,
+    run: (b) => call(b, 'api/limits/burst', okStatuses(200, 429)),
+  },
+  {
+    name: 'openapi',
+    weight: 1,
+    run: (b) => call(b, 'api/openapi.json', okStatuses(200, 429)),
+  },
+  {
+    name: 'ws.clean',
+    weight: 3,
+    run: (b) => socketChurn(b, false),
+  },
+  {
+    name: 'ws.abort',
+    weight: 3,
+    run: (b) => socketChurn(b, true),
+  },
+];
+
+export class Workload {
+  readonly stats = new Map<string, OpStats>();
+  #picker: readonly Op[] = [];
+
+  constructor(private readonly base: string) {
+    for (const op of OPS) {
+      this.stats.set(op.name, {
+        calls: 0,
+        failures: 0,
+        totalMs: 0,
+        maxMs: 0,
+        lastDetail: undefined,
+      });
+    }
+    // Expand the weights once so a pick is one array index rather than a scan.
+    this.#picker = OPS.flatMap((op) => Array<Op>(op.weight).fill(op));
+  }
+
+  /** Runs `concurrency` workers until `deadline`, resolving when all have stopped. */
+  async run(deadline: number, concurrency: number): Promise<void> {
+    const worker = async (): Promise<void> => {
+      while (Date.now() < deadline) {
+        const op =
+          this.#picker[Math.floor(Math.random() * this.#picker.length)];
+        if (op === undefined) return;
+        await this.#once(op);
+      }
+    };
+    await Promise.all(Array.from({ length: concurrency }, worker));
+  }
+
+  async #once(op: Op): Promise<void> {
+    const entry = this.stats.get(op.name);
+    if (entry === undefined) return;
+    const started = performance.now();
+    try {
+      await op.run(this.base);
+      entry.calls++;
+    } catch (error) {
+      entry.calls++;
+      entry.failures++;
+      entry.lastDetail = error instanceof Error ? error.message : String(error);
+    }
+    const ms = performance.now() - started;
+    entry.totalMs += ms;
+    entry.maxMs = Math.max(entry.maxMs, ms);
+  }
+
+  totals(): { calls: number; failures: number } {
+    let calls = 0;
+    let failures = 0;
+    for (const s of this.stats.values()) {
+      calls += s.calls;
+      failures += s.failures;
+    }
+    return { calls, failures };
+  }
+
+  rows(): readonly string[] {
+    return [...this.stats.entries()]
+      .filter(([, s]) => s.calls > 0)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, s]) => {
+        const mean = s.totalMs / s.calls;
+        const failed = s.failures > 0 ? ` FAILED ${s.failures}` : '';
+        const why = s.lastDetail === undefined ? '' : ` (${s.lastDetail})`;
+        return (
+          `${name.padEnd(16)} ${String(s.calls).padStart(6)} calls  ` +
+          `mean ${mean.toFixed(2)}ms  max ${s.maxMs.toFixed(1)}ms${failed}${why}`
+        );
+      });
+  }
+}

--- a/examples/full/src/soak/workload.ts
+++ b/examples/full/src/soak/workload.ts
@@ -39,7 +39,13 @@ const call = async (
   accept: ReadonlySet<number>,
   init?: RequestInit,
 ): Promise<string> => {
-  const res = await fetch(new URL(path, base), init);
+  // Without a deadline a hung route parks its worker for the whole run, so the
+  // soak quietly loses concurrency instead of reporting the route that stopped
+  // answering. Well above the slowest observed route on a loaded 2-core runner.
+  const res = await fetch(new URL(path, base), {
+    ...init,
+    signal: AbortSignal.timeout(10_000),
+  });
   // The body must be drained or the socket is held until GC.
   await res.arrayBuffer();
   if (!accept.has(res.status)) {

--- a/examples/full/src/tour.test.ts
+++ b/examples/full/src/tour.test.ts
@@ -570,3 +570,20 @@ it('leaves every other route reachable without credentials', () => {
   );
   expect(tour.text).toContain('GET /api/users -> 200 [{"id":1,"name":"ada"}');
 });
+
+/**
+ * The Postgres backend, which was named in a comment and called by nothing until
+ * the soak audit went looking. Both halves are asserted: fan-out reaching the
+ * other node exactly once, and the 7999-byte `NOTIFY` cap degrading to a local
+ * delivery plus a warning rather than a silent drop.
+ */
+it('relays over Postgres LISTEN/NOTIFY, and reports a frame over the cap', () => {
+  expect(tour.text).toMatch(
+    /(deliveries: A 1, B 1|skipping the Postgres relay demo)/,
+  );
+  if (tour.text.includes('skipping the Postgres relay demo')) return;
+  expect(tour.text).toContain('two nodes on LISTEN/NOTIFY');
+  // A keeps it, B never sees it, and the relay says why.
+  expect(tour.text).toContain('a 9000-byte frame: A 1, B 0');
+  expect(tour.text).toMatch(/the websocket relay could not publish/);
+});

--- a/examples/full/src/tour.test.ts
+++ b/examples/full/src/tour.test.ts
@@ -587,3 +587,14 @@ it('relays over Postgres LISTEN/NOTIFY, and reports a frame over the cap', () =>
   expect(tour.text).toContain('a 9000-byte frame: A 1, B 0');
   expect(tour.text).toMatch(/the websocket relay could not publish/);
 });
+
+/**
+ * `overlap: 'skip'` is the default and every other schedule here takes it, so the
+ * concurrent branch had no exercise at all. Two triggers inside one run's own
+ * sleep: `skip` would hold this at one in flight.
+ */
+it('runs a concurrent-overlap schedule twice at once', () => {
+  expect(tour.text).toContain(
+    'overlap: concurrent -> 2 runs, 2 in flight at once',
+  );
+});

--- a/examples/full/src/tour/tour.service.ts
+++ b/examples/full/src/tour/tour.service.ts
@@ -3,6 +3,7 @@ import type { HttpApp } from '@dunx/http';
 import { AuthDemo } from '../auth/auth.demo.js';
 import { Sessions } from '../cache/sessions.service.js';
 import { ChatDemo } from '../chat/chat.demo.js';
+import { PostgresRelayDemo } from '../chat/postgres-relay.demo.js';
 import { ProtocolsDemo } from '../protocols/protocols.demo.js';
 import { CompressionDemo } from '../http/compression.demo.js';
 import { TraceDemo } from '../http/trace.demo.js';
@@ -39,6 +40,7 @@ export class Tour {
     private readonly compression: CompressionDemo,
     private readonly trace: TraceDemo,
     private readonly chat: ChatDemo,
+    private readonly postgresRelay: PostgresRelayDemo,
     private readonly protocols: ProtocolsDemo,
     private readonly guards: GuardsDemo,
     private readonly health: HealthDemo,
@@ -89,6 +91,9 @@ export class Tour {
 
     this.group('@dunx/http - the websocket relay, two nodes, one topic');
     await this.chat.relayed(url);
+    // The same fan-out on the other backend, so both are proven rather than one
+    // being proven and the other named in a comment.
+    await this.postgresRelay.demonstrate();
 
     this.group('@dunx/http - @Public, @Roles and @UseGuards');
     await this.guards.demonstrate(url);

--- a/packages/http/src/health/controller.ts
+++ b/packages/http/src/health/controller.ts
@@ -1,6 +1,7 @@
 import { inject } from '@dunx/core';
 import { Controller, Get } from '../route/decorators.js';
 import { ApiHidden, Public } from '../route/metadata.js';
+import { SkipThrottle } from '../throttle/decorators.js';
 import { HEALTH_REPORT_SCHEMA } from './report-schema.js';
 import { HealthRegistry, type HealthReport } from './registry.js';
 
@@ -22,8 +23,13 @@ const answer = (report: HealthReport): Response =>
  * finishes every `onInit` before `listen()` binds, so a connection refused *is* "not
  * started yet" and a third endpoint would restate it.
  *
- * `@Public()` because a probe has no credentials. Both routes are documented, under
- * the `Health` tag; `HealthModule.forRoot({ documented: false })` mounts
+ * `@Public()` because a probe has no credentials, and `@SkipThrottle()` for the same
+ * reason: a probe is not a caller with a budget. `app.use(ThrottleGuard)` covers
+ * every route, so without the exemption an orchestrator polling a pod that is
+ * already shedding load reads 429, calls the process unhealthy and restarts it.
+ *
+ * Both routes are documented, under the `Health` tag;
+ * `HealthModule.forRoot({ documented: false })` mounts
  * {@link HiddenHealthController} instead.
  */
 @Controller('health')
@@ -44,6 +50,7 @@ export class HealthController {
    * killing, and reporting `down` invites a SIGKILL mid-drain.
    */
   @Public()
+  @SkipThrottle()
   @Get('/live', probeResponses)
   async live(): Promise<Response> {
     return answer(await this.#health.liveness());
@@ -51,6 +58,7 @@ export class HealthController {
 
   /** Should the process receive traffic. Fails from the moment the drain starts. */
   @Public()
+  @SkipThrottle()
   @Get('/ready', probeResponses)
   async ready(): Promise<Response> {
     return answer(await this.#health.readiness());

--- a/packages/http/src/health/routes.test.ts
+++ b/packages/http/src/health/routes.test.ts
@@ -3,6 +3,8 @@ import { Module } from '@dunx/core';
 import { HttpFactory } from '../server/factory.js';
 import { HealthIndicator, type ProbeResult } from './contracts.js';
 import { HealthModule } from './module.js';
+import { ThrottleGuard } from '../throttle/guard.js';
+import { ThrottleModule } from '../throttle/module.js';
 
 class Db extends HealthIndicator {
   readonly name = 'database';
@@ -106,6 +108,41 @@ test('documented: false still serves both probes', async () => {
   // handlers, so what is served is identical - only the document changes.
   expect((await fetch(`${url}health/live`)).status).toBe(200);
   expect((await fetch(`${url}health/ready`)).status).toBe(200);
+
+  await app.shutdown();
+});
+
+/**
+ * A probe is not a caller with a budget.
+ *
+ * `app.use(ThrottleGuard)` is the documented way to rate limit an app, and it runs
+ * for every route including the two this module mounts. An orchestrator polling a
+ * pod that is already at its limit then reads 429 on `/health/live`, decides the
+ * process is unhealthy and restarts it, which is the opposite of what a rate limit
+ * is for: load shedding turns into a restart loop at exactly the wrong moment.
+ * Found by the soak run in `examples/full`, at 10k requests a second.
+ */
+test('a global throttle does not reach the probes', async () => {
+  @Module({
+    imports: [
+      HealthModule.forRoot({ readiness: [new Db()], liveness: [new Db()] }),
+      ThrottleModule.forRoot({
+        prefix: 'probe-test',
+        limit: 1,
+        windowSeconds: 60,
+      }),
+    ],
+  })
+  class Root {}
+
+  const app = await HttpFactory.create(Root, { requestLogging: false });
+  app.use(ThrottleGuard);
+  const url = await app.listen(0);
+
+  for (let i = 0; i < 5; i += 1) {
+    expect((await fetch(`${url}health/live`)).status).toBe(200);
+    expect((await fetch(`${url}health/ready`)).status).toBe(200);
+  }
 
   await app.shutdown();
 });

--- a/packages/http/src/throttle/options.ts
+++ b/packages/http/src/throttle/options.ts
@@ -55,7 +55,7 @@ export class ThrottleOptions {
   readonly store: ThrottleStore | undefined;
 
   constructor(init: ThrottleOptionsInit) {
-    if (init.prefix.trim() === '') {
+    if (typeof init.prefix !== 'string' || init.prefix.trim() === '') {
       throw new AppError(
         'ThrottleModule needs a prefix naming this application, and it has no ' +
           'default: two apps sharing one Redis with one throttle namespace each ' +

--- a/packages/http/src/throttle/throttle.test.ts
+++ b/packages/http/src/throttle/throttle.test.ts
@@ -8,7 +8,7 @@ import { HttpFactory } from '../server/factory.js';
 import { SkipThrottle, Throttle } from './decorators.js';
 import { ThrottleGuard } from './guard.js';
 import { ThrottleModule } from './module.js';
-import { ThrottleOptions } from './options.js';
+import { ThrottleOptions, type ThrottleOptionsInit } from './options.js';
 import {
   MemoryThrottleStore,
   RedisThrottleStore,
@@ -61,13 +61,23 @@ class Counting extends ConsoleLogger {
 describe('ThrottleOptions', () => {
   const base = { limit: 2, windowSeconds: 60 };
 
-  it('refuses an empty prefix rather than inventing one', () => {
-    expect(() => new ThrottleOptions({ ...base, prefix: '' })).toThrow(
-      /needs a prefix/,
-    );
-    expect(() => new ThrottleOptions({ ...base, prefix: '   ' })).toThrow(
-      /needs a prefix/,
-    );
+  /**
+   * `undefined` is the case that matters most and was the one that got through:
+   * reading the prefix off `ConfigService` in `forRootAsync` makes it undefined at
+   * runtime whenever the variable is unset, whatever the type says, and the guard
+   * used to call `.trim()` on it and die with `undefined is not an object` before
+   * it could say any of this.
+   */
+  it('refuses a missing or empty prefix rather than inventing one', () => {
+    for (const prefix of [undefined, '', '   ']) {
+      expect(
+        () =>
+          new ThrottleOptions({
+            ...base,
+            prefix,
+          } as unknown as ThrottleOptionsInit),
+      ).toThrow(/needs a prefix/);
+    }
   });
 
   it('refuses a limit or a window below one', () => {

--- a/packages/infra/src/db/transaction.test.ts
+++ b/packages/infra/src/db/transaction.test.ts
@@ -388,3 +388,85 @@ describe('overlapping top-level transactions', () => {
     expect(names()).toEqual(['nested']);
   });
 });
+
+describe('a BEGIN that fails', () => {
+  /** Strands the depth counter if the throw escapes before the `finally`. */
+  const failABegin = async (): Promise<void> => {
+    db.run(sql.raw('BEGIN'));
+    const error = await rejection(transaction(db, () => insert('never')));
+    expect(error.message).toMatch(/BEGIN/);
+    db.run(sql.raw('ROLLBACK'));
+  };
+
+  /**
+   * The counter is incremented before `BEGIN` runs and decremented in a `finally`
+   * that `BEGIN` is not inside, so a throw there strands it above zero for the
+   * life of the handle. Every later call then reads `depth > 0`, skips the queue
+   * and issues `SAVEPOINT dunx_sp_N` instead of `BEGIN`.
+   *
+   * That turns two unrelated top-level transactions into nested savepoints on one
+   * connection, and the outer one rolling back discards the inner one's committed
+   * work. `SQLITE_BUSY` from a second writer on a file-backed database reaches
+   * this in production; opening a transaction by hand is the same failure without
+   * the race.
+   */
+  it('does not let a later rollback discard another transaction', async () => {
+    await failABegin();
+
+    const failing = rejection(
+      transaction(db, async (tx) => {
+        tx.insert(entries).values({ name: 'discarded' }).run();
+        await Bun.sleep(5);
+        throw new Error('nope');
+      }),
+    );
+    const succeeding = transaction(db, async (tx) => {
+      await Bun.sleep(1);
+      tx.insert(entries).values({ name: 'kept' }).run();
+    });
+
+    await Promise.all([failing, succeeding]);
+    expect(names()).toEqual(['kept']);
+  });
+});
+
+describe('a BEGIN that fails', () => {
+  /** Strands the depth counter if the throw escapes before the `finally`. */
+  const failABegin = async (): Promise<void> => {
+    db.run(sql.raw('BEGIN'));
+    const error = await rejection(transaction(db, () => insert('never')));
+    expect(error.message).toMatch(/BEGIN/);
+    db.run(sql.raw('ROLLBACK'));
+  };
+
+  /**
+   * The counter is incremented before `BEGIN` runs and decremented in a `finally`
+   * that `BEGIN` is not inside, so a throw there strands it above zero for the
+   * life of the handle. Every later call then reads `depth > 0`, skips the queue
+   * and issues `SAVEPOINT dunx_sp_N` instead of `BEGIN`.
+   *
+   * That turns two unrelated top-level transactions into nested savepoints on one
+   * connection, and the outer one rolling back discards the inner one's committed
+   * work. `SQLITE_BUSY` from a second writer on a file-backed database reaches
+   * this in production; opening a transaction by hand is the same failure without
+   * the race.
+   */
+  it('does not let a later rollback discard another transaction', async () => {
+    await failABegin();
+
+    const failing = rejection(
+      transaction(db, async (tx) => {
+        tx.insert(entries).values({ name: 'discarded' }).run();
+        await Bun.sleep(5);
+        throw new Error('nope');
+      }),
+    );
+    const succeeding = transaction(db, async (tx) => {
+      await Bun.sleep(1);
+      tx.insert(entries).values({ name: 'kept' }).run();
+    });
+
+    await Promise.all([failing, succeeding]);
+    expect(names()).toEqual(['kept']);
+  });
+});

--- a/packages/infra/src/db/transaction.ts
+++ b/packages/infra/src/db/transaction.ts
@@ -70,8 +70,22 @@ const scoped = async <TSchema extends Record<string, unknown>, T>(
   const depth = scope.depth++;
   const savepoint = `dunx_sp_${depth}`;
 
-  exec(db, depth === 0 ? 'BEGIN' : `SAVEPOINT ${savepoint}`);
+  /**
+   * `BEGIN` itself throws - `SQLITE_BUSY` against a second writer, or a
+   * transaction something else already opened - and it has to be inside the
+   * `try`, or the `finally` never runs and the depth is stranded above zero for
+   * the life of the handle. Every later call then reads `depth > 0`, skips the
+   * queue and issues a savepoint, so two unrelated top-level transactions nest
+   * and one rolling back discards the other's work.
+   *
+   * `opened` is what keeps the rollback honest once it is inside: there is
+   * nothing to roll back from a transaction that never started, and trying
+   * replaces the real error with a second one.
+   */
+  let opened = false;
   try {
+    exec(db, depth === 0 ? 'BEGIN' : `SAVEPOINT ${savepoint}`);
+    opened = true;
     // The same handle, not a derived one: there is exactly one connection, so
     // every statement issued anywhere is already inside this transaction. That is
     // also why the schema type survives a transaction unchanged.
@@ -79,6 +93,9 @@ const scoped = async <TSchema extends Record<string, unknown>, T>(
     exec(db, depth === 0 ? 'COMMIT' : `RELEASE ${savepoint}`);
     return result;
   } catch (error) {
+    if (!opened) {
+      throw error;
+    }
     if (depth === 0) {
       exec(db, 'ROLLBACK');
     } else {

--- a/packages/infra/src/pagination/options.ts
+++ b/packages/infra/src/pagination/options.ts
@@ -58,6 +58,11 @@ const one = (value: unknown): string | undefined => {
   // A query string can repeat a key. The first wins, matching how a route's own
   // parser reads `?take=1&take=2`, rather than silently concatenating them.
   if (Array.isArray(value)) return one(value[0]);
+  // A number counts. The input is meant to be raw query values, but a route that
+  // validated first with `z.coerce.number()` hands over a number, and returning
+  // undefined for it meant `take` silently reverted to the default: the caller
+  // asked for 1 and got 20, with no error to notice.
+  if (typeof value === 'number') return String(value);
   return typeof value === 'string' ? value : undefined;
 };
 

--- a/packages/infra/src/pagination/pagination.test.ts
+++ b/packages/infra/src/pagination/pagination.test.ts
@@ -143,6 +143,19 @@ describe('parsePageOptions', () => {
     });
   });
 
+  /**
+   * Raw query values are strings, but a route that validated first with
+   * `z.coerce.number()` hands over a number. Returning undefined for it made
+   * `take` revert to the default with nothing to notice: the caller asked for 1
+   * and got 20 rows back. Found by wiring the example's keyset route to a
+   * validated query.
+   */
+  it('reads a take that a validator already turned into a number', () => {
+    expect(parsePageOptions({ take: 5 }).take).toBe(5);
+    expect(parsePageOptions({ take: [5] }).take).toBe(5);
+    expect(parsePageOptions({ take: '5' }).take).toBe(5);
+  });
+
   it('reads a plain object and a URLSearchParams the same way', () => {
     const expected = {
       take: 5,

--- a/packages/infra/src/queue/module.test.ts
+++ b/packages/infra/src/queue/module.test.ts
@@ -116,6 +116,38 @@ describe('QueueModule.forRoot', () => {
     expect(queue.listenerCount('error')).toBeGreaterThan(0);
   });
 
+  /**
+   * A queue name is memoised and holds a Redis connection until shutdown, so a
+   * name derived from data - `emails:${tenantId}` - reserves one of each per
+   * tenant the process ever sees. The warning is the whole mitigation: evicting a
+   * `Queue` means an async `close()` racing a publish, and a hard cap would be
+   * wrong for the rare app that really has hundreds.
+   */
+  it('warns once when the queue names look derived from data', async () => {
+    const warnings: unknown[] = [];
+    const logger = new ConsoleLogger(undefined, 'fatal');
+    logger.warn = (message: unknown): void => {
+      warnings.push(message);
+    };
+
+    @Module({
+      imports: [QueueModule.forRoot({ url })],
+      providers: [provide(Logger, { useValue: logger })],
+    })
+    class Root {}
+
+    app = await AppFactory.create(Root);
+    const publisher = app.get(JobPublisher);
+    for (let i = 0; i < 70; i += 1) publisher.queue(`tenant-${i}`);
+
+    const crossed = warnings.filter(
+      (entry) =>
+        typeof entry === 'string' && entry.includes('distinct queue names'),
+    );
+    expect(crossed).toHaveLength(1);
+    expect(publisher.opened).toHaveLength(70);
+  });
+
   it('reports a queue error through the bound Logger, with the error', async () => {
     const entries: { message: unknown; params: unknown[] }[] = [];
     // A real ConsoleLogger with `warn` shadowed. Spreading one copied `logLevel`

--- a/packages/infra/src/queue/publisher.ts
+++ b/packages/infra/src/queue/publisher.ts
@@ -5,6 +5,13 @@ import { describeJob } from './discover.js';
 import { QueueOptions } from './options.js';
 
 /**
+ * Distinct queue names past which they are more likely derived from data than
+ * written by hand. A warning, not a cap: `Queue.close()` is async, so evicting one
+ * races a publish. See `module.test.ts`.
+ */
+const WARN_AT_QUEUES = 64;
+
+/**
  * Enqueues jobs. The other half of the split the dispatcher is: nothing here knows
  * how a job runs, and nothing in the dispatcher knows how one arrives - so a web
  * process imports this and never opens a worker.
@@ -42,13 +49,9 @@ export class JobPublisher implements OnShutdown {
    * validate and nothing gained by holding a socket for a queue nobody publishes
    * to.
    *
-   * **Held once opened, and `name` is whatever the caller passed.** Each miss
-   * constructs a `Queue` and opens a `Bun.RedisClient` that
-   * {@link QueueConnection} keeps until shutdown, so routing per tenant with
-   * `publish(\`emails:${tenantId}\`, ...)` reserves one queue, one socket and one
-   * entry per tenant the process has ever seen. A queue name belongs to the
-   * application's vocabulary, not to its data: keep the set finite and put the
-   * tenant in the job payload.
+   * **Held once opened, and `name` is whatever the caller passed**, so a name
+   * derived from data reserves a queue and a Redis connection per value, until
+   * shutdown. Put the tenant in the payload, not the queue name.
    */
   queue(name: string): Queue {
     const existing = this.#queues.get(name);
@@ -72,6 +75,15 @@ export class JobPublisher implements OnShutdown {
     });
 
     this.#queues.set(name, created);
+    // Exactly once, on the crossing, so a busy publisher does not repeat itself.
+    if (this.#queues.size === WARN_AT_QUEUES) {
+      this.#logger.warn(
+        `${WARN_AT_QUEUES} distinct queue names have been opened, each holding a ` +
+          'Redis connection until shutdown. A queue name belongs to the ' +
+          "application's vocabulary; if these are derived from data, put that in " +
+          'the job payload and publish to one queue instead.',
+      );
+    }
     return created;
   }
 

--- a/packages/infra/src/queue/publisher.ts
+++ b/packages/infra/src/queue/publisher.ts
@@ -41,6 +41,14 @@ export class JobPublisher implements OnShutdown {
    * not a resource to reserve, so there is nothing for a registration step to
    * validate and nothing gained by holding a socket for a queue nobody publishes
    * to.
+   *
+   * **Held once opened, and `name` is whatever the caller passed.** Each miss
+   * constructs a `Queue` and opens a `Bun.RedisClient` that
+   * {@link QueueConnection} keeps until shutdown, so routing per tenant with
+   * `publish(\`emails:${tenantId}\`, ...)` reserves one queue, one socket and one
+   * entry per tenant the process has ever seen. A queue name belongs to the
+   * application's vocabulary, not to its data: keep the set finite and put the
+   * tenant in the job payload.
    */
   queue(name: string): Queue {
     const existing = this.#queues.get(name);

--- a/packages/infra/src/redis/client.ts
+++ b/packages/infra/src/redis/client.ts
@@ -393,6 +393,10 @@ export class Redis extends RedisConnection implements OnInit, OnShutdown {
     }
 
     const existing = this.#listeners.get(channel);
+    // Only what this call adds is this call's to undo: subscribing the same
+    // listener twice must not let the second attempt's failure retract the first
+    // attempt's live subscription.
+    const added = existing === undefined || !existing.has(listener);
     if (existing) {
       existing.add(listener);
     } else {
@@ -404,13 +408,16 @@ export class Redis extends RedisConnection implements OnInit, OnShutdown {
         await client.subscribe(channel, listener);
       });
     } catch (error) {
-      // The registry is what `close()` walks and what a reconnect replays, so an
-      // entry with no subscription behind it is a permanent one: the key is
-      // caller-supplied, and per-room or per-user fan-out against a broker that
-      // flaps leaves one behind for every channel that ever failed.
-      const set = this.#listeners.get(channel);
-      set?.delete(listener);
-      if (set !== undefined && set.size === 0) this.#listeners.delete(channel);
+      // A failed SUBSCRIBE leaves nothing on the wire, so the registration it was
+      // for has to go too. The key is caller-supplied, and per-room fan-out
+      // against a broker that flaps would otherwise leave one entry behind for
+      // every channel that ever failed, with nothing to sweep it.
+      if (added) {
+        const set = this.#listeners.get(channel);
+        set?.delete(listener);
+        if (set !== undefined && set.size === 0)
+          this.#listeners.delete(channel);
+      }
       throw error;
     }
   }
@@ -424,27 +431,23 @@ export class Redis extends RedisConnection implements OnInit, OnShutdown {
     // Nothing was ever subscribed here; Bun would throw ERR_REDIS_INVALID_STATE.
     if (!client || !registered) return;
 
-    // Both branches tidy in a `finally`: a rejected UNSUBSCRIBE used to leave the
-    // channel key behind, and in the listener branch an empty `Set` with it.
+    // The registry is dropped only once the command has succeeded, which is what
+    // keeps a retry working: the guard above returns early for a channel with no
+    // entry, so tidying on failure would turn the caller's second attempt into a
+    // silent no-op while the wire stayed subscribed.
     if (listener) {
+      await this.#run('UNSUBSCRIBE', async () => {
+        await client.unsubscribe(channel, listener);
+      });
       registered.delete(listener);
-      try {
-        await this.#run('UNSUBSCRIBE', async () => {
-          await client.unsubscribe(channel, listener);
-        });
-      } finally {
-        if (registered.size === 0) this.#listeners.delete(channel);
-      }
-      return;
-    }
-
-    try {
+      if (registered.size > 0) return;
+    } else {
       await this.#run('UNSUBSCRIBE', async () => {
         await client.unsubscribe(channel);
       });
-    } finally {
-      this.#listeners.delete(channel);
     }
+
+    this.#listeners.delete(channel);
   }
 
   send(command: string, args: readonly RedisArg[] = []): Promise<unknown> {

--- a/packages/infra/src/redis/client.ts
+++ b/packages/infra/src/redis/client.ts
@@ -399,9 +399,20 @@ export class Redis extends RedisConnection implements OnInit, OnShutdown {
       this.#listeners.set(channel, new Set([listener]));
     }
 
-    await this.#run('SUBSCRIBE', async () => {
-      await client.subscribe(channel, listener);
-    });
+    try {
+      await this.#run('SUBSCRIBE', async () => {
+        await client.subscribe(channel, listener);
+      });
+    } catch (error) {
+      // The registry is what `close()` walks and what a reconnect replays, so an
+      // entry with no subscription behind it is a permanent one: the key is
+      // caller-supplied, and per-room or per-user fan-out against a broker that
+      // flaps leaves one behind for every channel that ever failed.
+      const set = this.#listeners.get(channel);
+      set?.delete(listener);
+      if (set !== undefined && set.size === 0) this.#listeners.delete(channel);
+      throw error;
+    }
   }
 
   async unsubscribe(
@@ -413,19 +424,27 @@ export class Redis extends RedisConnection implements OnInit, OnShutdown {
     // Nothing was ever subscribed here; Bun would throw ERR_REDIS_INVALID_STATE.
     if (!client || !registered) return;
 
+    // Both branches tidy in a `finally`: a rejected UNSUBSCRIBE used to leave the
+    // channel key behind, and in the listener branch an empty `Set` with it.
     if (listener) {
       registered.delete(listener);
-      await this.#run('UNSUBSCRIBE', async () => {
-        await client.unsubscribe(channel, listener);
-      });
-      if (registered.size > 0) return;
-    } else {
+      try {
+        await this.#run('UNSUBSCRIBE', async () => {
+          await client.unsubscribe(channel, listener);
+        });
+      } finally {
+        if (registered.size === 0) this.#listeners.delete(channel);
+      }
+      return;
+    }
+
+    try {
       await this.#run('UNSUBSCRIBE', async () => {
         await client.unsubscribe(channel);
       });
+    } finally {
+      this.#listeners.delete(channel);
     }
-
-    this.#listeners.delete(channel);
   }
 
   send(command: string, args: readonly RedisArg[] = []): Promise<unknown> {

--- a/packages/infra/src/schedule/registry.ts
+++ b/packages/infra/src/schedule/registry.ts
@@ -44,6 +44,13 @@ export class ScheduleEntry {
  * feature flag or a per-tenant schedule has nowhere else to live, and without it a
  * schedule changes only by redeploying. `trigger` also makes a schedule testable
  * without waiting for a minute boundary, which is `Bun.cron`'s resolution.
+ *
+ * **A one-shot is held until it is removed.** A `TIMEOUT` entry is marked
+ * `finished` when it fires and stays in the map, so `get` and `list` can still
+ * report it, and `remove(name)` is what reclaims it. Adding one per tenant or per
+ * event without removing it grows the map for the life of the process. dunx's own
+ * schedules are all added once at boot, so this only reaches an app calling `add`
+ * at runtime.
  */
 export class ScheduleRegistry {
   readonly #armed = new Map<string, Armed>();

--- a/scripts/ci.ts
+++ b/scripts/ci.ts
@@ -157,6 +157,34 @@ export const PHASES: readonly Phase[] = Object.freeze([
         run: ['bun', 'run', '--filter', '@dunx/example-databases', 'start'],
       },
       { name: 'scaffolds', run: ['bun', 'run', 'check:scaffolds'] },
+      /**
+       * The whole app under sustained mixed load, which is the only step that
+       * exercises the framework the way a deployment does: connection churn,
+       * concurrent writes, rate limiting, and a shutdown with traffic in flight.
+       * It found `/health/live` answering 429 behind a global `ThrottleGuard`,
+       * which no per-request test can see.
+       *
+       * Short enough that the leak verdict reports rather than judges - that
+       * needs minutes, and `bun run soak` locally is where it gets them. What
+       * this catches in 40 seconds is an unexpected status, a stalled loop, a
+       * subscriber that outlived its socket, and a shutdown that hangs.
+       */
+      {
+        name: 'soak',
+        run: [
+          'bun',
+          'run',
+          '--filter',
+          '@dunx/example-full',
+          'soak',
+          '--',
+          '--seconds',
+          '40',
+          '--concurrency',
+          '12',
+        ],
+        echo: 24,
+      },
     ],
   },
   {

--- a/tools/create-app/src/interactive.test.ts
+++ b/tools/create-app/src/interactive.test.ts
@@ -74,6 +74,27 @@ class Session {
     }
   }
 
+  /**
+   * Writes a key until the process goes away, or gives up.
+   *
+   * `waitFor` returns when the prompt's text is on screen, which is not the same
+   * moment the CLI starts reading raw bytes. On a loaded runner the gap is wide
+   * enough to swallow a keystroke, and a swallowed `\u0003` means nothing ever
+   * ends the process: this test failed that way in CI while passing on its own.
+   * Repeating is safe because the second one lands after the first has already
+   * torn the prompt down.
+   */
+  async pressUntilExit(key: string, attempts = 10): Promise<void> {
+    for (let i = 0; i < attempts; i += 1) {
+      this.#terminal.write(key);
+      const done = await Promise.race([
+        this.#process.exited.then(() => true),
+        Bun.sleep(250).then(() => false),
+      ]);
+      if (done) return;
+    }
+  }
+
   /** The exit code, or a failure naming what was on screen when it hung. */
   async exited(): Promise<number> {
     const code = await Promise.race([
@@ -126,8 +147,9 @@ describe('the CLI through a real terminal', () => {
 
     await session.waitFor('Space toggles');
     // Raw mode delivers this as a byte rather than a signal, so nothing ends the
-    // process unless the CLI does.
-    await session.press('\u0003');
+    // process unless the CLI does - and nothing at all if the byte arrives before
+    // the CLI is reading, which is why this repeats rather than pressing once.
+    await session.pressUntilExit('\u0003');
 
     expect(await session.exited()).toBe(130);
     expect(existsSync(join(cwd, 'billing'))).toBe(false);

--- a/tools/create-app/templates/features/chat/chat.demo.ts
+++ b/tools/create-app/templates/features/chat/chat.demo.ts
@@ -2,60 +2,9 @@ import { Logger, Module } from '@dunx/core';
 import { HttpFactory, PubSub, type HttpApp } from '@dunx/http';
 import { isConnectionError, RedisConnection } from '@dunx/infra/redis';
 import { RELAY_CHANNEL } from '../config.js';
+import { connect, type Client } from './ws-client.js';
 import { ChatGateway } from './chat.gateway.js';
 import { Lobby } from './lobby.service.js';
-
-interface Client {
-  next(): Promise<string>;
-  send(event: string, data: unknown): void;
-  close(): void;
-  /** Every frame this socket ever received, so a *second* delivery is visible. */
-  readonly received: readonly string[];
-}
-
-/** A real `new WebSocket()`, with a deadline so a stall fails instead of hanging. */
-const connect = async (base: string): Promise<Client> => {
-  const socket = new WebSocket(
-    new URL('chat', base).href.replace('http', 'ws'),
-  );
-  const frames: string[] = [];
-  const received: string[] = [];
-  const waiting: ((frame: string) => void)[] = [];
-
-  socket.addEventListener('message', (event: MessageEvent) => {
-    const frame = String(event.data);
-    received.push(frame);
-    const waiter = waiting.shift();
-    if (waiter) waiter(frame);
-    else frames.push(frame);
-  });
-  await new Promise<void>((resolve, reject) => {
-    socket.addEventListener('open', () => resolve(), { once: true });
-    setTimeout(() => reject(new Error('the socket never opened')), 2000);
-  });
-
-  return {
-    next: () =>
-      new Promise<string>((resolve, reject) => {
-        const queued = frames.shift();
-        if (queued !== undefined) {
-          resolve(queued);
-          return;
-        }
-        const timer = setTimeout(
-          () => reject(new Error('no frame arrived')),
-          2000,
-        );
-        waiting.push((frame) => {
-          clearTimeout(timer);
-          resolve(frame);
-        });
-      }),
-    send: (event, data) => socket.send(JSON.stringify({ event, data })),
-    close: () => socket.close(),
-    received,
-  };
-};
 
 /**
  * A second node in-process: two `Bun.serve` instances, two containers, two

--- a/tools/create-app/templates/features/chat/chat.module.ts
+++ b/tools/create-app/templates/features/chat/chat.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@dunx/core';
 import { CacheModule } from '../cache/cache.module.js';
 import { ChatDemo } from './chat.demo.js';
+import { PostgresRelayDemo } from './postgres-relay.demo.js';
 import { ChatGateway } from './chat.gateway.js';
 import { Lobby } from './lobby.service.js';
 
@@ -9,7 +10,7 @@ import { Lobby } from './lobby.service.js';
 @Module({
   // `RedisConnection`, for cross-process fan-out.
   imports: [CacheModule],
-  providers: [ChatGateway, Lobby, ChatDemo],
-  exports: [Lobby, ChatDemo],
+  providers: [ChatGateway, Lobby, ChatDemo, PostgresRelayDemo],
+  exports: [Lobby, ChatDemo, PostgresRelayDemo],
 })
 export class ChatModule {}

--- a/tools/create-app/templates/features/chat/postgres-relay.demo.ts
+++ b/tools/create-app/templates/features/chat/postgres-relay.demo.ts
@@ -1,0 +1,148 @@
+import { Logger, Module, provide } from '@dunx/core';
+import {
+  HttpFactory,
+  HttpOptionsProvider,
+  PubSub,
+  WsRelay,
+  WsRelayModule,
+  type PubSubRelay,
+} from '@dunx/http';
+import { RELAY_CHANNEL } from '../config.js';
+import { ChatGateway } from './chat.gateway.js';
+import { Lobby } from './lobby.service.js';
+import { connect } from './ws-client.js';
+
+/**
+ * Read here rather than injected: the module is declared at file scope, so it
+ * cannot reach `ConfigService`. The default matches `compose.yml` and the schema's.
+ */
+const POSTGRES_URL =
+  Bun.env['POSTGRES_URL'] ?? 'postgres://dunx:dunx@localhost:5432/dunx';
+
+/**
+ * The same fan-out as the Redis relay, over `Bun.SQL`'s `LISTEN`/`NOTIFY`, for an
+ * app that already has Postgres and would rather not run a broker.
+ *
+ * Two nodes, each with its own `WsRelayModule.forPostgres` and its own `PubSub`
+ * origin. Neither shares a container with the other, which is what makes the
+ * delivery real rather than a same-process shortcut.
+ */
+/**
+ * Binding the relay is not the same as using it. `WsRelayModule` puts a `WsRelay`
+ * in the container; what attaches it to `PubSub` is an `HttpOptionsProvider`
+ * answering `relay`, exactly as `AppHttpOptions` does for the app itself. Without
+ * this the nodes come up, the sockets work, and every publish stays local.
+ */
+class NodeHttpOptions extends HttpOptionsProvider {
+  constructor(private readonly bus: WsRelay) {
+    super();
+  }
+
+  override get relay(): PubSubRelay {
+    return this.bus;
+  }
+
+  override readonly relayChannel = RELAY_CHANNEL;
+}
+
+@Module({
+  imports: [WsRelayModule.forPostgres({ url: POSTGRES_URL })],
+  providers: [
+    ChatGateway,
+    Lobby,
+    // Bound to the token `HttpFactory` asks for, not registered as itself:
+    // the factory looks up `HttpOptionsProvider` and promotes a default when
+    // nothing answers it, so a bare subclass in `providers` is never consulted.
+    provide(HttpOptionsProvider, { useClass: NodeHttpOptions }),
+  ],
+})
+class PostgresNode {}
+
+/** Postgres caps a `NOTIFY` payload at 7999 bytes, envelope included. */
+const OVER_THE_NOTIFY_CAP = 9000;
+
+export class PostgresRelayDemo {
+  constructor(private readonly logger: Logger) {}
+
+  async demonstrate(): Promise<void> {
+    const { logger } = this;
+    if (!(await this.#postgresUp())) {
+      logger.warn(
+        `skipping the Postgres relay demo: nothing answering at ${POSTGRES_URL}`,
+      );
+      logger.info('`bun run services:up` starts it, and CI runs the same file');
+      return;
+    }
+
+    const [a, b] = await Promise.all([this.#node(), this.#node()]);
+    try {
+      logger.info(
+        `two nodes on LISTEN/NOTIFY, origins …${a.pubsub.origin.slice(-6)} / …${b.pubsub.origin.slice(-6)}`,
+      );
+
+      const [onA, onB] = await Promise.all([connect(a.url), connect(b.url)]);
+      await Promise.all([onA.next(), onB.next()]);
+
+      const said = 'across nodes, over Postgres';
+      a.pubsub.publishEvent(Lobby.TOPIC, 'said', said);
+      logger.info(
+        `node B's client <- ${await onB.next()} (relayed via NOTIFY)`,
+      );
+
+      await Bun.sleep(250);
+      const seen = (frames: readonly string[]): number =>
+        frames.filter((frame) => frame.includes(said)).length;
+      logger.info(
+        `deliveries: A ${seen(onA.received)}, B ${seen(onB.received)} ` +
+          '(one each, so the publisher did not fan its own frame out twice)',
+      );
+
+      // Postgres refuses the NOTIFY rather than truncating it. The publish is
+      // reported and fan-out stays local, which is the documented degradation.
+      const huge = 'x'.repeat(OVER_THE_NOTIFY_CAP);
+      a.pubsub.publishEvent(Lobby.TOPIC, 'said', huge);
+      await Bun.sleep(400);
+      const huge_ = (frames: readonly string[]): number =>
+        frames.filter((frame) => frame.includes(huge)).length;
+      logger.info(
+        `a ${OVER_THE_NOTIFY_CAP}-byte frame: A ${huge_(onA.received)}, B ${huge_(onB.received)} ` +
+          '(over the 7999-byte NOTIFY cap, so the publishing node still delivers ' +
+          'it and the relay reports one warn)',
+      );
+
+      onA.close();
+      onB.close();
+      await Bun.sleep(20);
+    } finally {
+      await Promise.all([a.app.shutdown(), b.app.shutdown()]);
+    }
+  }
+
+  async #node(): Promise<{
+    app: Awaited<ReturnType<typeof HttpFactory.create>>;
+    url: string;
+    pubsub: PubSub;
+  }> {
+    const app = await HttpFactory.create(PostgresNode, {
+      requestLogging: false,
+    });
+    const url = await app.listen(0);
+    return { app, url, pubsub: app.get(PubSub) };
+  }
+
+  /** A relay demo needs its backend; an absent one is a skip, not a failure. */
+  async #postgresUp(): Promise<boolean> {
+    const sql = new Bun.SQL(POSTGRES_URL, {
+      max: 1,
+      connectionTimeout: 2,
+    });
+    try {
+      await sql`select 1`;
+      return true;
+    } catch {
+      return false;
+    } finally {
+      await sql.close().catch(() => undefined);
+    }
+  }
+}

--- a/tools/create-app/templates/features/chat/postgres-relay.demo.ts
+++ b/tools/create-app/templates/features/chat/postgres-relay.demo.ts
@@ -19,6 +19,16 @@ import { connect } from './ws-client.js';
 const POSTGRES_URL =
   Bun.env['POSTGRES_URL'] ?? 'postgres://dunx:dunx@localhost:5432/dunx';
 
+/** Host and database only. The url carries a password and a log outlives it. */
+const where = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return 'the configured Postgres';
+  }
+};
+
 /**
  * The same fan-out as the Redis relay, over `Bun.SQL`'s `LISTEN`/`NOTIFY`, for an
  * app that already has Postgres and would rather not run a broker.
@@ -58,6 +68,12 @@ class NodeHttpOptions extends HttpOptionsProvider {
 })
 class PostgresNode {}
 
+interface Node {
+  readonly app: Awaited<ReturnType<typeof HttpFactory.create>>;
+  readonly url: string;
+  readonly pubsub: PubSub;
+}
+
 /** Postgres caps a `NOTIFY` payload at 7999 bytes, envelope included. */
 const OVER_THE_NOTIFY_CAP = 9000;
 
@@ -68,14 +84,19 @@ export class PostgresRelayDemo {
     const { logger } = this;
     if (!(await this.#postgresUp())) {
       logger.warn(
-        `skipping the Postgres relay demo: nothing answering at ${POSTGRES_URL}`,
+        `skipping the Postgres relay demo: nothing answering at ${where(POSTGRES_URL)}`,
       );
       logger.info('`bun run services:up` starts it, and CI runs the same file');
       return;
     }
 
-    const [a, b] = await Promise.all([this.#node(), this.#node()]);
+    // Started one at a time and collected as they come up. `Promise.all` rejects
+    // on the first failure and abandons a peer that had already bound a port,
+    // which keeps the process alive after the demo has given up.
+    const nodes: Node[] = [];
     try {
+      nodes.push(await this.#node(), await this.#node());
+      const [a, b] = nodes as [Node, Node];
       logger.info(
         `two nodes on LISTEN/NOTIFY, origins …${a.pubsub.origin.slice(-6)} / …${b.pubsub.origin.slice(-6)}`,
       );
@@ -114,20 +135,22 @@ export class PostgresRelayDemo {
       onB.close();
       await Bun.sleep(20);
     } finally {
-      await Promise.all([a.app.shutdown(), b.app.shutdown()]);
+      await Promise.all(nodes.map((node) => node.app.shutdown()));
     }
   }
 
-  async #node(): Promise<{
-    app: Awaited<ReturnType<typeof HttpFactory.create>>;
-    url: string;
-    pubsub: PubSub;
-  }> {
+  async #node(): Promise<Node> {
     const app = await HttpFactory.create(PostgresNode, {
       requestLogging: false,
     });
-    const url = await app.listen(0);
-    return { app, url, pubsub: app.get(PubSub) };
+    try {
+      const url = await app.listen(0);
+      return { app, url, pubsub: app.get(PubSub) };
+    } catch (error) {
+      // The container is up even when the port is not, so it is ours to close.
+      await app.shutdown();
+      throw error;
+    }
   }
 
   /** A relay demo needs its backend; an absent one is a skip, not a failure. */

--- a/tools/create-app/templates/features/chat/ws-client.ts
+++ b/tools/create-app/templates/features/chat/ws-client.ts
@@ -1,0 +1,59 @@
+/**
+ * A real `new WebSocket()` against the chat gateway, with a deadline so a stall
+ * fails instead of hanging.
+ *
+ * Shared rather than copied: both relay demos and the soak workload open sockets
+ * the same way, and a second copy of the frame-queue handling is where the two
+ * would drift.
+ */
+export interface Client {
+  next(): Promise<string>;
+  send(event: string, data: unknown): void;
+  close(): void;
+  /** Every frame this socket ever received, so a *second* delivery is visible. */
+  readonly received: readonly string[];
+}
+
+/** A real `new WebSocket()`, with a deadline so a stall fails instead of hanging. */
+export const connect = async (base: string): Promise<Client> => {
+  const socket = new WebSocket(
+    new URL('chat', base).href.replace('http', 'ws'),
+  );
+  const frames: string[] = [];
+  const received: string[] = [];
+  const waiting: ((frame: string) => void)[] = [];
+
+  socket.addEventListener('message', (event: MessageEvent) => {
+    const frame = String(event.data);
+    received.push(frame);
+    const waiter = waiting.shift();
+    if (waiter) waiter(frame);
+    else frames.push(frame);
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener('open', () => resolve(), { once: true });
+    setTimeout(() => reject(new Error('the socket never opened')), 2000);
+  });
+
+  return {
+    next: () =>
+      new Promise<string>((resolve, reject) => {
+        const queued = frames.shift();
+        if (queued !== undefined) {
+          resolve(queued);
+          return;
+        }
+        const timer = setTimeout(
+          () => reject(new Error('no frame arrived')),
+          2000,
+        );
+        waiting.push((frame) => {
+          clearTimeout(timer);
+          resolve(frame);
+        });
+      }),
+    send: (event, data) => socket.send(JSON.stringify({ event, data })),
+    close: () => socket.close(),
+    received,
+  };
+};

--- a/tools/create-app/templates/features/chat/ws-client.ts
+++ b/tools/create-app/templates/features/chat/ws-client.ts
@@ -43,14 +43,20 @@ export const connect = async (base: string): Promise<Client> => {
           resolve(queued);
           return;
         }
-        const timer = setTimeout(
-          () => reject(new Error('no frame arrived')),
-          2000,
-        );
-        waiting.push((frame) => {
+        const waiter = (frame: string): void => {
           clearTimeout(timer);
           resolve(frame);
-        });
+        };
+        // Dropped from the queue before rejecting, or the next frame is handed to
+        // this dead promise and discarded, and every later `next()` waits one
+        // frame behind. Only shows up after a timeout, which is when the test is
+        // already trying to explain itself.
+        const timer = setTimeout(() => {
+          const at = waiting.indexOf(waiter);
+          if (at !== -1) waiting.splice(at, 1);
+          reject(new Error('no frame arrived'));
+        }, 2000);
+        waiting.push(waiter);
       }),
     send: (event, data) => socket.send(JSON.stringify({ event, data })),
     close: () => socket.close(),

--- a/tools/create-app/templates/features/database/ledger.controller.ts
+++ b/tools/create-app/templates/features/database/ledger.controller.ts
@@ -7,7 +7,14 @@ import {
   Post,
   type Input,
 } from '@dunx/http';
-import { PAGINATION, type Page } from '@dunx/infra/pagination';
+import {
+  decodeCursor,
+  encodeCursor,
+  PAGINATION,
+  pageOf,
+  parsePageOptions,
+  type Page,
+} from '@dunx/infra/pagination';
 import { z } from 'zod';
 import { Ledger } from './ledger.service.js';
 import type { Entry } from './schema.js';
@@ -69,6 +76,18 @@ const pageQuery = z
   });
 
 const pagedEntries = { query: pageQuery } as const;
+const keyset = {
+  query: z.object({
+    take: z.coerce
+      .number()
+      .int()
+      .min(PAGINATION.MIN_TAKE)
+      .max(PAGINATION.MAX_TAKE)
+      .optional(),
+    cursor: z.string().max(PAGINATION.MAX_CURSOR).optional(),
+  }),
+} as const;
+
 const oneEntry = { params: EntryIndex } as const;
 const createEntry = { body: CreateEntry } as const;
 const transfer = { body: Transfer } as const;
@@ -150,6 +169,62 @@ export class LedgerController {
         `${(error as Error).message} - rolled back, still ${this.ledger.rows()} rows`,
       );
     }
+  }
+
+  /**
+   * Keyset pagination without the service: `parsePageOptions` reads the query the
+   * way the module's own docs suggest a schema does, `pageOf` shapes the envelope
+   * from rows the caller already has, and a cursor round-trips through
+   * `encodeCursor`/`decodeCursor`.
+   *
+   * The cursor is opaque on purpose and every malformed one collapses to the same
+   * `CursorError`, so `?cursor=not-a-cursor` answers 400 rather than telling the
+   * caller which layer rejected it.
+   */
+  @Get('/keyset', keyset)
+  keyset({ query }: Input<typeof keyset>): {
+    options: { take: number; direction: string; order: string };
+    page: Page<Entry>;
+    roundTrip: { encoded: string; decoded: { s: string; i: string } } | null;
+  } {
+    // Throws PageOptionsError on a take outside the range, which the framework
+    // renders as a 400 because the class carries the status.
+    const options = parsePageOptions(query as Record<string, unknown>);
+    // A cursor handed back in is decoded first, which is where a hand-written one
+    // fails, and it is what the next page is keyed from.
+    const roundTrip =
+      query.cursor === undefined
+        ? null
+        : { encoded: query.cursor, decoded: decodeCursor(query.cursor) };
+
+    const cursorOf = (row: Entry): string =>
+      // No timestamp on this table, so the id is both sort value and tiebreak.
+      encodeCursor(row.id, String(row.id));
+
+    // Descending ids, so the page after a cursor is everything below it. One row
+    // more than asked for is what answers `hasNextPage` without a second count.
+    const after = roundTrip === null ? undefined : Number(roundTrip.decoded.i);
+    const scanned = this.ledger
+      .list(PAGINATION.MAX_TAKE)
+      .filter((row) => after === undefined || row.id < after);
+    const rows = scanned.slice(0, options.take);
+
+    const page = pageOf(rows, {
+      take: options.take,
+      hasNextPage: scanned.length > options.take,
+      hasPreviousPage: after !== undefined,
+      cursorOf,
+    });
+
+    return {
+      options: {
+        take: options.take,
+        direction: options.direction,
+        order: options.order,
+      },
+      page,
+      roundTrip,
+    };
   }
 
   @Delete('/:id', oneEntry)

--- a/tools/create-app/templates/features/http/request-trail.ts
+++ b/tools/create-app/templates/features/http/request-trail.ts
@@ -1,9 +1,26 @@
 import type { BunRequest } from 'bun';
 import type { Middleware, Next, RouteContext } from '@dunx/http';
 
-/** The observable side effect: whatever the middleware saw is readable after. */
+/**
+ * The observable side effect: whatever the middleware saw is readable after.
+ *
+ * Capped, because this grows by one entry on **every request** and this folder is
+ * vendored into `@dunx/create-app`'s `http` feature. Unbounded it put 46 MiB on
+ * the heap across 3.1 million requests in the soak run and read as a framework
+ * leak until a heap census named the strings. A demo that keeps the last few
+ * hundred shows the same thing and survives production traffic.
+ */
+const KEEP = 500;
+
 export class RequestTrail {
   readonly entries: string[] = [];
+
+  record(entry: string): void {
+    this.entries.push(entry);
+    if (this.entries.length > KEEP) {
+      this.entries.splice(0, this.entries.length - KEEP);
+    }
+  }
 }
 
 /**
@@ -23,7 +40,7 @@ export class RequestTrailMiddleware implements Middleware {
     next: Next,
   ): Promise<Response> {
     const response = await next();
-    this.trail.entries.push(
+    this.trail.record(
       `${req.method} ${new URL(req.url).pathname} -> ${response.status} ` +
         `(${ctx.controller}.${ctx.handler})`,
     );

--- a/tools/create-app/templates/features/notes/notes.service.ts
+++ b/tools/create-app/templates/features/notes/notes.service.ts
@@ -1,6 +1,17 @@
 import { Logger } from '@dunx/core';
 import type { OnInit } from '@dunx/core';
 
+/**
+ * The list is capped, and the cap is the point.
+ *
+ * An in-memory demo store that only ever grows is a leak the moment anyone runs
+ * real traffic through it, and this folder is vendored into `@dunx/create-app`'s
+ * `notes` feature, so an unbounded array would ship into every scaffold. The soak
+ * run found it: 42,000 posts a minute put 250,000 retained strings on the heap and
+ * read as a framework leak until the census named them.
+ */
+const KEEP = 200;
+
 export class NotesService implements OnInit {
   readonly #rows = ['read the architecture doc', 'measure before deciding'];
 
@@ -16,6 +27,9 @@ export class NotesService implements OnInit {
 
   add(text: string): readonly string[] {
     this.#rows.push(text);
+    if (this.#rows.length > KEEP) {
+      this.#rows.splice(0, this.#rows.length - KEEP);
+    }
     return this.#rows;
   }
 }

--- a/tools/create-app/templates/features/schedule/maintenance.service.ts
+++ b/tools/create-app/templates/features/schedule/maintenance.service.ts
@@ -1,5 +1,5 @@
-import { Counter, Logger } from '@dunx/core';
-import { Cron, Interval, OnceOnBoot } from '@dunx/infra/schedule';
+import { Counter, Gauge, Logger } from '@dunx/core';
+import { Cron, Interval, OnceOnBoot, Overlap } from '@dunx/infra/schedule';
 
 /**
  * The three schedule decorators on one class, discovered off the prototype chain
@@ -41,6 +41,44 @@ export class Maintenance {
     await Bun.sleep(1);
     this.#compactions.inc();
     return this.#compactions.value;
+  }
+
+  readonly #slow = new Counter();
+  /**
+   * A `Gauge`, not `#inFlight += 1`. A compound assignment to a private field in
+   * a class that also has a decorated member is a `SyntaxError` in Bun's parser,
+   * still on 1.4.2 - which is what the note at the top of this class is about,
+   * and which this method walked straight into before it was written this way.
+   */
+  readonly #inFlight = new Gauge();
+  readonly #peak = new Gauge();
+
+  /**
+   * `overlap: Overlap.CONCURRENT`, which is the half `skip` hides.
+   *
+   * The default refuses to start a run while the last one is still going, so a
+   * handler that outlives its own cadence quietly runs at the rate it can finish.
+   * `concurrent` starts anyway, and `maxInFlight` is how you can tell: triggered
+   * twice inside its own sleep it reaches 2, where the sweep above stays at 1.
+   */
+  @Interval(600_000, {
+    name: 'maintenance.overlapping',
+    overlap: Overlap.CONCURRENT,
+  })
+  async overlappingWork(): Promise<number> {
+    this.#inFlight.inc();
+    this.#peak.set(Math.max(this.#peak.value, this.#inFlight.value));
+    try {
+      await Bun.sleep(40);
+      this.#slow.inc();
+      return this.#slow.value;
+    } finally {
+      this.#inFlight.dec();
+    }
+  }
+
+  get overlapping(): { runs: number; maxInFlight: number } {
+    return { runs: this.#slow.value, maxInFlight: this.#peak.value };
   }
 
   get counts(): { sweeps: number; compactions: number; warmed: boolean } {

--- a/tools/create-app/templates/features/schedule/schedule.demo.ts
+++ b/tools/create-app/templates/features/schedule/schedule.demo.ts
@@ -41,6 +41,18 @@ export class ScheduleDemo {
         'neither waited for a clock',
     );
 
+    // Two triggers inside one run's own sleep. `concurrent` lets the second start,
+    // so both are in flight at once; the default would have skipped it.
+    await Promise.all([
+      this.registry.trigger('maintenance.overlapping'),
+      this.registry.trigger('maintenance.overlapping'),
+    ]);
+    const overlapping = this.maintenance.overlapping;
+    this.logger.info(
+      `overlap: concurrent -> ${overlapping.runs} runs, ` +
+        `${overlapping.maxInFlight} in flight at once (skip would hold it at 1)`,
+    );
+
     const entry = this.registry.get('maintenance.compact');
     this.logger.info(
       `runs recorded on the entry -> ${entry?.runs ?? 0}, lastError ` +


### PR DESCRIPTION
A soak harness for `examples/full` plus the framework fixes it surfaced. `bun run ci` green, 13/13.

**Framework fixes**

- `HealthController` carried `@Public()` but not `@SkipThrottle()`, so `app.use(ThrottleGuard)` rate-limited the probes. At 10k rps the soak got 429 on 10,511 of 11,511 liveness checks: an orchestrator reads that as unhealthy and restarts a pod that is merely busy.
- `ThrottleOptions` died with `undefined is not an object` before it could print the careful message it has for a missing prefix. `forRootAsync` off an unset env var hits exactly that.
- The SQLite transaction depth counter strands on a failed `BEGIN` (`SQLITE_BUSY`, or a transaction something else opened), permanently. Every later transaction then becomes a bare `SAVEPOINT`, so two unrelated top-level transactions nest and one rolling back discards the other's committed work.
- The Redis subscription registry kept entries for failed `SUBSCRIBE`/`UNSUBSCRIBE`. The key is caller-supplied, so per-room fan-out against a flapping broker leaks one entry per channel, with no sweep.

Each has a test that fails without the fix.

**The harness**

Sixteen weighted operations across HTTP, websocket churn, SQLite, Redis, validation failures, unmatched paths and rate limiting. The leak verdict is settled heap across rounds, each ending in a forced GC, because an in-flight slope measures the allocator: RSS climbed 11 MiB/min on a run whose `heapUsed` was falling.

It found two unbounded stores, both here rather than in the framework, and both vendored into `@dunx/create-app`: `RequestTrail.entries` grew by one string on every request (46 MiB over 3.1M requests) and `NotesService.#rows` on every POST. Capped.

Clean run after: 3,185,066 calls at 10,473/s, 0 failures, settled heap flat 19.4 to 19.8 MiB over ten rounds, max loop stall 3 ms.

**CI**

The examples job declared no services, so the relay fan-out, queue workers, Redis cache and shared throttle store skipped on every run. It has valkey and postgres now, and a 40-second soak step. This contradicts CLAUDE.md's "and nowhere else" for services, which is about the coverage denominator and does not apply to a job that measures none, so that paragraph is updated too. Worth a look, since it is your rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Full examples now support sustained HTTP and WebSocket soak testing.
  - Added a PostgreSQL-backed WebSocket relay demonstration for cross-node messaging.
  - Added service setup for running full examples with Valkey and PostgreSQL.
  - Added warnings when many distinct queues retain connections.

- **Bug Fixes**
  - Improved transaction error handling when setup fails.
  - Preserved subscription listeners when subscription changes fail.
  - Added validation for empty or invalid throttle prefixes.
  - Limited request-trail and notes retention to prevent unbounded memory growth.

- **Tests**
  - Expanded coverage for health checks, throttling, transactions, queue usage, and long-running workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->