### PR TITLE
fix(ci): retry the image pull that turned main red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
 
+      - name: Build
+        run: bun run ci build
+
       # `examples/full/compose.yml` rather than a `services:` block, so what the
       # example needs is described once and the same command brings it up on a
       # laptop. It also gets the images from public.ecr.aws, which a `services:`
       # block would too but nobody would notice was load bearing.
+      #
+      # **After the build, and it has to be.** The script runs from
+      # `examples/full`, so Bun reads that directory's bunfig and tries to preload
+      # `@dunx/transform/preload` - which is `packages/transform/dist`, and does
+      # not exist until the build has run. Before it, this step died with
+      # `preload not found` having pulled nothing.
       - name: Start the services the example needs
         run: bun run --filter '@dunx/example-full' services:up
-
-      - name: Build
-        run: bun run ci build
 
       # Every example is a bootstrap that rots the moment nobody runs it. An
       # example whose backing service is absent (Redis, Postgres, MySQL, S3)

--- a/examples/full/package.json
+++ b/examples/full/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "bun --watch src/main.ts",
     "services:down": "docker compose down -v",
-    "services:up": "docker compose up -d --wait",
+    "services:up": "bun services.ts",
     "soak": "bun src/soak/soak.ts",
     "start": "bun src/main.ts",
     "test": "bun test",

--- a/examples/full/services.ts
+++ b/examples/full/services.ts
@@ -1,0 +1,46 @@
+/**
+ * `compose pull` with retries, then `compose up --wait`.
+ *
+ * A registry throttles anonymous pulls and a CI runner shares its IP with every
+ * other runner on the host, so the pull is the one step here that fails for
+ * reasons that have nothing to do with the change under test. Moving off Docker
+ * Hub to public.ecr.aws bought a much larger budget and not an unlimited one:
+ * `toomanyrequests: Rate exceeded` turned up on main the first time this ran, and
+ * three pulls in a row hit it locally while the file was being written.
+ *
+ * So the pull is separated from the start and retried. `up --wait` afterwards is
+ * offline once the images are local, and it is the part that must not be retried
+ * blindly: a container that fails its healthcheck is a real failure.
+ */
+const ATTEMPTS = 5;
+
+const run = async (args: readonly string[]): Promise<number> => {
+  const proc = Bun.spawn(['docker', 'compose', ...args], {
+    cwd: import.meta.dir,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  return proc.exited;
+};
+
+const pull = async (): Promise<void> => {
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    if ((await run(['pull', '--quiet'])) === 0) return;
+    if (attempt === ATTEMPTS) {
+      throw new Error(
+        `docker compose pull failed ${ATTEMPTS} times. The last one is above; a ` +
+          'rate limit is the usual reason and it clears on its own.',
+      );
+    }
+    // 2s, 4s, 8s, 16s. A throttle window is seconds, not minutes.
+    const waitMs = 2000 * 2 ** (attempt - 1);
+    console.log(
+      `pull failed, retrying in ${waitMs / 1000}s (${attempt}/${ATTEMPTS - 1})`,
+    );
+    await Bun.sleep(waitMs);
+  }
+};
+
+await pull();
+const code = await run(['up', '-d', '--wait']);
+process.exit(code);

--- a/examples/full/tsconfig.json
+++ b/examples/full/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"],
+  "include": ["src", "services.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
`Examples, tour and scaffolds` failed on main with `toomanyrequests: Rate exceeded` from public.ecr.aws, before any test ran.

Moving off Docker Hub bought a bigger pull budget, not an unlimited one - the compose file already said so, and this is that prediction landing. `services:up` now retries `compose pull` with backoff (2s, 4s, 8s, 16s), then runs `compose up --wait` once. The start is not retried: once the images are local it is offline, and a failed healthcheck is a real failure.

Also names the script in the example's tsconfig `include`. Without that `tsc` passed (it only walks `src`) while oxlint's type-aware pass failed on the same file for want of Bun's types - caught by the pre-commit hook, not by me.

`bun run ci` green, 13/13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service startup reliability by retrying Docker image downloads when temporary failures occur.
  - Services now wait until they are ready before startup completes.
  - Startup failures now return the correct process status.

- **Developer Experience**
  - The full example’s service command now uses a dedicated runner for more consistent local setup.
  - Example builds now complete before required services are started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->