### PR TITLE
test(examples): load-run oracle, negative-flow suites, and three fixes they found

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -226,7 +226,7 @@ header (`MISSING_OR_NULL_ORIGIN`), so a server-side client has to send one match
 
 ### The origin check is off under `NODE_ENV=test`
 
-Which `bun test` sets, so no suite in this repo can assert it. Measured on
+Which `bun test` sets, so an in-process suite cannot observe it. Measured on
 `examples/full`, signing in with a session cookie and no `Origin`:
 
 | `NODE_ENV`  | status |
@@ -239,8 +239,15 @@ Which `bun test` sets, so no suite in this repo can assert it. Measured on
 A wrong `Origin` behaves the same way: 403 `INVALID_ORIGIN` with `NODE_ENV`
 unset, 200 under `bun test`. Both halves of the check are exempt, not one.
 
-`examples/full/src/auth.test.ts` asserts the 200 and says why. The test worth
-writing is the 403, and it fails: reading that failure as better-auth not
-checking the origin is the way this ends with someone deleting a security
-control. The tour never met it because `auth.demo.ts` sends a trusted `Origin`
-on every call.
+So the suite asserts both halves and needs two processes to do it. In-process
+it asserts the 200 and says why, because the test worth writing is the 403 and
+it fails there: reading that failure as better-auth not checking the origin is
+the way this ends with someone deleting a security control. The 403 is asserted
+against a spawned `NODE_ENV=production`, which is the same spawn the shutdown
+suite uses, and covers `MISSING_OR_NULL_ORIGIN` and `INVALID_ORIGIN` both.
+
+Sign-up and sign-in there carry no `Origin` at all. The check fires on a
+cookie-bearing request, and a present-but-untrusted origin is refused with or
+without one, so sending none until there is a cookie is what keeps the two
+assertions about the cookie-bearing case. The tour never met any of this because
+`auth.demo.ts` sends a trusted `Origin` on every call.

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -223,3 +223,24 @@ drops what follows the first semicolon - four `CREATE TABLE`s in one template gi
 one table. And better-auth rejects a cookie-bearing state change with no `Origin`
 header (`MISSING_OR_NULL_ORIGIN`), so a server-side client has to send one matching
 `trustedOrigins`; a browser does it for free.
+
+### The origin check is off under `NODE_ENV=test`
+
+Which `bun test` sets, so no suite in this repo can assert it. Measured on
+`examples/full`, signing in with a session cookie and no `Origin`:
+
+| `NODE_ENV`  | status |
+| ----------- | ------ |
+| unset       | 403    |
+| test        | 200    |
+| development | 403    |
+| production  | 403    |
+
+A wrong `Origin` behaves the same way: 403 `INVALID_ORIGIN` with `NODE_ENV`
+unset, 200 under `bun test`. Both halves of the check are exempt, not one.
+
+`examples/full/src/auth.test.ts` asserts the 200 and says why. The test worth
+writing is the 403, and it fails: reading that failure as better-auth not
+checking the origin is the way this ends with someone deleting a security
+control. The tour never met it because `auth.demo.ts` sends a trusted `Origin`
+on every call.

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -139,6 +139,29 @@ Consequences, all measured:
 
 No `Symbol.metadata`, no polyfill, no import-order dependence.
 
+### Who knows the global prefix
+
+`routesOf` walks prototypes, so it reads the path a `@Get` declared. The prefix is
+applied at `listen()`, and neither of the two places it could come from answers
+what the router ended up with: `HttpOptionsProvider.prefix` is a getter read once
+during option resolution, and `setGlobalPrefix()` may run after `create()`.
+
+So `listen()` attaches the resolved value to `RoutePrefix`, which is bound in the
+global wrapper for the reason above. `@dunx/dashboard` injects it and its route
+panel reported `/notes` for a route served at `/api/notes` without it, which an
+operator would copy and get a 404 from. That package's own suite pins both
+halves.
+
+Gateways are the half that must not be prefixed. `listen()` builds the upgrade
+table from the gateway paths untouched, so `@Gateway('/chat')` is served at
+`/chat` whatever the routes carry. Applying the prefix to both would have broken
+the panel it was fixing, which is why that suite asserts a socket upgrade against
+the path the panel reports.
+
+`@dunx/mcp` reads the same routes and cannot do this: it never boots the app, so
+there is no `listen()` to have resolved anything. It reports what the code
+declares.
+
 ### Declined: trailing-slash normalisation
 
 `GET /t` is a 200, and `GET /t/` is a 404. Nest, Express and Fastify all

--- a/docs/architecture/tooling.md
+++ b/docs/architecture/tooling.md
@@ -369,3 +369,77 @@ static to read.
 So the split is: routes are static and need no file, contributions are not and do.
 `DocumentSource` improved the file rather than removing it, since a config file
 can now hand over a provider instead of a thunk.
+
+## The load run measured the rate limiter, not the app
+
+`examples/full`'s soak is the only step that puts the whole framework under
+sustained traffic, and for its first version the traffic did not reach the
+handlers. Every operation named a set of acceptable statuses and every set
+included 429, so a run that was refused end to end reported no failures.
+
+Reading `RequestMetrics` after a 40 s run at concurrency 12 gave the shape:
+
+| status | share |
+| ------ | ----- |
+| 200    | 28.9% |
+| 201    | 3.4%  |
+| 429    | 59.4% |
+
+The example's `THROTTLE_LIMIT` is 1,000 per 60 s and the run was doing about
+9,000 requests a second, so each route spent its budget inside the first second
+and the remaining 40 s measured refusals. Every route showed exactly 1,000
+non-429 answers and a mean of 1.05 ms, which is the guard's cost rather than a
+handler's.
+
+Three changes, and the third is the one that generalises:
+
+- `THROTTLE_LIMIT` is raised for the run, so the app is what is under load.
+  `/limits/burst` keeps its own `@Throttle` of three per minute and is what
+  proves refusals still happen.
+- Each worker sends its own `x-api-key`. `ThrottleModule`'s `subject` reads that
+  header before falling back to the address, and every worker shared one
+  loopback address, so the whole run shared one budget.
+- An operation now names the statuses that are **work** and the statuses that
+  are a **refusal** separately, and the run floors the ratio. One accept-set per
+  operation cannot tell "the app served 8,000 requests" from "the app declined
+  8,000 requests", and that is the distinction a load test exists to make.
+
+The same window afterwards: 67.6% 200, 13.3% 201, and 4.8% 429 all on
+`/limits/burst`.
+
+### What a raised budget stopped covering
+
+The run that found `/health/live` answering 429 behind a global `ThrottleGuard`
+can no longer reach the limit on a probe. So the exemption is asserted directly
+instead: a counted route carries `ratelimit-limit` on the response it allowed,
+and a `@SkipThrottle()` route carries no such header at all. `throttle.test.ts`
+covers the policy against a budget of five, where exhausting it is three
+requests rather than a load run.
+
+### Shutdown with traffic in flight
+
+The harness awaited every worker before calling `shutdown()`, so the phase named
+after connection churn ran against an idle server. It now starts the traffic,
+waits for the workers to have requests on the wire, shuts down underneath them,
+and asserts that the run settles rather than hanging on a socket the server left
+open. Workers are stopped once the port closes: left running to their deadline
+they retry a refused connection as fast as the loop allows, and one 8-second
+window logged 189,803 of those.
+
+### The leak verdict
+
+An in-flight memory slope measures the allocator as much as the program. RSS
+climbed 11 MiB/min on a run whose `heapUsed` was falling and whose settled RSS
+came back 20 MiB below its own peak, because an arena grows under load and is
+returned lazily.
+
+So the run is split into rounds, each ending with a forced GC and a quiet
+sample, and the least-squares fit is over those. A leak survives a GC; an arena
+does not. RSS is reported rather than judged, for the same reason.
+
+The threshold is 2 MiB/min, which is roughly 3 GiB a day: a pod restarting on a
+memory limit inside a week. A settled reading carries about +/-2.5 MiB of GC
+noise, so both the fitted slope and the raw first-to-last rise have to clear
+that before the run fails, and a window under three minutes reports the trend
+instead of judging it. Saying otherwise would be a coin toss dressed as a gate,
+which is why the CI run at 40 seconds prints the number and does not fail on it.

--- a/docs/architecture/tooling.md
+++ b/docs/architecture/tooling.md
@@ -413,8 +413,9 @@ The run that found `/health/live` answering 429 behind a global `ThrottleGuard`
 can no longer reach the limit on a probe. So the exemption is asserted directly
 instead: a counted route carries `ratelimit-limit` on the response it allowed,
 and a `@SkipThrottle()` route carries no such header at all. `throttle.test.ts`
-covers the policy against a budget of five, where exhausting it is three
-requests rather than a load run.
+covers the policy at a module default of five requests per 60 s, where spending
+a budget is six requests rather than a load run, and `/limits/burst` keeps its
+own `@Throttle` of three so a handler overriding the module is covered too.
 
 ### Shutdown with traffic in flight
 

--- a/examples/full/src/auth.test.ts
+++ b/examples/full/src/auth.test.ts
@@ -186,8 +186,9 @@ it('refuses a second sign-up for the same address', async () => {
 /**
  * better-auth refuses a cookie-bearing state change whose `Origin` is missing or
  * untrusted, and **the whole check is off when `NODE_ENV` is `test`**, which
- * `bun test` sets. So this asserts the exemption rather than the protection: the
- * obvious test, expecting a 403, fails here for that reason alone.
+ * `bun test` sets. So the obvious test, expecting a 403, fails here for that
+ * reason alone. This asserts the exemption; the protection is asserted at the
+ * bottom of the file, against a spawned `NODE_ENV=production`.
  * See docs/architecture/authentication.md, "The origin check is off".
  */
 it('does not enforce the origin check under bun test, which sets NODE_ENV=test', async () => {
@@ -220,3 +221,90 @@ it('stops admitting the cookie after sign-out', async () => {
   const after = await profile({ cookie: session.cookie });
   expect(after.status).toBe(401);
 });
+
+/**
+ * The protection itself, which the suite above cannot reach: `bun test` sets
+ * `NODE_ENV=test` for this process and better-auth reads it. So the app is
+ * spawned with `NODE_ENV=production`, the way `shutdown.test.ts` spawns it, and
+ * the flow is driven over HTTP from here.
+ *
+ * Sign-up and sign-in carry no `Origin` on purpose: the check fires on a
+ * cookie-bearing request, and a *present but untrusted* origin is refused with
+ * or without one. Sending none until there is a cookie is what makes the two
+ * assertions below about the cookie-bearing case specifically.
+ */
+it('enforces the origin check outside test mode', async () => {
+  const proc = Bun.spawn(['bun', 'src/main.ts'], {
+    cwd: new URL('..', import.meta.url).pathname,
+    env: { ...process.env, NODE_ENV: 'production', PORT: '0' },
+    stdout: 'pipe',
+    stderr: 'inherit',
+  });
+
+  try {
+    let text = '';
+    const decoder = new TextDecoder();
+    const reading = (async () => {
+      for await (const chunk of proc.stdout) {
+        text += decoder.decode(chunk, { stream: true });
+      }
+    })();
+    while (!text.includes('ctrl-c to stop')) await Bun.sleep(20);
+    const spawned = /listening on (http:\/\/[^\s"]+)/.exec(text)?.[1] ?? '';
+    expect(spawned).not.toBe('');
+    const origin = new URL(spawned).origin;
+
+    const account = {
+      email: 'origin@example.test',
+      password: 'a long enough password',
+      name: 'Origin',
+    };
+    const call = (
+      endpoint: string,
+      body: unknown,
+      headers: Record<string, string> = {},
+    ): Promise<Response> =>
+      fetch(`${origin}/api/auth/${endpoint}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...headers },
+        body: JSON.stringify(body),
+      });
+
+    expect((await call('sign-up/email', account)).status).toBe(200);
+    const signIn = await call('sign-in/email', {
+      email: account.email,
+      password: account.password,
+    });
+    expect(signIn.status).toBe(200);
+    const cookie = signIn.headers
+      .getSetCookie()
+      .map((entry) => entry.split(';')[0])
+      .join('; ');
+    expect(cookie).not.toBe('');
+
+    const credentials = {
+      email: account.email,
+      password: account.password,
+    };
+    const missing = await call('sign-in/email', credentials, { cookie });
+    expect(missing.status).toBe(403);
+    expect((await missing.json()) as { code: string }).toMatchObject({
+      code: 'MISSING_OR_NULL_ORIGIN',
+    });
+
+    const untrusted = await call('sign-in/email', credentials, {
+      cookie,
+      origin: 'http://evil.example',
+    });
+    expect(untrusted.status).toBe(403);
+    expect((await untrusted.json()) as { code: string }).toMatchObject({
+      code: 'INVALID_ORIGIN',
+    });
+
+    proc.kill('SIGTERM');
+    await proc.exited;
+    await reading;
+  } finally {
+    if (!proc.killed) proc.kill('SIGKILL');
+  }
+}, 60_000);

--- a/examples/full/src/auth.test.ts
+++ b/examples/full/src/auth.test.ts
@@ -1,0 +1,192 @@
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { Auth } from '@dunx/auth';
+import type { HttpApp } from '@dunx/http';
+import { SyncDatabase } from '@dunx/infra/db';
+import { eq } from 'drizzle-orm';
+import type * as schema from './database/schema.js';
+import { user } from './database/schema.js';
+import { createApp } from './main.js';
+
+/**
+ * better-auth mounted, and `SessionGuard` in front of `/api/profile`.
+ *
+ * `auth.demo.ts` walks this same flow during the tour and logs each status;
+ * nothing asserted any of it, so the whole authenticated half of the example was
+ * covered by an exit code. Every credential here is minted by the suite against
+ * an in-memory database, so nothing carries between runs.
+ */
+let app: HttpApp;
+let base = '';
+/** What better-auth checks a state-changing request's `Origin` against. */
+let origin = '';
+
+const CREDENTIALS = {
+  email: 'grace@example.test',
+  password: 'a long enough password',
+  name: 'Grace',
+};
+
+const authPost = (
+  endpoint: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<Response> =>
+  fetch(`${base}/api/auth/${endpoint}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin, ...headers },
+    body: JSON.stringify(body),
+  });
+
+const profile = (
+  headers: Record<string, string> = {},
+  path = '',
+): Promise<Response> => fetch(`${base}/api/profile${path}`, { headers });
+
+/** The `bearer` plugin returns a token in a header; the cookie is the other half. */
+const credentialsFrom = (
+  response: Response,
+): { token: string; cookie: string } => ({
+  token: response.headers.get('set-auth-token') ?? '',
+  cookie: response.headers
+    .getSetCookie()
+    .map((entry) => entry.split(';')[0])
+    .join('; '),
+});
+
+let session: { token: string; cookie: string } = { token: '', cookie: '' };
+
+beforeAll(async () => {
+  app = await createApp();
+  base = new URL(await app.listen(0)).origin;
+  // The server is on port 0, so its own origin is not what better-auth trusts.
+  origin = (await app.get(Auth).$context).baseURL;
+
+  expect((await authPost('sign-up/email', CREDENTIALS)).status).toBe(200);
+  const signIn = await authPost('sign-in/email', {
+    email: CREDENTIALS.email,
+    password: CREDENTIALS.password,
+  });
+  expect(signIn.status).toBe(200);
+  session = credentialsFrom(signIn);
+});
+
+afterAll(async () => {
+  await app.shutdown();
+});
+
+it('mints a session cookie and a bearer token at sign-in', () => {
+  expect(session.cookie).not.toBe('');
+  expect(session.token).not.toBe('');
+});
+
+it('refuses a guarded route with no credentials', async () => {
+  const response = await profile();
+
+  expect(response.status).toBe(401);
+});
+
+it('refuses a guarded route with a bearer token that is not one', async () => {
+  const response = await profile({ authorization: 'Bearer not-a-real-token' });
+
+  expect(response.status).toBe(401);
+});
+
+it('refuses a guarded route with a forged session cookie', async () => {
+  const response = await profile({
+    cookie: 'better-auth.session_token=forged.signature',
+  });
+
+  expect(response.status).toBe(401);
+});
+
+it('admits the session cookie and names the caller', async () => {
+  const response = await profile({ cookie: session.cookie });
+
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { email: string; sessionId: string };
+  expect(body.email).toBe(CREDENTIALS.email);
+  expect(body.sessionId).not.toBe('');
+});
+
+it('admits the bearer token as well as the cookie', async () => {
+  const response = await profile({
+    authorization: `Bearer ${session.token}`,
+  });
+
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { email: string };
+  expect(body.email).toBe(CREDENTIALS.email);
+});
+
+it('skips the guard entirely on a @Public() route', async () => {
+  const response = await profile({}, '/anonymous');
+
+  expect(response.status).toBe(200);
+  // No session is looked up, so a caller is not established even with a cookie.
+  expect(await response.json()).toEqual({ caller: null });
+});
+
+it('forbids @Roles("admin") for a signed-in user without the role', async () => {
+  const response = await profile({ cookie: session.cookie }, '/audit');
+
+  // Authenticated and refused: 403 rather than the 401 above.
+  expect(response.status).toBe(403);
+});
+
+it('admits @Roles("admin") once the role is on the user', async () => {
+  app
+    .get(SyncDatabase<typeof schema>)
+    .update(user)
+    .set({ role: 'admin' })
+    .where(eq(user.email, CREDENTIALS.email))
+    .run();
+
+  const response = await profile({ cookie: session.cookie }, '/audit');
+
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { caller: string };
+  expect(body.caller).toBe(CREDENTIALS.email);
+});
+
+it('refuses a sign-in with the wrong password', async () => {
+  const response = await authPost('sign-in/email', {
+    email: CREDENTIALS.email,
+    password: 'not the password',
+  });
+
+  expect(response.status).toBe(401);
+});
+
+it('refuses a sign-in for an address that never signed up', async () => {
+  const response = await authPost('sign-in/email', {
+    email: 'nobody@example.test',
+    password: 'a long enough password',
+  });
+
+  expect(response.status).toBe(401);
+});
+
+it('refuses a sign-up under the minimum password length', async () => {
+  const response = await authPost('sign-up/email', {
+    email: 'short@example.test',
+    password: 'short',
+    name: 'Short',
+  });
+
+  expect(response.status).toBe(400);
+});
+
+it('refuses a second sign-up for the same address', async () => {
+  const response = await authPost('sign-up/email', CREDENTIALS);
+
+  expect(response.status).toBeGreaterThanOrEqual(400);
+  expect(response.status).toBeLessThan(500);
+});
+
+it('stops admitting the cookie after sign-out', async () => {
+  const signOut = await authPost('sign-out', {}, { cookie: session.cookie });
+  expect(signOut.status).toBe(200);
+
+  const after = await profile({ cookie: session.cookie });
+  expect(after.status).toBe(401);
+});

--- a/examples/full/src/auth.test.ts
+++ b/examples/full/src/auth.test.ts
@@ -183,6 +183,36 @@ it('refuses a second sign-up for the same address', async () => {
   expect(response.status).toBeLessThan(500);
 });
 
+/**
+ * better-auth refuses a cookie-bearing state change whose `Origin` is missing or
+ * untrusted, and **the whole check is off when `NODE_ENV` is `test`**, which
+ * `bun test` sets. So this asserts the exemption rather than the protection: the
+ * obvious test, expecting a 403, fails here for that reason alone.
+ * See docs/architecture/authentication.md, "The origin check is off".
+ */
+it('does not enforce the origin check under bun test, which sets NODE_ENV=test', async () => {
+  expect(Bun.env['NODE_ENV']).toBe('test');
+
+  const signIn = (origin?: string): Promise<Response> =>
+    fetch(`${base}/api/auth/sign-in/email`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        cookie: session.cookie,
+        ...(origin === undefined ? {} : { origin }),
+      },
+      body: JSON.stringify({
+        email: CREDENTIALS.email,
+        password: CREDENTIALS.password,
+      }),
+    });
+
+  // Both halves of the check, both exempt: outside test mode these are
+  // MISSING_OR_NULL_ORIGIN and INVALID_ORIGIN respectively.
+  expect((await signIn()).status).toBe(200);
+  expect((await signIn('http://evil.example')).status).toBe(200);
+});
+
 it('stops admitting the cookie after sign-out', async () => {
   const signOut = await authPost('sign-out', {}, { cookie: session.cookie });
   expect(signOut.status).toBe(200);

--- a/examples/full/src/auth.test.ts
+++ b/examples/full/src/auth.test.ts
@@ -6,6 +6,7 @@ import { eq } from 'drizzle-orm';
 import type * as schema from './database/schema.js';
 import { user } from './database/schema.js';
 import { createApp } from './main.js';
+import { SpawnedApp } from './spawn-app.js';
 
 /**
  * better-auth mounted, and `SessionGuard` in front of `/api/profile`.
@@ -234,26 +235,10 @@ it('stops admitting the cookie after sign-out', async () => {
  * assertions below about the cookie-bearing case specifically.
  */
 it('enforces the origin check outside test mode', async () => {
-  const proc = Bun.spawn(['bun', 'src/main.ts'], {
-    cwd: new URL('..', import.meta.url).pathname,
-    env: { ...process.env, NODE_ENV: 'production', PORT: '0' },
-    stdout: 'pipe',
-    stderr: 'inherit',
-  });
+  const spawned = new SpawnedApp();
 
   try {
-    let text = '';
-    const decoder = new TextDecoder();
-    const reading = (async () => {
-      for await (const chunk of proc.stdout) {
-        text += decoder.decode(chunk, { stream: true });
-      }
-    })();
-    while (!text.includes('ctrl-c to stop')) await Bun.sleep(20);
-    const spawned = /listening on (http:\/\/[^\s"]+)/.exec(text)?.[1] ?? '';
-    expect(spawned).not.toBe('');
-    const origin = new URL(spawned).origin;
-
+    const origin = new URL(await spawned.serving()).origin;
     const account = {
       email: 'origin@example.test',
       password: 'a long enough password',
@@ -282,10 +267,7 @@ it('enforces the origin check outside test mode', async () => {
       .join('; ');
     expect(cookie).not.toBe('');
 
-    const credentials = {
-      email: account.email,
-      password: account.password,
-    };
+    const credentials = { email: account.email, password: account.password };
     const missing = await call('sign-in/email', credentials, { cookie });
     expect(missing.status).toBe(403);
     expect((await missing.json()) as { code: string }).toMatchObject({
@@ -301,10 +283,8 @@ it('enforces the origin check outside test mode', async () => {
       code: 'INVALID_ORIGIN',
     });
 
-    proc.kill('SIGTERM');
-    await proc.exited;
-    await reading;
+    expect(await spawned.stop()).toBe(0);
   } finally {
-    if (!proc.killed) proc.kill('SIGKILL');
+    spawned.kill();
   }
 }, 60_000);

--- a/examples/full/src/auth/auth.demo.ts
+++ b/examples/full/src/auth/auth.demo.ts
@@ -124,8 +124,13 @@ export class AuthDemo {
     );
   }
 
-  /** better-auth rejects a cookie-bearing state change with no `Origin`
-   * (`MISSING_OR_NULL_ORIGIN`); it has to match `trustedOrigins`. */
+  /**
+   * better-auth rejects a cookie-bearing state change with no `Origin`
+   * (`MISSING_OR_NULL_ORIGIN`); it has to match `trustedOrigins`.
+   *
+   * The check is off when `NODE_ENV` is `test`, so `bun test` cannot see it and
+   * `auth.test.ts` asserts the exemption rather than the protection.
+   */
   private post(
     base: string,
     endpoint: string,

--- a/examples/full/src/auth/auth.demo.ts
+++ b/examples/full/src/auth/auth.demo.ts
@@ -128,8 +128,8 @@ export class AuthDemo {
    * better-auth rejects a cookie-bearing state change with no `Origin`
    * (`MISSING_OR_NULL_ORIGIN`); it has to match `trustedOrigins`.
    *
-   * The check is off when `NODE_ENV` is `test`, so `bun test` cannot see it and
-   * `auth.test.ts` asserts the exemption rather than the protection.
+   * The check is off when `NODE_ENV` is `test`, so `auth.test.ts` asserts the
+   * exemption in-process and the protection in a spawned `NODE_ENV=production`.
    */
   private post(
     base: string,

--- a/examples/full/src/chat/ws-client.ts
+++ b/examples/full/src/chat/ws-client.ts
@@ -9,16 +9,22 @@
 export interface Client {
   next(): Promise<string>;
   send(event: string, data: unknown): void;
+  /** An unwrapped frame: binary, or text a gateway is meant to refuse. */
+  sendRaw(frame: string | Uint8Array): void;
   close(): void;
   /** Every frame this socket ever received, so a *second* delivery is visible. */
   readonly received: readonly string[];
 }
 
-/** A real `new WebSocket()`, with a deadline so a stall fails instead of hanging. */
-export const connect = async (base: string): Promise<Client> => {
-  const socket = new WebSocket(
-    new URL('chat', base).href.replace('http', 'ws'),
-  );
+/**
+ * A real `new WebSocket()`, with a deadline so a stall fails instead of hanging.
+ *
+ * `path` so the same helper reaches `/telemetry`, which speaks binary frames.
+ * A second copy of the frame queue for the sake of one segment is what Rule 2
+ * is about.
+ */
+export const connect = async (base: string, path = 'chat'): Promise<Client> => {
+  const socket = new WebSocket(new URL(path, base).href.replace('http', 'ws'));
   const frames: string[] = [];
   const received: string[] = [];
   const waiting: ((frame: string) => void)[] = [];
@@ -59,6 +65,7 @@ export const connect = async (base: string): Promise<Client> => {
         waiting.push(waiter);
       }),
     send: (event, data) => socket.send(JSON.stringify({ event, data })),
+    sendRaw: (frame) => socket.send(frame),
     close: () => socket.close(),
     received,
   };

--- a/examples/full/src/config.ts
+++ b/examples/full/src/config.ts
@@ -43,6 +43,11 @@ const envSchema = z.object({
   SCHEDULE_TZ: z.string().default('UTC'),
   /** Per-call budget for the outbound client. */
   UPSTREAM_TIMEOUT_MS: z.coerce.number().int().min(1).default(5000),
+  /**
+   * Guards the ops page when set. Absent by default so `bun start` is
+   * explorable and `@dunx/dashboard` still warns that it is unguarded.
+   */
+  DASHBOARD_TOKEN: z.string().min(1).optional(),
   /** better-auth signs session cookies with this. 32 characters is its own minimum. */
   AUTH_SECRET: z
     .string()
@@ -70,6 +75,7 @@ export interface AppConfig {
   readonly redis: { readonly url: string | undefined };
   readonly images: { readonly quality: number };
   readonly auth: { readonly secret: string };
+  readonly dashboard: { readonly token: string | undefined };
   readonly throttle: { readonly limit: number; readonly windowSeconds: number };
   readonly schedule: { readonly tz: string };
   readonly upstream: { readonly timeoutMs: number };
@@ -109,6 +115,7 @@ export const validate = (env: ConfigSource): AppConfig => {
     redis: { url: value.REDIS_URL },
     images: { quality: value.IMAGE_QUALITY },
     auth: { secret: value.AUTH_SECRET },
+    dashboard: { token: value.DASHBOARD_TOKEN },
     throttle: {
       limit: value.THROTTLE_LIMIT,
       windowSeconds: value.THROTTLE_WINDOW_SECONDS,

--- a/examples/full/src/dashboard.test.ts
+++ b/examples/full/src/dashboard.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import type { HttpApp } from '@dunx/http';
+import { testClient, type TestClient } from '@dunx/testing';
+import { createApp } from './main.js';
+
+/**
+ * The operations mount, whose only coverage was the tour's exit code and two
+ * assertions on log lines.
+ *
+ * The redaction test is the one that matters: `reveal` is an opt-in allow-list
+ * and everything else is masked, so a value leaking into the config panel is a
+ * secret on an operator's screen. `AUTH_SECRET` is the canary because the
+ * example has one with a known value.
+ *
+ * `authorize` is **not** covered, because this example deliberately mounts
+ * without one so `bun start` is explorable (`dashboard/dashboard.module.ts`).
+ * The 404-for-a-stranger behaviour is asserted in `@dunx/dashboard`'s own suite.
+ */
+let app: HttpApp;
+let client: TestClient;
+
+const MOUNT = 'api/_dunx';
+/** `config.ts` defaults it, so the suite knows exactly what must not appear. */
+const SECRET = 'dunx-full-example-development-secret-not-for-production';
+
+beforeAll(async () => {
+  app = await createApp();
+  client = testClient(await app.listen(0));
+});
+
+afterAll(async () => {
+  await app.shutdown();
+});
+
+it('serves the page at the mount', async () => {
+  const response = await client.request(MOUNT);
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get('content-type')).toContain('text/html');
+  expect(await response.text()).toContain('<html');
+});
+
+it('serves the page for a path under the mount, so a reload survives', async () => {
+  const response = await client.request(`${MOUNT}/routes`);
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get('content-type')).toContain('text/html');
+});
+
+it('reports the routes, gateways and providers it discovered', async () => {
+  const { status, body } = await client.json<{
+    routes: { method: string; path: string }[];
+    providers: unknown[];
+    modules: unknown[];
+  }>(`${MOUNT}/api/snapshot`);
+
+  expect(status).toBe(200);
+  expect(body.routes.length).toBeGreaterThan(20);
+  expect(body.providers.length).toBeGreaterThan(0);
+  expect(body.modules.length).toBeGreaterThan(0);
+  // The paths here are the discovered ones, **without** the global prefix the
+  // server answers on: this is `/notes`, and the URL that serves it is
+  // `/api/notes`.
+  expect(body.routes.some((route) => route.path === '/notes')).toBe(true);
+});
+
+it('redacts every config value outside the reveal list', async () => {
+  const response = await client.request(`${MOUNT}/api/snapshot`);
+  const text = await response.text();
+
+  // The whole payload, not one field: a secret is a leak wherever it surfaces.
+  expect(text).not.toContain(SECRET);
+  // What `reveal` does allow, so the test would fail if the panel had gone blank
+  // rather than being correctly masked.
+  expect(text).toContain('dunx-full');
+});
+
+it('reports http and db statistics, both configured', async () => {
+  const { status, body } = await client.json<{
+    http: { configured: boolean };
+    db: { configured: boolean };
+  }>(`${MOUNT}/api/stats`);
+
+  expect(status).toBe(200);
+  // `metrics: true` on `HttpFactory.create` and on `DbModule` is what fills these.
+  expect(body.http.configured).toBe(true);
+  expect(body.db.configured).toBe(true);
+});
+
+it('reports the runtime', async () => {
+  const { status, body } = await client.json<{ uptimeMs: number }>(
+    `${MOUNT}/api/runtime`,
+  );
+
+  expect(status).toBe(200);
+  expect(body.uptimeMs).toBeGreaterThanOrEqual(0);
+});
+
+it('names the queues without opening a connection to them', async () => {
+  const { status, body } = await client.json<{ queues: string[] }>(
+    `${MOUNT}/api/queues`,
+  );
+
+  expect(status).toBe(200);
+  expect(body.queues).toContain('thumbnails');
+});
+
+it('reports whether redis is configured', async () => {
+  const { status } = await client.json(`${MOUNT}/api/redis`);
+
+  expect(status).toBe(200);
+});
+
+it('refuses a verb the mount does not answer', async () => {
+  const { status } = await client.json<{ error: string }>(
+    `${MOUNT}/api/snapshot`,
+    { method: 'POST' },
+  );
+
+  expect(status).toBe(405);
+});
+
+it('answers 404 for a JSON endpoint it does not have', async () => {
+  const { status } = await client.json<{ error: string }>(
+    `${MOUNT}/api/not-a-panel`,
+  );
+
+  expect(status).toBe(404);
+});

--- a/examples/full/src/dashboard.test.ts
+++ b/examples/full/src/dashboard.test.ts
@@ -1,6 +1,15 @@
 import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { ConfigModule } from '@dunx/core';
+import { DashboardMiddleware } from '@dunx/dashboard';
 import type { HttpApp } from '@dunx/http';
-import { testClient, type TestClient } from '@dunx/testing';
+import {
+  createTestServer,
+  testClient,
+  type TestClient,
+  type TestServer,
+} from '@dunx/testing';
+import { AppConfigService, validate } from './config.js';
+import { OpsModule } from './dashboard/dashboard.module.js';
 import { createApp } from './main.js';
 
 /**
@@ -22,6 +31,8 @@ let client: TestClient;
 const MOUNT = 'api/_dunx';
 /** `config.ts` defaults it, so the suite knows exactly what must not appear. */
 const SECRET = 'dunx-full-example-development-secret-not-for-production';
+/** What the guarded server below expects in `x-dashboard-token`. */
+const TOKEN = 'let-me-in';
 
 beforeAll(async () => {
   app = await createApp();
@@ -58,10 +69,9 @@ it('reports the routes, gateways and providers it discovered', async () => {
   expect(body.routes.length).toBeGreaterThan(20);
   expect(body.providers.length).toBeGreaterThan(0);
   expect(body.modules.length).toBeGreaterThan(0);
-  // The paths here are the discovered ones, **without** the global prefix the
-  // server answers on: this is `/notes`, and the URL that serves it is
-  // `/api/notes`.
-  expect(body.routes.some((route) => route.path === '/notes')).toBe(true);
+  // The path as served, prefix included, so an operator can copy one out of the
+  // panel and have it answer.
+  expect(body.routes.some((route) => route.path === '/api/notes')).toBe(true);
 });
 
 it('redacts every config value outside the reveal list', async () => {
@@ -126,4 +136,85 @@ it('answers 404 for a JSON endpoint it does not have', async () => {
   );
 
   expect(status).toBe(404);
+});
+
+/**
+ * `authorize` with `DASHBOARD_TOKEN` set, which the app above deliberately runs
+ * without. A rejected caller gets **404, not 403**: a 403 confirms the mount is
+ * there, and the point of `authorize` is that a stranger learns nothing.
+ *
+ * Its own server, because the option is read once when the module builds.
+ */
+const guarded = async (): Promise<TestServer> =>
+  createTestServer({
+    modules: [
+      ConfigModule.forRoot({
+        validate,
+        as: AppConfigService,
+        source: { DASHBOARD_TOKEN: TOKEN },
+      }),
+      OpsModule,
+    ],
+    prefix: 'api',
+    middleware: [DashboardMiddleware],
+  });
+
+it('answers 404 to a caller with no dashboard token', async () => {
+  const server = await guarded();
+
+  try {
+    const response = await server.request(`${MOUNT}/api/snapshot`);
+    expect(response.status).toBe(404);
+    // Not the JSON panel either: a body would leak the shape of what is behind it.
+    expect(await response.text()).not.toContain('routes');
+  } finally {
+    await server.app.shutdown();
+  }
+});
+
+it('answers 404 to a caller with the wrong dashboard token', async () => {
+  const server = await guarded();
+
+  try {
+    const response = await server.request(`${MOUNT}/api/snapshot`, {
+      headers: { 'x-dashboard-token': 'not-the-token' },
+    });
+    expect(response.status).toBe(404);
+  } finally {
+    await server.app.shutdown();
+  }
+});
+
+it('serves the panels to a caller holding the token', async () => {
+  const server = await guarded();
+
+  try {
+    const { status, body } = await server.json<{ routes: unknown[] }>(
+      `${MOUNT}/api/snapshot`,
+      { headers: { 'x-dashboard-token': TOKEN } },
+    );
+    expect(status).toBe(200);
+    expect(body.routes.length).toBeGreaterThan(0);
+
+    const page = await server.request(MOUNT, {
+      headers: { 'x-dashboard-token': TOKEN },
+    });
+    expect(page.status).toBe(200);
+  } finally {
+    await server.app.shutdown();
+  }
+});
+
+it('leaves the app’s own routes reachable without the token', async () => {
+  const server = await guarded();
+
+  try {
+    // `authorize` guards the mount, not the app: a 404 here would mean the
+    // middleware had claimed a path that is not its own. `/api/ledger` comes from
+    // `DatabaseModule`, which `OpsModule` imports for the db stats panel.
+    const response = await server.request('api/ledger');
+    expect(response.status).toBe(200);
+  } finally {
+    await server.app.shutdown();
+  }
 });

--- a/examples/full/src/dashboard/dashboard.module.ts
+++ b/examples/full/src/dashboard/dashboard.module.ts
@@ -17,9 +17,11 @@ import { DashboardDemo } from './dashboard.demo.js';
  * comes out of the container: `JobPublisher` satisfies `QueueSource` and
  * `RedisConnection` satisfies `RedisProbe`, with no adapter between them.
  *
- * No `authorize` here, so the page is explorable with `bun start` - the package
- * warns at boot, and the warning is part of the demonstration. A real one gets
- * the raw `Request` and runs before any guard, so it must be self-sufficient.
+ * `authorize` only when `DASHBOARD_TOKEN` is set, which it is not by default: the
+ * page stays explorable with `bun start` and the package's boot warning is part
+ * of the demonstration. Set the variable and a caller without the header gets
+ * **404, not 403** - the mount does not admit it exists. It takes the raw
+ * `Request` and runs before any guard, so it must be self-sufficient.
  */
 @Module({
   imports: [
@@ -55,6 +57,16 @@ import { DashboardDemo } from './dashboard.demo.js';
         // redacted, including the database url and every secret.
         reveal: (key: string) => key === 'appName' || key === 'port',
         openApiPath: '/api/docs',
+        // Spread rather than `authorize: undefined`: `exactOptionalPropertyTypes`
+        // separates an absent option from one explicitly undefined, and the
+        // package's boot warning reads the difference.
+        ...(config.get('dashboard.token') === undefined
+          ? {}
+          : {
+              authorize: (req: Bun.BunRequest) =>
+                req.headers.get('x-dashboard-token') ===
+                config.get('dashboard.token'),
+            }),
       }),
       inject: [
         JobPublisher,

--- a/examples/full/src/gateway.test.ts
+++ b/examples/full/src/gateway.test.ts
@@ -36,14 +36,20 @@ const socketUrl = (path: string): string =>
  * server's own cleanup: this suite read 2 as its baseline and asserted 3 while
  * the previous test's two sockets were still on their way out.
  */
+const STABLE_READINGS = 4;
+
 const settledCount = async (): Promise<number> => {
   const pubsub = app.get(PubSub);
   let last = pubsub.subscriberCount(Lobby.TOPIC);
-  for (let i = 0; i < 20; i += 1) {
+  let stable = 0;
+  for (let i = 0; i < 40; i += 1) {
     await Bun.sleep(50);
     const now = pubsub.subscriberCount(Lobby.TOPIC);
-    if (now === last) return now;
+    // One unchanged reading is not settled: a close that has not begun to
+    // decrement yet looks exactly like one that finished.
+    stable = now === last ? stable + 1 : 0;
     last = now;
+    if (stable >= STABLE_READINGS) return now;
   }
   return last;
 };

--- a/examples/full/src/gateway.test.ts
+++ b/examples/full/src/gateway.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { PubSub, type HttpApp } from '@dunx/http';
+import { connect } from './chat/ws-client.js';
+import { Lobby } from './chat/lobby.service.js';
+import { createApp } from './main.js';
+
+/**
+ * The websocket half, including the branches nothing reached.
+ *
+ * The tour opens a chat socket and asserts on the log line it produces. What no
+ * test covered: the upgrade being **refused**, the telemetry gateway's text-frame
+ * path, and whether a subscriber is dropped when its socket goes away without a
+ * close frame. The load run opens and aborts thousands of sockets per run and
+ * only ever checked the subscriber count at the end, so a leak smaller than the
+ * run was invisible.
+ */
+let app: HttpApp;
+let base = '';
+
+beforeAll(async () => {
+  app = await createApp();
+  base = await app.listen(0);
+});
+
+afterAll(async () => {
+  await app.shutdown();
+});
+
+const socketUrl = (path: string): string =>
+  new URL(path, base).href.replace('http', 'ws');
+
+/**
+ * The subscriber count once every socket closed by an earlier test has gone.
+ *
+ * A close is a round trip, so reading the count straight after one races the
+ * server's own cleanup: this suite read 2 as its baseline and asserted 3 while
+ * the previous test's two sockets were still on their way out.
+ */
+const settledCount = async (): Promise<number> => {
+  const pubsub = app.get(PubSub);
+  let last = pubsub.subscriberCount(Lobby.TOPIC);
+  for (let i = 0; i < 20; i += 1) {
+    await Bun.sleep(50);
+    const now = pubsub.subscriberCount(Lobby.TOPIC);
+    if (now === last) return now;
+    last = now;
+  }
+  return last;
+};
+
+it('refuses the upgrade when @OnUpgrade returns a Response', async () => {
+  const opened = await new Promise<boolean>((resolve) => {
+    const socket = new WebSocket(socketUrl('chat?as=banned'));
+    const timer = setTimeout(() => resolve(false), 2000);
+    socket.addEventListener('open', () => {
+      clearTimeout(timer);
+      socket.close();
+      resolve(true);
+    });
+    socket.addEventListener('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+
+  expect(opened).toBe(false);
+});
+
+it('answers the refused upgrade with the status the handler chose', async () => {
+  const response = await fetch(new URL('chat?as=banned', base), {
+    headers: {
+      upgrade: 'websocket',
+      connection: 'Upgrade',
+      'sec-websocket-key': btoa('0123456789abcdef'),
+      'sec-websocket-version': '13',
+    },
+  });
+
+  expect(response.status).toBe(403);
+  expect(await response.text()).toBe('nope');
+});
+
+it('welcomes a socket the upgrade admitted', async () => {
+  const client = await connect(base);
+
+  expect(await client.next()).toBe('welcome');
+  client.close();
+});
+
+it('broadcasts to every subscriber and answers the sender', async () => {
+  const first = await connect(base);
+  const second = await connect(base);
+  expect(await first.next()).toBe('welcome');
+  expect(await second.next()).toBe('welcome');
+
+  first.send('say', 'hello lobby');
+
+  // The broadcast reaches both, and the reply carries the delivery count.
+  const delivered = [
+    await first.next(),
+    await first.next(),
+    await second.next(),
+  ];
+  expect(delivered.some((frame) => frame.includes('hello lobby'))).toBe(true);
+  expect(delivered.some((frame) => frame.includes('delivered'))).toBe(true);
+
+  first.close();
+  second.close();
+});
+
+it('drops the subscriber when a socket closes', async () => {
+  const pubsub = app.get(PubSub);
+  const before = await settledCount();
+
+  const client = await connect(base);
+  await client.next();
+  expect(pubsub.subscriberCount(Lobby.TOPIC)).toBe(before + 1);
+
+  client.close();
+  // The close is a round trip, so the count settles a tick later.
+  await Bun.sleep(150);
+  expect(pubsub.subscriberCount(Lobby.TOPIC)).toBe(before);
+});
+
+it('drops the subscriber when a socket goes away with no close frame', async () => {
+  const pubsub = app.get(PubSub);
+  const before = await settledCount();
+
+  const socket = new WebSocket(socketUrl('chat'));
+  await new Promise<void>((resolve, reject) => {
+    socket.addEventListener('open', () => resolve(), { once: true });
+    setTimeout(() => reject(new Error('the socket never opened')), 2000);
+  });
+  expect(pubsub.subscriberCount(Lobby.TOPIC)).toBe(before + 1);
+
+  // No close handshake: the half a clean-close-only cleanup path would miss.
+  socket.terminate();
+  await Bun.sleep(250);
+  expect(pubsub.subscriberCount(Lobby.TOPIC)).toBe(before);
+});
+
+it('summarises a binary frame on the telemetry gateway', async () => {
+  const client = await connect(base, 'telemetry');
+
+  client.sendRaw(new Uint8Array([1, 2, 3, 4]));
+  const frame = await client.next();
+
+  expect(frame).toContain('Blob(4)');
+  expect(frame).toContain('[1, 2, 3, 4]');
+  client.close();
+});
+
+it('refuses a text frame where the telemetry gateway wants binary', async () => {
+  const client = await connect(base, 'telemetry');
+
+  client.sendRaw('not binary');
+  const frame = await client.next();
+
+  expect(frame).toBe('expected a binary frame, got 10 chars of text');
+  client.close();
+});

--- a/examples/full/src/negative.test.ts
+++ b/examples/full/src/negative.test.ts
@@ -366,23 +366,49 @@ it('never counts the health probes against the rate limit', async () => {
 it('releases a request whose client went away mid-flight', async () => {
   const metrics = app.get(RequestMetrics);
   const settled = metrics.snapshot().inFlight;
+  const IN_FLIGHT = 25;
+  /**
+   * Under the handler's 300 ms sleep, so a run where the abort reached nothing
+   * fails here: the requests would still be parked and `inFlight` still 25.
+   * Waiting past 300 ms instead would pass either way, since the handlers
+   * complete on their own and decrement it whatever the client did.
+   */
+  const DEADLINE_MS = 150;
 
-  // `/upstream/slow` sleeps 300ms and is @SkipThrottle, so 25 of them are all
-  // parked in the handler when the aborts land.
-  const aborted = Array.from({ length: 25 }, async () => {
+  const controllers: AbortController[] = [];
+  const calls = Array.from({ length: IN_FLIGHT }, () => {
     const controller = new AbortController();
-    const call = fetch(new URL('api/upstream/slow', client.url), {
+    controllers.push(controller);
+    // `/upstream/slow` sleeps 300ms and is @SkipThrottle, so all 25 are parked
+    // in the handler when the aborts land.
+    return fetch(new URL('api/upstream/slow', client.url), {
       signal: controller.signal,
     }).catch(() => 'aborted');
-    await Bun.sleep(20);
-    controller.abort();
-    return call;
   });
-  await Promise.all(aborted);
-  await Bun.sleep(600);
+
+  // They have to be on the wire before the abort means anything.
+  let reached = 0;
+  for (let i = 0; i < 50 && reached < IN_FLIGHT; i += 1) {
+    await Bun.sleep(10);
+    reached = metrics.snapshot().inFlight - settled;
+  }
+  expect(reached).toBe(IN_FLIGHT);
+
+  for (const controller of controllers) controller.abort();
+  const abortedAt = performance.now();
+  let released = -1;
+  while (performance.now() - abortedAt < DEADLINE_MS) {
+    if (metrics.snapshot().inFlight === settled) {
+      released = performance.now() - abortedAt;
+      break;
+    }
+    await Bun.sleep(5);
+  }
 
   // A client that hangs up is not an error the server has to answer for, but a
   // request it never lets go of is a leak that only shows under load.
-  expect(metrics.snapshot().inFlight).toBe(settled);
+  expect(released).toBeGreaterThanOrEqual(0);
+  expect(released).toBeLessThan(DEADLINE_MS);
+  await Promise.all(calls);
   expect((await json<{ ok: true }>('reports/health')).status).toBe(200);
 });

--- a/examples/full/src/negative.test.ts
+++ b/examples/full/src/negative.test.ts
@@ -1,0 +1,388 @@
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { RequestMetrics, type HttpApp } from '@dunx/http';
+import { testClient, type JsonInit, type TestClient } from '@dunx/testing';
+import { createApp } from './main.js';
+
+/**
+ * The refusals: what every route answers when the request is wrong.
+ *
+ * `service.test.ts` covers the happy path and four failures alongside it. This
+ * file is the other side, and it exists because the load run enumerated statuses
+ * that no test asserted: 22 routes declare zod schemas and three of them had a
+ * 400 test, five handlers `throw` a 404 and one of those was covered.
+ */
+let app: HttpApp;
+let client: TestClient;
+
+const json = <T>(path: string, init?: JsonInit) =>
+  client.json<T>(`api/${path}`, init);
+
+const send = (
+  method: string,
+  body: unknown,
+  headers?: Record<string, string>,
+): JsonInit => ({
+  method,
+  json: body,
+  ...(headers === undefined ? {} : { headers }),
+});
+
+/** The shape `HttpError` serialises to, which every refusal below shares. */
+interface ErrorBody {
+  error: string;
+  status: number;
+}
+
+beforeAll(async () => {
+  app = await createApp();
+  client = testClient(await app.listen(0));
+});
+
+afterAll(async () => {
+  await app.shutdown();
+});
+
+it('rejects a query parameter over its maximum', async () => {
+  const { status, body } = await json<ErrorBody>('users?limit=999');
+
+  expect(status).toBe(400);
+  expect(body.status).toBe(400);
+  // The message names the parameter, which is the whole point of validating at
+  // the edge rather than in the handler.
+  expect(JSON.stringify(body)).toContain('limit');
+});
+
+it('rejects a query parameter that will not coerce', async () => {
+  const { status } = await json<ErrorBody>('users?limit=not-a-number');
+
+  expect(status).toBe(400);
+});
+
+it('rejects a path parameter under its minimum', async () => {
+  const { status } = await json<ErrorBody>('users/0');
+
+  expect(status).toBe(400);
+});
+
+it('rejects a path parameter that is not a number', async () => {
+  const { status } = await json<ErrorBody>('users/abc');
+
+  expect(status).toBe(400);
+});
+
+it('answers 404 for a user id that does not exist', async () => {
+  const { status, body } = await json<ErrorBody>('users/999999');
+
+  expect(status).toBe(404);
+  expect(body.status).toBe(404);
+});
+
+it('rejects a body field of the wrong type', async () => {
+  const { status } = await json<ErrorBody>('notes', send('POST', { text: 42 }));
+
+  expect(status).toBe(400);
+});
+
+it('rejects a body with the field missing', async () => {
+  const { status } = await json<ErrorBody>('notes', send('POST', {}));
+
+  expect(status).toBe(400);
+});
+
+it('rejects a body that is not JSON at all', async () => {
+  const response = await client.request('api/notes', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{"text": ',
+  });
+
+  // A parse failure is the caller's fault, so it must not surface as a 500.
+  expect(response.status).toBe(400);
+});
+
+it('parses a JSON body sent with no content-type', async () => {
+  const response = await client.request('api/notes', {
+    method: 'POST',
+    body: JSON.stringify({ text: 'no content type' }),
+  });
+
+  // Lenient on purpose, and asserted so it stays a decision: the body is read
+  // and validated on its own merits rather than on the header a client set.
+  expect(response.status).toBe(201);
+});
+
+it('rejects an image width over the ceiling', async () => {
+  const { status } = await json<ErrorBody>('images/render?width=9999');
+
+  expect(status).toBe(400);
+});
+
+it('rejects an image format outside the enum', async () => {
+  const { status } = await json<ErrorBody>('images/render?format=bogus');
+
+  expect(status).toBe(400);
+});
+
+it('describes an inline image, and rejects one that is not base64', async () => {
+  const rendered = await client.request('api/images/render?width=8&format=png');
+  const bytes = await rendered.bytes();
+  const base64 = Buffer.from(bytes).toString('base64');
+
+  const ok = await json<{ width: number; format: string }>(
+    'images/describe',
+    send('POST', { base64 }),
+  );
+  // POST answers 201 unless a route says otherwise, `describe` does not.
+  expect(ok.status).toBe(201);
+  expect(ok.body.width).toBe(8);
+
+  const bad = await json<ErrorBody>(
+    'images/describe',
+    send('POST', { base64: '' }),
+  );
+  expect(bad.status).toBe(400);
+});
+
+it('rejects a cache ttl over its maximum', async () => {
+  const { status } = await json<ErrorBody>(
+    'cache/ttl-too-long',
+    send('PUT', { data: { a: 1 }, ttl: 99999 }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('rejects a cache payload that is not an object', async () => {
+  const { status } = await json<ErrorBody>(
+    'cache/wrong-shape',
+    send('PUT', { data: 'not an object' }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('rejects an empty storage key', async () => {
+  const { status } = await json<ErrorBody>('files/object?key=');
+
+  expect(status).toBe(400);
+});
+
+it('rejects a storage key over its length limit', async () => {
+  const { status } = await json<ErrorBody>(
+    `files/object?key=${'k'.repeat(201)}`,
+  );
+
+  expect(status).toBe(400);
+});
+
+it('refuses to walk out of the storage root', async () => {
+  const { status } = await json<ErrorBody>(
+    `files/object?key=${encodeURIComponent('../../etc/passwd')}`,
+  );
+
+  // `Storage` raises `PathTraversalError`, which the controller maps rather than
+  // letting it become a 500.
+  expect(status).toBe(400);
+});
+
+it('answers 404 for a storage key that was never written', async () => {
+  const { status } = await json<ErrorBody>(
+    'files/object?key=never-written.txt',
+  );
+
+  expect(status).toBe(404);
+});
+
+it('rejects a file body over the size cap', async () => {
+  const { status } = await json<ErrorBody>(
+    'files/object?key=too-big.txt',
+    send('PUT', { content: 'x'.repeat(64 * 1024 + 1) }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('writes, reads and deletes one object', async () => {
+  const key = 'negative/roundtrip.txt';
+  const q = `key=${encodeURIComponent(key)}`;
+
+  const written = await json<{ key: string; bytes: number }>(
+    `files/object?${q}`,
+    send('PUT', { content: 'hello' }),
+  );
+  expect(written.status).toBe(200);
+  expect(written.body.bytes).toBe(5);
+
+  const read = await client.request(`api/files/object?${q}`);
+  expect(read.status).toBe(200);
+  expect(await read.text()).toContain('hello');
+
+  const removed = await json<{ deleted: boolean }>(`files/object?${q}`, {
+    method: 'DELETE',
+  });
+  expect(removed.status).toBe(200);
+  expect(removed.body.deleted).toBe(true);
+
+  const gone = await json<ErrorBody>(`files/object?${q}`);
+  expect(gone.status).toBe(404);
+});
+
+it('reads and deletes one ledger entry, then answers 404 for both', async () => {
+  const created = await json<{ id: number; memo: string }>(
+    'ledger',
+    send('POST', { memo: 'negative-test', amount: 7 }),
+  );
+  expect(created.status).toBe(201);
+  const { id } = created.body;
+
+  const read = await json<{ id: number; amount: number }>(`ledger/${id}`);
+  expect(read.status).toBe(200);
+  expect(read.body.amount).toBe(7);
+
+  const removed = await json<{ deleted: boolean }>(`ledger/${id}`, {
+    method: 'DELETE',
+  });
+  expect(removed.status).toBe(200);
+  expect(removed.body.deleted).toBe(true);
+
+  expect((await json<ErrorBody>(`ledger/${id}`)).status).toBe(404);
+  expect(
+    (await json<ErrorBody>(`ledger/${id}`, { method: 'DELETE' })).status,
+  ).toBe(404);
+});
+
+it('rejects a ledger entry with no memo', async () => {
+  const { status } = await json<ErrorBody>(
+    'ledger',
+    send('POST', { memo: '', amount: 1 }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('rejects a ledger amount that is not an integer', async () => {
+  const { status } = await json<ErrorBody>(
+    'ledger',
+    send('POST', { memo: 'fractional', amount: 1.5 }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('rejects a transfer of a negative amount', async () => {
+  const { status } = await json<ErrorBody>(
+    'ledger/transfer',
+    send('POST', { from: 'a', to: 'b', amount: -5 }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('answers 404 for a cache key that is not there', async () => {
+  const { status } = await json<ErrorBody>('cache/definitely-not-stored');
+
+  // 503 when no broker is up, which is the route degrading rather than failing.
+  expect([404, 503]).toContain(status);
+});
+
+it('rejects a report with an empty title, once past the guards', async () => {
+  const { status } = await json<ErrorBody>(
+    'reports',
+    send('POST', { title: '' }, { authorization: 'Bearer admin' }),
+  );
+
+  expect(status).toBe(400);
+});
+
+it('challenges before it validates', async () => {
+  // Same invalid body, no credentials. The guard runs first, so this is a 401
+  // rather than the 400 above: middleware order is observable here.
+  const { status } = await json<ErrorBody>(
+    'reports',
+    send('POST', { title: '' }),
+  );
+
+  expect(status).toBe(401);
+});
+
+it('forbids a valid body from the wrong role', async () => {
+  const { status } = await json<ErrorBody>(
+    'reports',
+    send(
+      'POST',
+      { title: 'from a viewer' },
+      { authorization: 'Bearer viewer' },
+    ),
+  );
+
+  expect(status).toBe(403);
+});
+
+it('forbids a rename from a role that is not the editor', async () => {
+  const { status } = await json<ErrorBody>(
+    'reports/1',
+    send('PATCH', { title: 'renamed' }, { authorization: 'Bearer admin' }),
+  );
+
+  // `@Roles('editor')` at the method wins over `@Roles('admin')` at the class.
+  expect(status).toBe(403);
+});
+
+it('answers 404 for an unmatched path under the prefix', async () => {
+  const { status, body } = await json<ErrorBody>('nothing-here');
+
+  expect(status).toBe(404);
+  expect(body.error).toBe('NOT_FOUND');
+});
+
+it('answers 404 for a verb the route does not declare', async () => {
+  const { status } = await json<ErrorBody>('notes', { method: 'DELETE' });
+
+  expect(status).toBe(404);
+});
+
+it('answers 404 outside the global prefix', async () => {
+  const response = await client.request('users');
+
+  expect(response.status).toBe(404);
+});
+
+it('never counts the health probes against the rate limit', async () => {
+  const live = await client.request('api/health/live');
+  const ready = await client.request('api/health/ready');
+
+  // The load run that found `/health/live` answering 429 behind a global
+  // `ThrottleGuard` is why this is asserted rather than assumed. It raises the
+  // budget so the app rather than the limiter is what it measures, which means
+  // the run can no longer reach the limit on a probe: the exemption is visible
+  // here instead, as the absence of the headers a counted route carries.
+  expect(live.headers.get('ratelimit-limit')).toBeNull();
+  expect(ready.headers.get('ratelimit-limit')).toBeNull();
+
+  const counted = await client.request('api/notes');
+  expect(counted.headers.get('ratelimit-limit')).not.toBeNull();
+});
+
+it('releases a request whose client went away mid-flight', async () => {
+  const metrics = app.get(RequestMetrics);
+  const settled = metrics.snapshot().inFlight;
+
+  // `/upstream/slow` sleeps 300ms and is @SkipThrottle, so 25 of them are all
+  // parked in the handler when the aborts land.
+  const aborted = Array.from({ length: 25 }, async () => {
+    const controller = new AbortController();
+    const call = fetch(new URL('api/upstream/slow', client.url), {
+      signal: controller.signal,
+    }).catch(() => 'aborted');
+    await Bun.sleep(20);
+    controller.abort();
+    return call;
+  });
+  await Promise.all(aborted);
+  await Bun.sleep(600);
+
+  // A client that hangs up is not an error the server has to answer for, but a
+  // request it never lets go of is a leak that only shows under load.
+  expect(metrics.snapshot().inFlight).toBe(settled);
+  expect((await json<{ ok: true }>('reports/health')).status).toBe(200);
+});

--- a/examples/full/src/shutdown.test.ts
+++ b/examples/full/src/shutdown.test.ts
@@ -14,10 +14,14 @@ it('stays up until a signal, then drains in reverse order', async () => {
     expect(app.killed).toBe(false);
 
     expect(await app.stop()).toBe(0);
+    // Both present first: an absent marker is -1, which is less than any real
+    // index, so the order check passed when the hook had not run at all.
+    const draining = app.output.indexOf('users draining');
+    const closed = app.output.indexOf('database closed');
+    expect(draining).toBeGreaterThanOrEqual(0);
+    expect(closed).toBeGreaterThanOrEqual(0);
     // Reverse dependency order: the service drains before the database it needs.
-    expect(app.output.indexOf('users draining')).toBeLessThan(
-      app.output.indexOf('database closed'),
-    );
+    expect(draining).toBeLessThan(closed);
     // The temp dir is removed on the signal path too.
     expect(app.output).toContain('workspace removed:');
   } finally {

--- a/examples/full/src/shutdown.test.ts
+++ b/examples/full/src/shutdown.test.ts
@@ -1,43 +1,26 @@
 import { expect, it } from 'bun:test';
-
-const APP_DIR = new URL('..', import.meta.url).pathname;
+import { SpawnedApp } from './spawn-app.js';
 
 /**
  * `bun start` is a service: it holds the process open until a signal arrives.
  * That is exactly what the tour cannot check, so it gets its own spawn.
  */
 it('stays up until a signal, then drains in reverse order', async () => {
-  const proc = Bun.spawn(['bun', 'src/main.ts'], {
-    cwd: APP_DIR,
-    // Port 0 so the suite cannot collide with a real `bun start` on 3000.
-    env: { ...process.env, NODE_ENV: 'production', PORT: '0' },
-    stdout: 'pipe',
-    stderr: 'inherit',
-  });
+  const app = new SpawnedApp();
 
-  let text = '';
-  const decoder = new TextDecoder();
-  const drained = (async () => {
-    for await (const chunk of proc.stdout) {
-      text += decoder.decode(chunk, { stream: true });
-    }
-  })();
+  try {
+    expect(await app.serving()).toContain('http://');
+    // Still running: a service does not exit once it has finished starting.
+    expect(app.killed).toBe(false);
 
-  while (!text.includes('ctrl-c to stop')) await Bun.sleep(20);
-
-  // Still running: a service does not exit once it has finished starting.
-  expect(proc.killed).toBe(false);
-  expect(text).toContain('listening on http://');
-
-  proc.kill('SIGTERM');
-  const code = await proc.exited;
-  await drained;
-
-  expect(code).toBe(0);
-  // Reverse dependency order: the service drains before the database it needs.
-  expect(text.indexOf('users draining')).toBeLessThan(
-    text.indexOf('database closed'),
-  );
-  // The temp dir is removed on the signal path too.
-  expect(text).toContain('workspace removed:');
+    expect(await app.stop()).toBe(0);
+    // Reverse dependency order: the service drains before the database it needs.
+    expect(app.output.indexOf('users draining')).toBeLessThan(
+      app.output.indexOf('database closed'),
+    );
+    // The temp dir is removed on the signal path too.
+    expect(app.output).toContain('workspace removed:');
+  } finally {
+    app.kill();
+  }
 }, 30_000);

--- a/examples/full/src/soak/budget.ts
+++ b/examples/full/src/soak/budget.ts
@@ -44,13 +44,8 @@ export interface BudgetResult {
 const NS_PER_MS = 1_000_000;
 
 /**
- * Judges a load run from two sides: what the client saw, and what the server's
- * own `RequestMetrics` recorded.
- *
- * The server side is the half that was missing. A client-side accept-set answers
- * "did anything throw", where the histogram answers "what did each route
- * actually cost and what did it answer", which is the question a load test is
- * for.
+ * Judges a run from two sides: what the client saw, and what the server's own
+ * `RequestMetrics` recorded. The histogram is the half that was missing.
  */
 export class LoadBudget {
   constructor(private readonly limits: BudgetLimits = DEFAULT_LIMITS) {}

--- a/examples/full/src/soak/budget.ts
+++ b/examples/full/src/soak/budget.ts
@@ -1,0 +1,185 @@
+import type { HttpStatsReport } from '@dunx/http';
+import { OPS } from './ops.js';
+import type { OpStats } from './workload.js';
+
+export interface BudgetLimits {
+  /**
+   * The least share of an op's answered calls that must be work rather than a
+   * refusal. Under this the run is measuring the rate limiter.
+   */
+  readonly minWorkShare: number;
+  readonly minCallsPerSecond: number;
+  /** Per route, from the server's own histogram. */
+  readonly maxP99Ms: number;
+  readonly maxSingleRequestMs: number;
+}
+
+/**
+ * Generous on purpose. These catch a route that went from 4 ms to 5 s, not a
+ * regression of a few hundred microseconds: a shared CI runner moves the numbers
+ * far more than most changes do, and a tight budget here would fail on the
+ * machine rather than on the code.
+ */
+export const DEFAULT_LIMITS: BudgetLimits = {
+  minWorkShare: 0.9,
+  minCallsPerSecond: 200,
+  maxP99Ms: 250,
+  maxSingleRequestMs: 5000,
+};
+
+export interface BudgetInput {
+  readonly stats: ReadonlyMap<string, OpStats>;
+  readonly elapsedSeconds: number;
+  /** Absent for a phase judged on op outcomes alone, such as recovery. */
+  readonly metrics?: HttpStatsReport;
+  /** Ops needing the broker are not floored when nothing is answering. */
+  readonly redisUp: boolean;
+}
+
+export interface BudgetResult {
+  readonly failures: readonly string[];
+  readonly report: readonly string[];
+}
+
+const NS_PER_MS = 1_000_000;
+
+/**
+ * Judges a load run from two sides: what the client saw, and what the server's
+ * own `RequestMetrics` recorded.
+ *
+ * The server side is the half that was missing. A client-side accept-set answers
+ * "did anything throw", where the histogram answers "what did each route
+ * actually cost and what did it answer", which is the question a load test is
+ * for.
+ */
+export class LoadBudget {
+  constructor(private readonly limits: BudgetLimits = DEFAULT_LIMITS) {}
+
+  check(input: BudgetInput): BudgetResult {
+    const failures: string[] = [];
+    const report: string[] = [];
+    this.#checkOps(input, failures);
+    this.#checkThroughput(input, failures, report);
+    if (input.metrics !== undefined) {
+      this.#checkLatency(input.metrics, failures, report);
+      LoadBudget.#describeStatuses(input.metrics, report);
+    }
+    return { failures, report };
+  }
+
+  #checkOps(input: BudgetInput, failures: string[]): void {
+    for (const op of OPS) {
+      const s = input.stats.get(op.name);
+      if (s === undefined || s.calls === 0) continue;
+      if (s.errors > 0) {
+        failures.push(
+          `${op.name}: ${s.errors}/${s.calls} calls failed at the transport, last: ${s.lastDetail}`,
+        );
+      }
+      if (s.unexpected.size > 0) {
+        const seen = [...s.unexpected]
+          .map(([status, n]) => `${status} x${n}`)
+          .join(', ');
+        failures.push(
+          `${op.name}: answered ${seen}, which it names neither work nor a refusal`,
+        );
+      }
+      // An op whose service is absent is refused by design, so flooring it would
+      // fail every run on a laptop with nothing up.
+      if (op.requires === 'redis' && !input.redisUp) continue;
+      const answered = s.worked + s.refused;
+      if (answered === 0) continue;
+      const share = s.worked / answered;
+      if (share < this.limits.minWorkShare) {
+        failures.push(
+          `${op.name}: only ${(share * 100).toFixed(1)}% of ${answered} answered calls did work ` +
+            `(${s.refused} refused), under the ${(this.limits.minWorkShare * 100).toFixed(0)}% floor`,
+        );
+      }
+    }
+  }
+
+  #checkThroughput(
+    input: BudgetInput,
+    failures: string[],
+    report: string[],
+  ): void {
+    let worked = 0;
+    let refused = 0;
+    for (const s of input.stats.values()) {
+      worked += s.worked;
+      refused += s.refused;
+    }
+    const rate = worked / input.elapsedSeconds;
+    report.push(
+      `${worked} calls did work, ${refused} were refused, ${rate.toFixed(0)} working calls/s`,
+    );
+    if (rate < this.limits.minCallsPerSecond) {
+      failures.push(
+        `${rate.toFixed(0)} working calls/s is under the ${this.limits.minCallsPerSecond}/s floor`,
+      );
+    }
+  }
+
+  #checkLatency(
+    metrics: HttpStatsReport,
+    failures: string[],
+    report: string[],
+  ): void {
+    const slowest = [...metrics.routes]
+      .filter((r) => r.count > 0)
+      .sort((a, b) => (b.duration.p99 ?? 0) - (a.duration.p99 ?? 0));
+    report.push('slowest routes by p99 (server side):');
+    for (const route of slowest.slice(0, 5)) {
+      report.push(
+        `  ${`${route.method} ${route.route}`.padEnd(30)} ` +
+          `n=${String(route.count).padStart(6)} ` +
+          `p50 ${LoadBudget.#ms(route.duration.p50)} ` +
+          `p99 ${LoadBudget.#ms(route.duration.p99)} ` +
+          `max ${LoadBudget.#ms(route.duration.max)}`,
+      );
+    }
+    for (const route of slowest) {
+      const p99 = (route.duration.p99 ?? 0) / NS_PER_MS;
+      const max = (route.duration.max ?? 0) / NS_PER_MS;
+      const where = `${route.method} ${route.route}`;
+      if (p99 > this.limits.maxP99Ms) {
+        failures.push(
+          `${where}: p99 ${p99.toFixed(0)}ms over the ${this.limits.maxP99Ms}ms budget ` +
+            `(slowest trace ${route.slowestTraceId ?? 'unrecorded'})`,
+        );
+      }
+      if (max > this.limits.maxSingleRequestMs) {
+        failures.push(
+          `${where}: one request took ${max.toFixed(0)}ms, over the ` +
+            `${this.limits.maxSingleRequestMs}ms ceiling ` +
+            `(trace ${route.slowestTraceId ?? 'unrecorded'})`,
+        );
+      }
+    }
+  }
+
+  /** The server's own count per status, which is what proved the 429 problem. */
+  static #describeStatuses(metrics: HttpStatsReport, report: string[]): void {
+    const totals = new Map<string, number>();
+    let all = 0;
+    for (const route of metrics.routes) {
+      for (const [status, n] of Object.entries(route.byStatus)) {
+        totals.set(status, (totals.get(status) ?? 0) + n);
+        all += n;
+      }
+    }
+    if (all === 0) return;
+    const shares = [...totals]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([status, n]) => `${status}: ${((n / all) * 100).toFixed(1)}%`)
+      .join('  ');
+    report.push(`server saw ${all} requests - ${shares}`);
+  }
+
+  static #ms(ns: number | undefined): string {
+    return ns === undefined
+      ? '-'
+      : `${(ns / NS_PER_MS).toFixed(2)}ms`.padStart(9);
+  }
+}

--- a/examples/full/src/soak/client.ts
+++ b/examples/full/src/soak/client.ts
@@ -1,0 +1,99 @@
+/** What an op hands the client. A subset of `RequestInit`, so the spread stays typed. */
+export interface CallInit {
+  readonly method?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly body?: string;
+}
+
+/** Every call gets this long before the client gives up and reports the route. */
+const DEADLINE_MS = 10_000;
+
+/**
+ * One virtual user against the app under load.
+ *
+ * The api key is per worker because `ThrottleModule`'s `subject` reads
+ * `x-api-key` before falling back to the address (`throttle/throttle.module.ts`).
+ * Every worker shares one loopback address, so without a key the whole run spends
+ * one budget and the load test measures the rate limiter.
+ *
+ * `call` returns the status rather than throwing on one. An unexpected status is
+ * a result the run has to classify, not a transport failure, and collapsing the
+ * two hid which was which.
+ */
+export class OpClient {
+  constructor(
+    private readonly base: string,
+    private readonly apiKey: string,
+  ) {}
+
+  async call(path: string, init: CallInit = {}): Promise<number> {
+    // Without a deadline a hung route parks its worker for the whole run, so the
+    // load quietly loses concurrency instead of reporting what stopped answering.
+    const res = await fetch(new URL(path, this.base), {
+      ...(init.method === undefined ? {} : { method: init.method }),
+      ...(init.body === undefined ? {} : { body: init.body }),
+      headers: { ...init.headers, 'x-api-key': this.apiKey },
+      signal: AbortSignal.timeout(DEADLINE_MS),
+    });
+    // The body must be drained or the socket is held until GC.
+    await res.arrayBuffer();
+    return res.status;
+  }
+
+  /** A JSON body, which is three lines at every call site otherwise. */
+  json(path: string, body: unknown, method = 'POST'): Promise<number> {
+    return this.call(path, {
+      method,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * A websocket that opens, exchanges a frame and closes. Connection churn is the
+   * leak-prone half of a gateway: a subscriber map added to on open and tidied
+   * only on a clean close grows on every aborted connection.
+   *
+   * `abort` sends no close frame, which is the half a clean-close-only cleanup
+   * path misses.
+   */
+  async socket(path: string, abort: boolean): Promise<number> {
+    const url = new URL(path, this.base).href.replace('http', 'ws');
+    const socket = new WebSocket(url);
+    await OpClient.#opened(socket);
+    if (abort) {
+      socket.terminate?.();
+      socket.close();
+      return 200;
+    }
+    socket.send(JSON.stringify({ event: 'say', data: 'soak' }));
+    await Bun.sleep(5);
+    socket.close();
+    return 200;
+  }
+
+  static #opened(socket: WebSocket): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('socket never opened')),
+        4000,
+      );
+      socket.addEventListener(
+        'open',
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+      socket.addEventListener(
+        'error',
+        () => {
+          clearTimeout(timer);
+          reject(new Error('socket errored'));
+        },
+        { once: true },
+      );
+    });
+  }
+}

--- a/examples/full/src/soak/client.ts
+++ b/examples/full/src/soak/client.ts
@@ -64,10 +64,13 @@ export class OpClient {
 
   static #opened(socket: WebSocket): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error('socket never opened')),
-        4000,
-      );
+      const timer = setTimeout(() => {
+        // Closed before rejecting: a handshake that lands after the deadline
+        // would otherwise reach `@OnOpen`, subscribe, and leave a subscriber
+        // behind that the run then reports as a leak.
+        socket.close();
+        reject(new Error('socket never opened'));
+      }, 4000);
       socket.addEventListener(
         'open',
         () => {

--- a/examples/full/src/soak/client.ts
+++ b/examples/full/src/soak/client.ts
@@ -9,16 +9,10 @@ export interface CallInit {
 const DEADLINE_MS = 10_000;
 
 /**
- * One virtual user against the app under load.
- *
- * The api key is per worker because `ThrottleModule`'s `subject` reads
- * `x-api-key` before falling back to the address (`throttle/throttle.module.ts`).
- * Every worker shares one loopback address, so without a key the whole run spends
- * one budget and the load test measures the rate limiter.
- *
- * `call` returns the status rather than throwing on one. An unexpected status is
- * a result the run has to classify, not a transport failure, and collapsing the
- * two hid which was which.
+ * One virtual user against the app under load, with its own api key so the
+ * throttle counts it apart. `call` returns the status rather than throwing on
+ * one: an unexpected status is a result to classify, not a transport failure.
+ * See docs/architecture/tooling.md, "The load run measured the rate limiter".
  */
 export class OpClient {
   constructor(
@@ -50,12 +44,8 @@ export class OpClient {
   }
 
   /**
-   * A websocket that opens, exchanges a frame and closes. Connection churn is the
-   * leak-prone half of a gateway: a subscriber map added to on open and tidied
-   * only on a clean close grows on every aborted connection.
-   *
-   * `abort` sends no close frame, which is the half a clean-close-only cleanup
-   * path misses.
+   * Opens, exchanges a frame and closes. `abort` sends no close frame, which is
+   * the half a clean-close-only cleanup path misses.
    */
   async socket(path: string, abort: boolean): Promise<number> {
     const url = new URL(path, this.base).href.replace('http', 'ws');

--- a/examples/full/src/soak/ops.ts
+++ b/examples/full/src/soak/ops.ts
@@ -1,0 +1,354 @@
+import type { OpClient } from './client.js';
+
+/**
+ * What an op needs before its result means anything. `redis` ops answer 503 with
+ * nothing at the broker, which is the app degrading rather than failing, so the
+ * work floor is only applied to them when the broker is up.
+ */
+export type ServiceNeed = 'none' | 'redis';
+
+export interface Op {
+  readonly name: string;
+  /** Relative share of the traffic. */
+  readonly weight: number;
+  /**
+   * The statuses that mean the app **did the work the op asked for**. A 429 is
+   * here only where being refused is the behaviour under test.
+   */
+  readonly expect: ReadonlySet<number>;
+  /**
+   * A legitimate refusal rather than work: a rate limit, or a route whose service
+   * is absent. Counted apart from `expect` and floored, because a run where every
+   * op is refused used to report zero failures.
+   */
+  readonly tolerate: ReadonlySet<number>;
+  readonly requires: ServiceNeed;
+  run(client: OpClient): Promise<number>;
+}
+
+const of = (...codes: readonly number[]): ReadonlySet<number> => new Set(codes);
+const NONE: ReadonlySet<number> = new Set<number>();
+/** Every route behind the global `ThrottleGuard` may be refused by it. */
+const THROTTLED = of(429);
+
+/**
+ * The traffic the load run puts through the app.
+ *
+ * Each op names the statuses that are work and the statuses that are a refusal,
+ * separately. The pair is what lets the run tell "the app served 8,000 requests"
+ * apart from "the app declined 8,000 requests", which one accept-set per op
+ * could not: every op accepting 429 meant a run that was 59% rate-limited
+ * reported `0 failed`.
+ */
+export const OPS: readonly Op[] = [
+  {
+    name: 'notes.list',
+    weight: 8,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/notes'),
+  },
+  {
+    name: 'notes.create',
+    weight: 4,
+    expect: of(201),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.json('api/notes', { text: 'soak note' }),
+  },
+  {
+    name: 'users.list',
+    weight: 6,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/users?limit=5'),
+  },
+  {
+    name: 'users.one',
+    weight: 4,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/users/1'),
+  },
+  {
+    name: 'ledger.write',
+    weight: 5,
+    expect: of(201),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) =>
+      c.json('api/ledger', { account: 'soak', amount: 1, memo: 'soak' }),
+  },
+  {
+    name: 'ledger.page',
+    weight: 4,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/ledger/page?take=5'),
+  },
+  {
+    name: 'cache.rw',
+    weight: 4,
+    expect: of(200),
+    tolerate: of(429, 503),
+    requires: 'redis',
+    run: async (c) => {
+      const key = `soak-${Math.floor(Math.random() * 64)}`;
+      const put = await c.json(
+        `api/cache/${key}`,
+        { data: { soak: true }, ttl: 60 },
+        'PUT',
+      );
+      if (put !== 200) return put;
+      return c.call(`api/cache/${key}`);
+    },
+  },
+  {
+    name: 'trace',
+    weight: 3,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) =>
+      c.call('api/trace', {
+        headers: {
+          traceparent:
+            '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        },
+      }),
+  },
+  /**
+   * Liveness tolerates nothing. A 429 here is what the first load run of this
+   * app found: `/health/live` behind a global `ThrottleGuard` answers an
+   * orchestrator's probe with a rate limit and the pod is killed under load.
+   */
+  {
+    name: 'health.live',
+    weight: 2,
+    expect: of(200),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.call('api/health/live'),
+  },
+  {
+    name: 'health.ready',
+    weight: 2,
+    expect: of(200),
+    tolerate: of(503),
+    requires: 'none',
+    run: (c) => c.call('api/health/ready'),
+  },
+  {
+    name: 'validation.400',
+    weight: 3,
+    expect: of(400),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.json('api/notes', { text: '' }),
+  },
+  {
+    name: 'unmatched.404',
+    weight: 3,
+    expect: of(404),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) =>
+      c.call(`api/nothing-here-${Math.random().toString(36).slice(2, 8)}`),
+  },
+  /** Both statuses are the route working: three per minute, then refusals. */
+  {
+    name: 'throttle.burst',
+    weight: 4,
+    expect: of(200, 429),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.call('api/limits/burst'),
+  },
+  /** The module default rather than a handler's own, which nothing else covers. */
+  {
+    name: 'throttle.default',
+    weight: 2,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/limits/default'),
+  },
+  {
+    name: 'throttle.exempt',
+    weight: 1,
+    expect: of(200),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.call('api/limits/exempt'),
+  },
+  {
+    name: 'openapi',
+    weight: 1,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/openapi.json'),
+  },
+  {
+    name: 'ws.clean',
+    weight: 3,
+    expect: of(200),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.socket('chat', false),
+  },
+  {
+    name: 'ws.abort',
+    weight: 3,
+    expect: of(200),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.socket('chat', true),
+  },
+  {
+    name: 'images.render',
+    weight: 2,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/images/render?width=32&format=webp'),
+  },
+  {
+    name: 'images.metadata',
+    weight: 1,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/images/metadata?width=32'),
+  },
+  {
+    name: 'files.rw',
+    weight: 2,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: async (c) => {
+      const key = `soak/${Math.floor(Math.random() * 32)}.txt`;
+      const q = `key=${encodeURIComponent(key)}`;
+      const put = await c.json(
+        `api/files/object?${q}`,
+        { content: 'soak' },
+        'PUT',
+      );
+      if (put !== 200) return put;
+      return c.call(`api/files/object?${q}`);
+    },
+  },
+  {
+    name: 'files.list',
+    weight: 1,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/files?prefix=soak'),
+  },
+  {
+    name: 'jobs.enqueue',
+    weight: 2,
+    expect: of(201),
+    tolerate: of(429, 503),
+    requires: 'redis',
+    run: (c) => c.json('api/jobs/thumbnails', { width: 64, format: 'webp' }),
+  },
+  /** 503 twice per key then 200, by construction: both are the route working. */
+  {
+    name: 'upstream.flaky',
+    weight: 2,
+    expect: of(200, 503),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.call('api/upstream/flaky'),
+  },
+  {
+    name: 'upstream.missing',
+    weight: 1,
+    expect: of(404),
+    tolerate: NONE,
+    requires: 'none',
+    run: (c) => c.call('api/upstream/missing'),
+  },
+  {
+    name: 'guards.anon',
+    weight: 2,
+    expect: of(401),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/reports'),
+  },
+  /**
+   * The same route with credentials. Without this the guarded half of the app is
+   * only ever measured being refused, so a guard that rejected everyone would
+   * pass the load run.
+   */
+  {
+    name: 'guards.auth',
+    weight: 2,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) =>
+      c.call('api/reports', { headers: { authorization: 'Bearer viewer' } }),
+  },
+  /**
+   * Authenticated and refused: the class-level `@Roles('admin')` rejects
+   * `viewer`. Without the header this would be the guard's 401 instead, which is
+   * `guards.anon` and a different branch.
+   */
+  {
+    name: 'guards.role',
+    weight: 1,
+    expect: of(403),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) =>
+      c.call('api/reports', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer viewer',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ title: 'soak' }),
+      }),
+  },
+  {
+    name: 'auth.profile',
+    weight: 2,
+    expect: of(401),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/profile'),
+  },
+  {
+    name: 'wiring',
+    weight: 1,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/wiring'),
+  },
+  {
+    name: 'dashboard',
+    weight: 1,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/_dunx'),
+  },
+  {
+    name: 'docs',
+    weight: 1,
+    expect: of(200),
+    tolerate: THROTTLED,
+    requires: 'none',
+    run: (c) => c.call('api/docs'),
+  },
+];

--- a/examples/full/src/soak/ops.ts
+++ b/examples/full/src/soak/ops.ts
@@ -11,16 +11,9 @@ export interface Op {
   readonly name: string;
   /** Relative share of the traffic. */
   readonly weight: number;
-  /**
-   * The statuses that mean the app **did the work the op asked for**. A 429 is
-   * here only where being refused is the behaviour under test.
-   */
+  /** What means the app did the work. A 429 only where refusal is the point. */
   readonly expect: ReadonlySet<number>;
-  /**
-   * A legitimate refusal rather than work: a rate limit, or a route whose service
-   * is absent. Counted apart from `expect` and floored, because a run where every
-   * op is refused used to report zero failures.
-   */
+  /** A refusal rather than work: a rate limit, or an absent service. Floored. */
   readonly tolerate: ReadonlySet<number>;
   readonly requires: ServiceNeed;
   run(client: OpClient): Promise<number>;
@@ -32,13 +25,9 @@ const NONE: ReadonlySet<number> = new Set<number>();
 const THROTTLED = of(429);
 
 /**
- * The traffic the load run puts through the app.
- *
- * Each op names the statuses that are work and the statuses that are a refusal,
- * separately. The pair is what lets the run tell "the app served 8,000 requests"
- * apart from "the app declined 8,000 requests", which one accept-set per op
- * could not: every op accepting 429 meant a run that was 59% rate-limited
- * reported `0 failed`.
+ * The traffic the load run puts through the app, each op naming what counts as
+ * work and what counts as a refusal.
+ * See docs/architecture/tooling.md, "The load run measured the rate limiter".
  */
 export const OPS: readonly Op[] = [
   {
@@ -121,11 +110,7 @@ export const OPS: readonly Op[] = [
         },
       }),
   },
-  /**
-   * Liveness tolerates nothing. A 429 here is what the first load run of this
-   * app found: `/health/live` behind a global `ThrottleGuard` answers an
-   * orchestrator's probe with a rate limit and the pod is killed under load.
-   */
+  /** Tolerates nothing: a 429 here is an orchestrator killing the pod. */
   {
     name: 'health.live',
     weight: 2,

--- a/examples/full/src/soak/soak.ts
+++ b/examples/full/src/soak/soak.ts
@@ -12,15 +12,10 @@ import { Sampler } from './sampler.js';
 import { Workload } from './workload.js';
 
 /**
- * The example defaults to 1,000 requests per 60 s, which a load run exhausts in
- * its first second. A 40 s run at concurrency 12 answered **59.4% of its
- * requests with 429** and reported no failures, because every operation accepted
- * one: the rate limiter was the only thing under test.
- *
+ * Raised so the app rather than the rate limiter is what this measures.
  * `ConfigModule` holds a live reference to `Bun.env` and reads it when
  * `createApp()` runs, so setting it here reaches the app that boots below.
- * `/limits/burst` keeps its own `@Throttle` of 3 per minute and is what proves
- * refusals still happen; `throttle.test.ts` covers the module default.
+ * See docs/architecture/tooling.md, "The load run measured the rate limiter".
  */
 Bun.env['THROTTLE_LIMIT'] ??= '100000';
 
@@ -50,16 +45,8 @@ export interface SoakVerdict {
 const MB = 1024 * 1024;
 
 /**
- * The verdict comes from **settled** heap, not from the in-flight series.
- *
- * An in-flight slope measures the allocator as much as the program: RSS climbed
- * 11 MiB/min on a run whose `heapUsed` was falling and whose settled RSS came back
- * 20 MiB below its own peak, because an arena grows under load and is returned
- * lazily. So the run is split into rounds, each ending with a forced GC and a
- * quiet sample, and the fit is over those. A leak survives a GC; an arena does not.
- *
- * 2 MiB/min is roughly 3 GiB a day, which is a pod restarting on a memory limit
- * inside a week.
+ * Over the per-round settled readings, not the in-flight series. 2 MiB/min is
+ * about 3 GiB a day. See docs/architecture/tooling.md, "The leak verdict".
  */
 const SETTLED_HEAP_LIMIT_PER_MIN = 2 * MB;
 /** RSS is reported rather than judged, for the reason above. */
@@ -162,12 +149,9 @@ export class Soak {
 
   /**
    * A burst at {@link STRESS_FACTOR} times the steady concurrency, then a
-   * recovery round back at it.
-   *
-   * The work floor is **not** applied to the burst: being refused under stress is
-   * the rate limiter doing its job. What must hold is that nothing fails at the
-   * transport, no route answers a status it never answers when idle, and the app
-   * comes back - a server that degrades and stays degraded passes a steady run.
+   * recovery round back at it. No work floor on the burst: being refused under
+   * stress is correct. What must hold is that nothing fails at the transport, no
+   * route answers a status it never answers idle, and the app comes back.
    */
   async #stress(
     url: string,
@@ -215,13 +199,10 @@ export class Soak {
   }
 
   /**
-   * Shutdown with traffic **in flight**, which is the half a request-per-test
-   * suite cannot reach and the half a rolling deploy always hits.
-   *
-   * The traffic is its own `Workload` and its errors are not judged: once the
-   * port closes, an in-flight request failing is the point. What is judged is
-   * that `shutdown()` finishes inside its budget and that the traffic settles
-   * rather than hanging on a socket the server never closed.
+   * Shutdown with traffic **in flight**. The traffic is its own `Workload` and
+   * its errors are not judged: once the port closes, an in-flight request
+   * failing is the point. What is judged is that `shutdown()` finishes inside
+   * its budget and that the traffic settles rather than hanging.
    */
   async #shutdownUnderLoad(
     app: HttpApp,
@@ -251,9 +232,7 @@ export class Soak {
       // the process open for 15 seconds after a clean shutdown.
       if (handle !== undefined) clearTimeout(handle);
     }
-    // The port is closed, or shutdown gave up on closing it. Either way anything
-    // still looping is retrying a refused connection rather than testing
-    // something, and one 8-second window logged 189,803 of those.
+    // Anything still looping is now retrying a refused connection.
     traffic.stop();
     if (outcome === 'timeout') {
       failures.push(
@@ -320,13 +299,8 @@ export class Soak {
       (settledPoints[settledPoints.length - 1]?.[1] ?? 0) -
       (settledPoints[0]?.[1] ?? 0);
     const minutes = elapsed / 60;
-    /**
-     * A settled reading carries about +/-2.5 MiB of GC noise, so a one-minute run
-     * cannot resolve 2 MiB/min from nothing and saying otherwise would be a coin
-     * toss dressed as a gate. Both the fitted slope and the raw first-to-last rise
-     * have to clear the noise before this fails, and a window too short to judge
-     * says so instead of guessing.
-     */
+    // Both the slope and the raw rise must clear the noise floor, and a window
+    // too short to resolve 2 MiB/min says so rather than guessing.
     const judgeable =
       minutes >= MIN_VERDICT_MINUTES && settledPoints.length >= 4;
     report.push(

--- a/examples/full/src/soak/soak.ts
+++ b/examples/full/src/soak/soak.ts
@@ -234,13 +234,21 @@ export class Soak {
     }
     // Anything still looping is now retrying a refused connection.
     traffic.stop();
+    const ms = performance.now() - started;
+    // On the timeout path too: `stop()` ends a worker's loop but not the call
+    // inside it, so returning before this leaves fetches outstanding.
+    const settled = await Soak.#settle(running);
+    if (settled === 'hung') {
+      failures.push(
+        'traffic in flight at shutdown never settled: a socket was left open',
+      );
+    }
     if (outcome === 'timeout') {
       failures.push(
         'shutdown did not finish within 15s with traffic in flight',
       );
       return;
     }
-    const ms = performance.now() - started;
     report.push(
       `shutdown took ${ms.toFixed(0)}ms with ${inFlight} calls already made and workers still calling`,
     );
@@ -249,28 +257,28 @@ export class Soak {
         `shutdown took ${ms.toFixed(0)}ms under load, over the ${SHUTDOWN_BUDGET_MS}ms budget`,
       );
     }
+    if (settled === 'settled') {
+      const totals = traffic.totals();
+      report.push(
+        `traffic at shutdown settled: ${totals.calls} calls, ${totals.worked} worked before the port closed`,
+      );
+    }
+  }
 
-    // A cancellable timer for the reason the one above is: `Bun.sleep` cannot be
-    // cleared, so the loser of this race holds the process open for 15 seconds.
-    let settleHandle: ReturnType<typeof setTimeout> | undefined;
-    const settled = await Promise.race([
+  /**
+   * The bounded wait for traffic to stop. The timer is cleared either way:
+   * `Bun.sleep` cannot be, and the loser of the race held the process open.
+   */
+  static #settle(running: Promise<void>): Promise<'settled' | 'hung'> {
+    let handle: ReturnType<typeof setTimeout> | undefined;
+    return Promise.race([
       running.then(() => 'settled' as const),
       new Promise<'hung'>((resolve) => {
-        settleHandle = setTimeout(() => resolve('hung'), 15_000);
+        handle = setTimeout(() => resolve('hung'), 15_000);
       }),
     ]).finally(() => {
-      if (settleHandle !== undefined) clearTimeout(settleHandle);
+      if (handle !== undefined) clearTimeout(handle);
     });
-    if (settled === 'hung') {
-      failures.push(
-        'traffic in flight at shutdown never settled: a socket was left open',
-      );
-      return;
-    }
-    const totals = traffic.totals();
-    report.push(
-      `traffic at shutdown settled: ${totals.calls} calls, ${totals.worked} worked before the port closed`,
-    );
   }
 
   static #reportSampler(

--- a/examples/full/src/soak/soak.ts
+++ b/examples/full/src/soak/soak.ts
@@ -1,17 +1,37 @@
 import { Logger } from '@dunx/core';
-import { PubSub, type HttpApp } from '@dunx/http';
-import { createApp } from '../main.js';
+import {
+  HealthRegistry,
+  PubSub,
+  RequestMetrics,
+  type HttpApp,
+} from '@dunx/http';
 import { Lobby } from '../chat/lobby.service.js';
+import { createApp } from '../main.js';
+import { LoadBudget } from './budget.js';
 import { Sampler } from './sampler.js';
 import { Workload } from './workload.js';
 
 /**
+ * The example defaults to 1,000 requests per 60 s, which a load run exhausts in
+ * its first second. A 40 s run at concurrency 12 answered **59.4% of its
+ * requests with 429** and reported no failures, because every operation accepted
+ * one: the rate limiter was the only thing under test.
+ *
+ * `ConfigModule` holds a live reference to `Bun.env` and reads it when
+ * `createApp()` runs, so setting it here reaches the app that boots below.
+ * `/limits/burst` keeps its own `@Throttle` of 3 per minute and is what proves
+ * refusals still happen; `throttle.test.ts` covers the module default.
+ */
+Bun.env['THROTTLE_LIMIT'] ??= '100000';
+
+/**
  * A long-running process under sustained mixed load, watched for the things a
  * request-per-test suite cannot see: memory that never comes back, an event loop
- * that stalls, and per-connection state that outlives the connection.
+ * that stalls, per-connection state that outlives the connection, and a route
+ * whose p99 moved.
  *
  * `bun run soak` for the default 30 seconds, `bun run soak -- --seconds 600` for
- * a real one. The bounded version in `soak.test.ts` is what CI runs.
+ * a real one. CI runs 40 seconds at concurrency 12.
  */
 export interface SoakOptions {
   readonly seconds: number;
@@ -48,6 +68,10 @@ const MAX_LAG_MS = 750;
 const MIN_VERDICT_MINUTES = 3;
 /** One settled reading's GC noise, measured across runs at about +/-2.5 MiB. */
 const NOISE_FLOOR = 5 * MB;
+/** The stress burst, as a multiple of the steady concurrency. */
+const STRESS_FACTOR = 4;
+/** Shutdown has this long once traffic is in flight, and no longer. */
+const SHUTDOWN_BUDGET_MS = 10_000;
 
 export class Soak {
   constructor(private readonly options: SoakOptions) {}
@@ -59,6 +83,13 @@ export class Soak {
     const pubsub = app.get(PubSub);
     const failures: string[] = [];
     const report: string[] = [];
+
+    const redisUp = await Soak.#redisUp(app);
+    report.push(
+      redisUp
+        ? 'redis is up: the cache and queue ops are held to the work floor'
+        : 'redis is down: the cache and queue ops report but are not floored',
+    );
 
     const before = pubsub.subscriberCount(Lobby.TOPIC);
     const workload = new Workload(url);
@@ -97,11 +128,172 @@ export class Soak {
     const elapsed = (Date.now() - startedAt) / 1000;
     report.push(
       `${totals.calls} calls in ${elapsed.toFixed(1)}s, ` +
-        `${(totals.calls / elapsed).toFixed(0)}/s, ${totals.failures} failed`,
+        `${(totals.calls / elapsed).toFixed(0)}/s`,
     );
     report.push(...workload.rows());
-    const trends = sampler.trends(this.options.warmupMs);
-    report.push(...trends.map((trend) => Sampler.format(trend)));
+
+    const budget = new LoadBudget();
+    const verdict = budget.check({
+      stats: workload.stats,
+      elapsedSeconds: elapsed,
+      metrics: app.get(RequestMetrics).snapshot(),
+      redisUp,
+    });
+    report.push(...verdict.report);
+    failures.push(...verdict.failures);
+
+    Soak.#reportSampler(sampler, elapsed, settled, report, failures);
+    Soak.#reportLeak(settledPoints, elapsed, report, failures);
+
+    // Every socket the steady phase opened has closed by now, cleanly or not.
+    await Bun.sleep(250);
+    const after = pubsub.subscriberCount(Lobby.TOPIC);
+    report.push(`chat subscribers: ${before} before, ${after} after`);
+    if (after > before) {
+      failures.push(
+        `${after - before} chat subscriber(s) outlived their sockets (was ${before})`,
+      );
+    }
+
+    await this.#stress(url, redisUp, report, failures);
+    await this.#shutdownUnderLoad(app, url, report, failures);
+    return { ok: failures.length === 0, failures, calls: totals.calls, report };
+  }
+
+  /**
+   * A burst at {@link STRESS_FACTOR} times the steady concurrency, then a
+   * recovery round back at it.
+   *
+   * The work floor is **not** applied to the burst: being refused under stress is
+   * the rate limiter doing its job. What must hold is that nothing fails at the
+   * transport, no route answers a status it never answers when idle, and the app
+   * comes back - a server that degrades and stays degraded passes a steady run.
+   */
+  async #stress(
+    url: string,
+    redisUp: boolean,
+    report: string[],
+    failures: string[],
+  ): Promise<void> {
+    const concurrency = this.options.concurrency * STRESS_FACTOR;
+    const burst = new Workload(url);
+    const startedAt = Date.now();
+    await burst.run(Date.now() + 5000, concurrency);
+    const elapsed = (Date.now() - startedAt) / 1000;
+    const totals = burst.totals();
+    report.push(
+      `stress: ${totals.calls} calls at concurrency ${concurrency} in ${elapsed.toFixed(1)}s, ` +
+        `${totals.worked} worked, ${totals.refused} refused, ${totals.bad} bad`,
+    );
+    for (const [name, s] of burst.stats) {
+      if (s.errors > 0) {
+        failures.push(
+          `stress ${name}: ${s.errors}/${s.calls} failed at the transport, last: ${s.lastDetail}`,
+        );
+      }
+      if (s.unexpected.size > 0) {
+        const seen = [...s.unexpected]
+          .map(([status, n]) => `${status} x${n}`)
+          .join(', ');
+        failures.push(`stress ${name}: answered ${seen} under load`);
+      }
+    }
+
+    // Recovery: the same traffic at the steady rate has to meet the floor again.
+    const after = new Workload(url);
+    const recoveryStarted = Date.now();
+    await after.run(Date.now() + 4000, this.options.concurrency);
+    const recovery = new LoadBudget().check({
+      stats: after.stats,
+      elapsedSeconds: (Date.now() - recoveryStarted) / 1000,
+      redisUp,
+    });
+    report.push(
+      `recovery after stress: ${after.totals().worked} calls did work`,
+    );
+    failures.push(...recovery.failures.map((f) => `after stress, ${f}`));
+  }
+
+  /**
+   * Shutdown with traffic **in flight**, which is the half a request-per-test
+   * suite cannot reach and the half a rolling deploy always hits.
+   *
+   * The traffic is its own `Workload` and its errors are not judged: once the
+   * port closes, an in-flight request failing is the point. What is judged is
+   * that `shutdown()` finishes inside its budget and that the traffic settles
+   * rather than hanging on a socket the server never closed.
+   */
+  async #shutdownUnderLoad(
+    app: HttpApp,
+    url: string,
+    report: string[],
+    failures: string[],
+  ): Promise<void> {
+    const traffic = new Workload(url);
+    const running = traffic.run(Date.now() + 8000, this.options.concurrency);
+    // Long enough for every worker to have a request on the wire.
+    await Bun.sleep(500);
+    const inFlight = traffic.totals().calls;
+
+    const started = performance.now();
+    let handle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<'timeout'>((resolve) => {
+      handle = setTimeout(() => resolve('timeout'), 15_000);
+    });
+    let outcome: 'done' | 'timeout';
+    try {
+      outcome = await Promise.race([
+        app.shutdown().then(() => 'done' as const),
+        timeout,
+      ]);
+    } finally {
+      // The loser of the race is still a live timer, and leaving it pending held
+      // the process open for 15 seconds after a clean shutdown.
+      if (handle !== undefined) clearTimeout(handle);
+    }
+    // The port is closed, or shutdown gave up on closing it. Either way anything
+    // still looping is retrying a refused connection rather than testing
+    // something, and one 8-second window logged 189,803 of those.
+    traffic.stop();
+    if (outcome === 'timeout') {
+      failures.push(
+        'shutdown did not finish within 15s with traffic in flight',
+      );
+      return;
+    }
+    const ms = performance.now() - started;
+    report.push(
+      `shutdown took ${ms.toFixed(0)}ms with ${inFlight} calls already made and workers still calling`,
+    );
+    if (ms > SHUTDOWN_BUDGET_MS) {
+      failures.push(
+        `shutdown took ${ms.toFixed(0)}ms under load, over the ${SHUTDOWN_BUDGET_MS}ms budget`,
+      );
+    }
+
+    const settled = await Promise.race([
+      running.then(() => 'settled' as const),
+      Bun.sleep(15_000).then(() => 'hung' as const),
+    ]);
+    if (settled === 'hung') {
+      failures.push(
+        'traffic in flight at shutdown never settled: a socket was left open',
+      );
+      return;
+    }
+    const totals = traffic.totals();
+    report.push(
+      `traffic at shutdown settled: ${totals.calls} calls, ${totals.worked} worked before the port closed`,
+    );
+  }
+
+  static #reportSampler(
+    sampler: Sampler,
+    elapsed: number,
+    settled: ReturnType<typeof process.memoryUsage>,
+    report: string[],
+    failures: string[],
+  ): void {
     report.push(
       `cpu ${sampler.cpuMs().toFixed(0)}ms over ${elapsed.toFixed(1)}s ` +
         `(${((sampler.cpuMs() / (elapsed * 1000)) * 100).toFixed(0)}% of one core), ` +
@@ -110,17 +302,19 @@ export class Soak {
     report.push(
       `settled heap ${(settled.heapUsed / MB).toFixed(1)} MiB, rss ${(settled.rss / MB).toFixed(1)} MiB`,
     );
-
-    if (totals.failures > 0) {
-      for (const [name, s] of workload.stats) {
-        if (s.failures > 0) {
-          failures.push(
-            `${name}: ${s.failures}/${s.calls} failed, last: ${s.lastDetail}`,
-          );
-        }
-      }
+    if (sampler.maxLagMs() > MAX_LAG_MS) {
+      failures.push(
+        `event loop stalled for ${sampler.maxLagMs().toFixed(0)}ms`,
+      );
     }
+  }
 
+  static #reportLeak(
+    settledPoints: readonly (readonly [number, number])[],
+    elapsed: number,
+    report: string[],
+    failures: string[],
+  ): void {
     const growth = Soak.settledSlope(settledPoints);
     const rise =
       (settledPoints[settledPoints.length - 1]?.[1] ?? 0) -
@@ -153,24 +347,6 @@ export class Soak {
           'which a forced GC did not reclaim',
       );
     }
-    if (sampler.maxLagMs() > MAX_LAG_MS) {
-      failures.push(
-        `event loop stalled for ${sampler.maxLagMs().toFixed(0)}ms`,
-      );
-    }
-
-    // Every socket the workload opened has closed by now, cleanly or not.
-    await Bun.sleep(250);
-    const after = pubsub.subscriberCount(Lobby.TOPIC);
-    report.push(`chat subscribers: ${before} before, ${after} after`);
-    if (after > before) {
-      failures.push(
-        `${after - before} chat subscriber(s) outlived their sockets (was ${before})`,
-      );
-    }
-
-    await this.#shutdown(app, failures);
-    return { ok: failures.length === 0, failures, calls: totals.calls, report };
   }
 
   /** Least squares over the per-round quiet readings, in bytes per minute. */
@@ -191,31 +367,12 @@ export class Soak {
     return divisor === 0 ? 0 : (n * sxy - sx * sy) / divisor;
   }
 
-  /** Shutdown is itself under test: it has to finish, and it has to be quiet. */
-  async #shutdown(app: HttpApp, failures: string[]): Promise<void> {
-    const started = performance.now();
-    // The handle is kept and cleared: the loser of the race is still a live timer,
-    // and leaving it pending held the process open for 15 seconds after a clean
-    // shutdown, which is 15 seconds on every CI run.
-    let handle: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<'timeout'>((resolve) => {
-      handle = setTimeout(() => resolve('timeout'), 15_000);
-    });
-    let outcome: 'done' | 'timeout';
-    try {
-      outcome = await Promise.race([
-        app.shutdown().then(() => 'done' as const),
-        timeout,
-      ]);
-    } finally {
-      if (handle !== undefined) clearTimeout(handle);
-    }
-    if (outcome === 'timeout') {
-      failures.push('shutdown did not finish within 15s');
-      return;
-    }
-    const ms = performance.now() - started;
-    if (ms > 10_000) failures.push(`shutdown took ${ms.toFixed(0)}ms`);
+  /** The app's own answer, so the run and the readiness probe cannot disagree. */
+  static async #redisUp(app: HttpApp): Promise<boolean> {
+    const { checks } = await app.get(HealthRegistry).readiness();
+    return checks.some(
+      (check) => check.name.includes('redis') && check.state === 'up',
+    );
   }
 }
 

--- a/examples/full/src/soak/soak.ts
+++ b/examples/full/src/soak/soak.ts
@@ -250,10 +250,17 @@ export class Soak {
       );
     }
 
+    // A cancellable timer for the reason the one above is: `Bun.sleep` cannot be
+    // cleared, so the loser of this race holds the process open for 15 seconds.
+    let settleHandle: ReturnType<typeof setTimeout> | undefined;
     const settled = await Promise.race([
       running.then(() => 'settled' as const),
-      Bun.sleep(15_000).then(() => 'hung' as const),
-    ]);
+      new Promise<'hung'>((resolve) => {
+        settleHandle = setTimeout(() => resolve('hung'), 15_000);
+      }),
+    ]).finally(() => {
+      if (settleHandle !== undefined) clearTimeout(settleHandle);
+    });
     if (settled === 'hung') {
       failures.push(
         'traffic in flight at shutdown never settled: a socket was left open',

--- a/examples/full/src/soak/workload.ts
+++ b/examples/full/src/soak/workload.ts
@@ -1,350 +1,92 @@
-/**
- * The traffic the soak run puts through the app.
- *
- * Every operation names the statuses it accepts, because a soak that treats a
- * 429 or a 404 as a failure cannot exercise the rate limiter or the unmatched
- * path, and those are two of the four places that hold per-request state. An
- * unexpected status is recorded against the operation rather than thrown, so one
- * broken route does not end the run and hide everything behind it.
- */
-export interface OpResult {
-  readonly name: string;
-  readonly ok: boolean;
-  readonly ms: number;
-  readonly detail?: string;
-}
+import { OpClient } from './client.js';
+import { OPS, type Op } from './ops.js';
 
 export interface OpStats {
   calls: number;
-  failures: number;
+  /** Answered with a status the op called work. */
+  worked: number;
+  /** Answered with a legitimate refusal: a rate limit, or a degraded route. */
+  refused: number;
+  /** Answered with a status the op named neither, keyed by status. */
+  readonly unexpected: Map<number, number>;
+  /** The transport failed: a timeout, a reset, a socket that never opened. */
+  errors: number;
   totalMs: number;
   maxMs: number;
   lastDetail: string | undefined;
 }
 
-interface Op {
-  readonly name: string;
-  /** Relative share of the traffic. */
-  readonly weight: number;
-  run(base: string): Promise<string>;
-}
-
-const okStatuses = (...codes: readonly number[]): ReadonlySet<number> =>
-  new Set(codes);
-
-/** A fetch that names the route in its failure, since `fetch` alone does not. */
-const call = async (
-  base: string,
-  path: string,
-  accept: ReadonlySet<number>,
-  init?: RequestInit,
-): Promise<string> => {
-  // Without a deadline a hung route parks its worker for the whole run, so the
-  // soak quietly loses concurrency instead of reporting the route that stopped
-  // answering. Well above the slowest observed route on a loaded 2-core runner.
-  const res = await fetch(new URL(path, base), {
-    ...init,
-    signal: AbortSignal.timeout(10_000),
-  });
-  // The body must be drained or the socket is held until GC.
-  await res.arrayBuffer();
-  if (!accept.has(res.status)) {
-    throw new Error(`${init?.method ?? 'GET'} ${path} -> ${res.status}`);
-  }
-  return String(res.status);
-};
-
-const json = (body: unknown): RequestInit => ({
-  method: 'POST',
-  headers: { 'content-type': 'application/json' },
-  body: JSON.stringify(body),
+const emptyStats = (): OpStats => ({
+  calls: 0,
+  worked: 0,
+  refused: 0,
+  unexpected: new Map(),
+  errors: 0,
+  totalMs: 0,
+  maxMs: 0,
+  lastDetail: undefined,
 });
 
 /**
- * A websocket that opens, exchanges a frame and closes. Connection churn is the
- * leak-prone half of a gateway: a subscriber map that is added to on open and
- * only tidied on a clean close grows on every aborted connection.
+ * Drives `OPS` at a fixed concurrency and records what each one answered.
+ *
+ * Every worker is its own {@link OpClient} with its own api key, so the rate
+ * limiter counts them apart. Sharing one subject made the limiter the bottleneck
+ * and the run measured refusals rather than the app.
  */
-const socketChurn = async (base: string, abort: boolean): Promise<string> => {
-  const url = new URL('chat', base).href.replace('http', 'ws');
-  const socket = new WebSocket(url);
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('socket never opened')),
-      4000,
-    );
-    socket.addEventListener(
-      'open',
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
-    socket.addEventListener(
-      'error',
-      () => {
-        clearTimeout(timer);
-        reject(new Error('socket errored'));
-      },
-      { once: true },
-    );
-  });
-  if (abort) {
-    // No close frame: the half that a clean-close-only cleanup path misses.
-    socket.terminate?.();
-    socket.close();
-    return 'aborted';
-  }
-  socket.send(JSON.stringify({ event: 'say', data: 'soak' }));
-  await new Promise((resolve) => setTimeout(resolve, 5));
-  socket.close();
-  return 'closed';
-};
-
-const OPS: readonly Op[] = [
-  {
-    name: 'notes.list',
-    weight: 8,
-    run: (b) => call(b, 'api/notes', okStatuses(200, 429)),
-  },
-  {
-    name: 'notes.create',
-    weight: 4,
-    run: (b) =>
-      call(b, 'api/notes', okStatuses(201, 429), json({ text: 'soak note' })),
-  },
-  {
-    name: 'users.list',
-    weight: 6,
-    run: (b) => call(b, 'api/users?limit=5', okStatuses(200, 429)),
-  },
-  {
-    name: 'users.one',
-    weight: 4,
-    run: (b) => call(b, 'api/users/1', okStatuses(200, 404, 429)),
-  },
-  {
-    name: 'ledger.write',
-    weight: 5,
-    run: (b) =>
-      call(
-        b,
-        'api/ledger',
-        okStatuses(201, 429, 503),
-        json({ account: 'soak', amount: 1, memo: 'soak' }),
-      ),
-  },
-  {
-    name: 'ledger.page',
-    weight: 4,
-    run: (b) => call(b, 'api/ledger/page?take=5', okStatuses(200, 429, 503)),
-  },
-  {
-    name: 'cache.rw',
-    weight: 4,
-    run: async (b) => {
-      const key = `soak-${Math.floor(Math.random() * 64)}`;
-      await call(b, `api/cache/${key}`, okStatuses(200, 204, 429, 503), {
-        method: 'PUT',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ data: { soak: true }, ttl: 60 }),
-      });
-      return call(b, `api/cache/${key}`, okStatuses(200, 404, 429, 503));
-    },
-  },
-  {
-    name: 'trace',
-    weight: 3,
-    run: (b) =>
-      call(b, 'api/trace', okStatuses(200, 429), {
-        headers: {
-          traceparent:
-            '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
-        },
-      }),
-  },
-  {
-    name: 'health.ready',
-    weight: 2,
-    run: (b) => call(b, 'api/health/ready', okStatuses(200, 503)),
-  },
-  {
-    name: 'health.live',
-    weight: 2,
-    run: (b) => call(b, 'api/health/live', okStatuses(200, 503)),
-  },
-  {
-    name: 'validation.400',
-    weight: 3,
-    run: (b) => call(b, 'api/notes', okStatuses(400, 429), json({ text: '' })),
-  },
-  {
-    name: 'unmatched.404',
-    weight: 3,
-    run: (b) =>
-      call(
-        b,
-        `api/nothing-here-${Math.random().toString(36).slice(2, 8)}`,
-        okStatuses(404, 429),
-      ),
-  },
-  {
-    name: 'throttle.burst',
-    weight: 4,
-    run: (b) => call(b, 'api/limits/burst', okStatuses(200, 429)),
-  },
-  {
-    name: 'openapi',
-    weight: 1,
-    run: (b) => call(b, 'api/openapi.json', okStatuses(200, 429)),
-  },
-  {
-    name: 'ws.clean',
-    weight: 3,
-    run: (b) => socketChurn(b, false),
-  },
-  {
-    name: 'ws.abort',
-    weight: 3,
-    run: (b) => socketChurn(b, true),
-  },
-  /**
-   * The rest of the surface. Each accepts 503 as well, since an absent service is
-   * the app degrading rather than failing: the same run has to be meaningful on a
-   * laptop with nothing up and in CI with valkey and postgres.
-   */
-  {
-    name: 'images.render',
-    weight: 2,
-    run: (b) =>
-      call(
-        b,
-        'api/images/render?width=32&format=webp',
-        okStatuses(200, 429, 503),
-      ),
-  },
-  {
-    name: 'images.metadata',
-    weight: 1,
-    run: (b) =>
-      call(b, 'api/images/metadata?width=32', okStatuses(200, 429, 503)),
-  },
-  {
-    name: 'files.rw',
-    weight: 2,
-    run: async (b) => {
-      const key = `soak/${Math.floor(Math.random() * 32)}.txt`;
-      const q = `key=${encodeURIComponent(key)}`;
-      await call(
-        b,
-        `api/files/object?${q}`,
-        okStatuses(200, 201, 204, 429, 503),
-        {
-          method: 'PUT',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ content: 'soak' }),
-        },
-      );
-      return call(b, `api/files/object?${q}`, okStatuses(200, 404, 429, 503));
-    },
-  },
-  {
-    name: 'files.list',
-    weight: 1,
-    run: (b) => call(b, 'api/files?prefix=soak', okStatuses(200, 429, 503)),
-  },
-  {
-    name: 'jobs.enqueue',
-    weight: 2,
-    run: (b) =>
-      call(
-        b,
-        'api/jobs/thumbnails',
-        okStatuses(200, 201, 202, 429, 503),
-        json({ width: 64, format: 'webp' }),
-      ),
-  },
-  {
-    name: 'upstream.flaky',
-    weight: 2,
-    run: (b) =>
-      call(b, 'api/upstream/flaky', okStatuses(200, 429, 502, 503, 504)),
-  },
-  {
-    name: 'upstream.missing',
-    weight: 1,
-    run: (b) =>
-      call(b, 'api/upstream/missing', okStatuses(200, 404, 429, 502, 503, 504)),
-  },
-  {
-    name: 'guards.reports',
-    weight: 2,
-    run: (b) => call(b, 'api/reports', okStatuses(200, 401, 403, 429)),
-  },
-  {
-    name: 'auth.profile',
-    weight: 2,
-    run: (b) => call(b, 'api/profile', okStatuses(200, 401, 403, 429)),
-  },
-  {
-    name: 'wiring',
-    weight: 1,
-    run: (b) => call(b, 'api/wiring', okStatuses(200, 429)),
-  },
-  {
-    name: 'dashboard',
-    weight: 1,
-    run: (b) => call(b, 'api/_dunx', okStatuses(200, 404, 429)),
-  },
-  {
-    name: 'docs',
-    weight: 1,
-    run: (b) => call(b, 'api/docs', okStatuses(200, 429)),
-  },
-];
-
 export class Workload {
   readonly stats = new Map<string, OpStats>();
-  #picker: readonly Op[] = [];
+  readonly #picker: readonly Op[];
+  #stopped = false;
 
   constructor(private readonly base: string) {
-    for (const op of OPS) {
-      this.stats.set(op.name, {
-        calls: 0,
-        failures: 0,
-        totalMs: 0,
-        maxMs: 0,
-        lastDetail: undefined,
-      });
-    }
+    for (const op of OPS) this.stats.set(op.name, emptyStats());
     // Expand the weights once so a pick is one array index rather than a scan.
     this.#picker = OPS.flatMap((op) => Array<Op>(op.weight).fill(op));
   }
 
+  /**
+   * Asks every worker to finish its current call and leave.
+   *
+   * The shutdown phase needs this: once the port has closed, workers left running
+   * to their deadline retry a refused connection as fast as the loop allows, and
+   * one 8-second window logged 189,803 of them.
+   */
+  stop(): void {
+    this.#stopped = true;
+  }
+
   /** Runs `concurrency` workers until `deadline`, resolving when all have stopped. */
   async run(deadline: number, concurrency: number): Promise<void> {
-    const worker = async (): Promise<void> => {
-      while (Date.now() < deadline) {
+    const worker = async (id: number): Promise<void> => {
+      const client = new OpClient(this.base, `soak-vu-${id}`);
+      while (!this.#stopped && Date.now() < deadline) {
         const op =
           this.#picker[Math.floor(Math.random() * this.#picker.length)];
         if (op === undefined) return;
-        await this.#once(op);
+        await this.#once(op, client);
       }
     };
-    await Promise.all(Array.from({ length: concurrency }, worker));
+    await Promise.all(
+      Array.from({ length: concurrency }, (_, id) => worker(id)),
+    );
   }
 
-  async #once(op: Op): Promise<void> {
+  async #once(op: Op, client: OpClient): Promise<void> {
     const entry = this.stats.get(op.name);
     if (entry === undefined) return;
     const started = performance.now();
+    entry.calls++;
     try {
-      await op.run(this.base);
-      entry.calls++;
+      const status = await op.run(client);
+      if (op.expect.has(status)) entry.worked++;
+      else if (op.tolerate.has(status)) entry.refused++;
+      else {
+        entry.unexpected.set(status, (entry.unexpected.get(status) ?? 0) + 1);
+        entry.lastDetail = `unexpected ${status}`;
+      }
     } catch (error) {
-      entry.calls++;
-      entry.failures++;
+      entry.errors++;
       entry.lastDetail = error instanceof Error ? error.message : String(error);
     }
     const ms = performance.now() - started;
@@ -352,14 +94,19 @@ export class Workload {
     entry.maxMs = Math.max(entry.maxMs, ms);
   }
 
-  totals(): { calls: number; failures: number } {
+  totals(): { calls: number; worked: number; refused: number; bad: number } {
     let calls = 0;
-    let failures = 0;
+    let worked = 0;
+    let refused = 0;
+    let bad = 0;
     for (const s of this.stats.values()) {
       calls += s.calls;
-      failures += s.failures;
+      worked += s.worked;
+      refused += s.refused;
+      bad += s.errors;
+      for (const n of s.unexpected.values()) bad += n;
     }
-    return { calls, failures };
+    return { calls, worked, refused, bad };
   }
 
   rows(): readonly string[] {
@@ -368,11 +115,23 @@ export class Workload {
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([name, s]) => {
         const mean = s.totalMs / s.calls;
-        const failed = s.failures > 0 ? ` FAILED ${s.failures}` : '';
-        const why = s.lastDetail === undefined ? '' : ` (${s.lastDetail})`;
+        const refused = s.refused > 0 ? `  refused ${s.refused}` : '';
+        const unexpected =
+          s.unexpected.size === 0
+            ? ''
+            : `  UNEXPECTED ${[...s.unexpected]
+                .map(([status, n]) => `${status}x${n}`)
+                .join(' ')}`;
+        const errored = s.errors > 0 ? `  ERRORS ${s.errors}` : '';
+        const why =
+          s.lastDetail === undefined ||
+          (s.errors === 0 && s.unexpected.size === 0)
+            ? ''
+            : ` (${s.lastDetail})`;
         return (
-          `${name.padEnd(16)} ${String(s.calls).padStart(6)} calls  ` +
-          `mean ${mean.toFixed(2)}ms  max ${s.maxMs.toFixed(1)}ms${failed}${why}`
+          `${name.padEnd(17)} ${String(s.calls).padStart(6)} calls  ` +
+          `${String(s.worked).padStart(6)} worked  mean ${mean.toFixed(2)}ms  ` +
+          `max ${s.maxMs.toFixed(1)}ms${refused}${unexpected}${errored}${why}`
         );
       });
   }

--- a/examples/full/src/spawn-app.ts
+++ b/examples/full/src/spawn-app.ts
@@ -1,0 +1,80 @@
+/** What `main.ts` prints once every listener is bound. */
+const READY = 'ctrl-c to stop';
+const APP_DIR = new URL('..', import.meta.url).pathname;
+
+const spawn = (env: Record<string, string>) =>
+  Bun.spawn(['bun', 'src/main.ts'], {
+    cwd: APP_DIR,
+    // Port 0 so a suite cannot collide with a real `bun start` on 3000.
+    env: { ...process.env, NODE_ENV: 'production', PORT: '0', ...env },
+    stdout: 'pipe',
+    stderr: 'inherit',
+  });
+
+/**
+ * `bun src/main.ts` in a process of its own, for the two things an in-process
+ * `createApp()` cannot show: that a service stays up until a signal, and that
+ * a library reads the real `NODE_ENV` rather than the one `bun test` set.
+ */
+export class SpawnedApp {
+  readonly #proc: ReturnType<typeof spawn>;
+  readonly #reading: Promise<void>;
+  #text = '';
+
+  constructor(env: Record<string, string> = {}) {
+    const proc = spawn(env);
+    this.#proc = proc;
+    const decoder = new TextDecoder();
+    this.#reading = (async () => {
+      for await (const chunk of proc.stdout) {
+        this.#text += decoder.decode(chunk, { stream: true });
+      }
+    })();
+  }
+
+  /** Everything the app has written so far. */
+  get output(): string {
+    return this.#text;
+  }
+
+  get killed(): boolean {
+    return this.#proc.killed;
+  }
+
+  /**
+   * The url it is serving on, once it is. A boot that dies first throws rather
+   * than waiting for a readiness line that is never coming: 271 ms, against the
+   * suite's own timeout. Its error is on inherited stderr, beside this one.
+   */
+  async serving(): Promise<string> {
+    while (!this.#text.includes(READY)) {
+      const code = await Promise.race([
+        this.#proc.exited,
+        Bun.sleep(20).then(() => undefined),
+      ]);
+      if (code !== undefined) {
+        await this.#reading;
+        throw new Error(
+          `the app exited with ${code} before serving:\n${this.#text}`,
+        );
+      }
+    }
+    const url = /listening on (http:\/\/[^\s"]+)/.exec(this.#text)?.[1];
+    if (url === undefined) {
+      throw new Error(`the app is serving but printed no url:\n${this.#text}`);
+    }
+    return url;
+  }
+
+  /** SIGTERM, then the exit code once the output has drained. */
+  async stop(): Promise<number> {
+    this.#proc.kill('SIGTERM');
+    const code = await this.#proc.exited;
+    await this.#reading;
+    return code;
+  }
+
+  kill(): void {
+    if (!this.#proc.killed) this.#proc.kill('SIGKILL');
+  }
+}

--- a/examples/full/src/spawn-app.ts
+++ b/examples/full/src/spawn-app.ts
@@ -1,6 +1,8 @@
 /** What `main.ts` prints once every listener is bound. */
 const READY = 'ctrl-c to stop';
-const APP_DIR = new URL('..', import.meta.url).pathname;
+/** Decoded: `URL.pathname` keeps percent-encoding, so a checkout under a path
+ * with a space in it is not a directory `Bun.spawn` can enter. */
+const APP_DIR = Bun.fileURLToPath(new URL('..', import.meta.url));
 
 const spawn = (env: Record<string, string>) =>
   Bun.spawn(['bun', 'src/main.ts'], {
@@ -12,9 +14,8 @@ const spawn = (env: Record<string, string>) =>
   });
 
 /**
- * `bun src/main.ts` in a process of its own, for the two things an in-process
- * `createApp()` cannot show: that a service stays up until a signal, and that
- * a library reads the real `NODE_ENV` rather than the one `bun test` set.
+ * `bun src/main.ts` in a process of its own: for a service that stays up until a
+ * signal, and for a library reading the real `NODE_ENV` rather than `bun test`'s.
  */
 export class SpawnedApp {
   readonly #proc: ReturnType<typeof spawn>;
@@ -32,7 +33,6 @@ export class SpawnedApp {
     })();
   }
 
-  /** Everything the app has written so far. */
   get output(): string {
     return this.#text;
   }

--- a/examples/full/src/throttle.test.ts
+++ b/examples/full/src/throttle.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { ConfigModule } from '@dunx/core';
+import { ThrottleGuard } from '@dunx/http';
+import { createTestServer, type TestServer } from '@dunx/testing';
+import { AppConfigService, validate } from './config.js';
+import { LimitsModule } from './throttle/throttle.module.js';
+
+/**
+ * The rate limiter against a budget small enough to exhaust.
+ *
+ * The load run cannot answer these: it raises `THROTTLE_LIMIT` so the app rather
+ * than the limiter is what it measures, and `/limits/burst` returning 200 for
+ * every call would still read as the route working. So the policy is asserted
+ * here, where the budget is five and the window is a minute.
+ *
+ * `source` rather than the process environment, which is what keeps this
+ * independent of whatever `bun test` was launched with. Leaving `REDIS_URL` out
+ * of it is deliberate too: `ThrottleModule`'s factory probes the cache and picks
+ * `MemoryThrottleStore` when nothing answers, so the counter is per process and
+ * the run does not depend on a broker.
+ */
+const LIMIT = 5;
+
+let server: TestServer;
+/** The `subject` reads `x-api-key` first, so a fresh one is a fresh budget. */
+let caller = 0;
+const asNewCaller = (): Record<string, string> => {
+  caller += 1;
+  return { 'x-api-key': `throttle-test-${caller}` };
+};
+
+const hammer = async (
+  path: string,
+  times: number,
+  headers: Record<string, string>,
+): Promise<number[]> => {
+  const seen: number[] = [];
+  for (let i = 0; i < times; i += 1) {
+    seen.push((await server.request(path, { headers })).status);
+  }
+  return seen;
+};
+
+beforeAll(async () => {
+  server = await createTestServer({
+    modules: [
+      ConfigModule.forRoot({
+        validate,
+        as: AppConfigService,
+        source: {
+          THROTTLE_LIMIT: String(LIMIT),
+          THROTTLE_WINDOW_SECONDS: '60',
+        },
+      }),
+      LimitsModule,
+    ],
+    middleware: [ThrottleGuard],
+  });
+});
+
+afterAll(async () => {
+  await server.app.shutdown();
+});
+
+it('spends the module default, then refuses', async () => {
+  const seen = await hammer('limits/default', LIMIT + 2, asNewCaller());
+
+  expect(seen.slice(0, LIMIT)).toEqual(Array<number>(LIMIT).fill(200));
+  expect(seen.slice(LIMIT)).toEqual([429, 429]);
+});
+
+it("lets a handler's own @Throttle win over the module default", async () => {
+  // Three per minute, under the module's five: the handler decides.
+  const seen = await hammer('limits/burst', 5, asNewCaller());
+
+  expect(seen).toEqual([200, 200, 200, 429, 429]);
+});
+
+it('never counts a @SkipThrottle() route', async () => {
+  const seen = await hammer('limits/exempt', LIMIT * 3, asNewCaller());
+
+  expect(seen.every((status) => status === 200)).toBe(true);
+});
+
+it('counts each subject apart', async () => {
+  const first = asNewCaller();
+  expect(await hammer('limits/default', LIMIT, first)).toEqual(
+    Array<number>(LIMIT).fill(200),
+  );
+  expect(
+    (await server.request('limits/default', { headers: first })).status,
+  ).toBe(429);
+
+  // A different `x-api-key` is a different subject, so it starts at full budget.
+  const second = asNewCaller();
+  expect(
+    (await server.request('limits/default', { headers: second })).status,
+  ).toBe(200);
+});
+
+it('counts each route apart', async () => {
+  const headers = asNewCaller();
+  await hammer('limits/default', LIMIT + 1, headers);
+
+  // `/burst` has its own counter, so exhausting `/default` did not spend it.
+  expect((await server.request('limits/burst', { headers })).status).toBe(200);
+});
+
+it('describes the refusal in headers a client can retry on', async () => {
+  const headers = asNewCaller();
+  await hammer('limits/default', LIMIT, headers);
+  const refused = await server.request('limits/default', { headers });
+
+  expect(refused.status).toBe(429);
+  expect(refused.headers.get('ratelimit-limit')).toBe(String(LIMIT));
+  expect(refused.headers.get('ratelimit-remaining')).toBe('0');
+  const retryAfter = Number(refused.headers.get('retry-after'));
+  expect(retryAfter).toBeGreaterThan(0);
+  expect(retryAfter).toBeLessThanOrEqual(60);
+});
+
+it('takes the app error shape rather than a bare status', async () => {
+  const headers = asNewCaller();
+  await hammer('limits/default', LIMIT, headers);
+  const { status, body } = await server.json<{ error: string; status: number }>(
+    'limits/default',
+    { headers },
+  );
+
+  expect(status).toBe(429);
+  expect(body.status).toBe(429);
+  expect(body.error).toContain(String(LIMIT));
+});
+
+it('marks a counted route in the headers of a response it allowed', async () => {
+  const allowed = await server.request('limits/default', {
+    headers: asNewCaller(),
+  });
+
+  expect(allowed.status).toBe(200);
+  expect(allowed.headers.get('ratelimit-limit')).toBe(String(LIMIT));
+  expect(allowed.headers.get('ratelimit-remaining')).toBe(String(LIMIT - 1));
+});
+
+it('leaves no rate-limit headers on a route it never counts', async () => {
+  const exempt = await server.request('limits/exempt', {
+    headers: asNewCaller(),
+  });
+
+  expect(exempt.status).toBe(200);
+  // The cheap way to tell "exempt" from "counted but not yet exhausted": an
+  // exhausted budget is one status, an uncounted route is no headers at all.
+  expect(exempt.headers.get('ratelimit-limit')).toBeNull();
+  expect(exempt.headers.get('ratelimit-remaining')).toBeNull();
+});

--- a/packages/dashboard/src/api/snapshot.ts
+++ b/packages/dashboard/src/api/snapshot.ts
@@ -1,5 +1,10 @@
 import { modulesOf, providersOf, type ModuleRef } from '@dunx/core';
-import { gatewaysOf, isGateway, routesOf } from '@dunx/http/internal';
+import {
+  gatewaysOf,
+  isGateway,
+  routesOf,
+  type RoutePrefix,
+} from '@dunx/http/internal';
 import type { DashboardOptions } from '../options.js';
 import type { ConfigEntry, Meta, Snapshot } from './types.js';
 
@@ -51,9 +56,19 @@ export const metaOf = (options: DashboardOptions): Meta => ({
 export const snapshotOf = (
   root: ModuleRef,
   options: DashboardOptions,
+  prefix: RoutePrefix,
 ): Snapshot => ({
   meta: metaOf(options),
-  routes: routesOf(root),
+  /**
+   * Prefixed, because `routesOf` reads the path off a prototype and the global
+   * prefix is applied at `listen()`. Without this the panel reported `/notes` for
+   * a route served at `/api/notes`, so an operator copying a path got a 404.
+   */
+  routes: routesOf(root).map((route) => ({
+    ...route,
+    path: prefix.apply(route.path),
+  })),
+  // Not prefixed: `listen()` builds the upgrade table from these untouched.
   gateways: gatewaysOf(root),
   // Core cannot import `@dunx/http`, so the gateway marker arrives as an option.
   // Without it a gateway would be listed as an ordinary provider here while the

--- a/packages/dashboard/src/middleware.ts
+++ b/packages/dashboard/src/middleware.ts
@@ -1,3 +1,4 @@
+import type { RoutePrefix } from '@dunx/http/internal';
 import { Logger, type ModuleRef } from '@dunx/core';
 import type { Middleware, Next, RouteContext } from '@dunx/http';
 import type { BunRequest } from 'bun';
@@ -24,7 +25,12 @@ export class DashboardMiddleware implements Middleware {
   #page: Promise<string> | undefined;
   #board: Promise<Board> | undefined;
 
-  constructor(options: DashboardOptions, root: ModuleRef, logger: Logger) {
+  constructor(
+    options: DashboardOptions,
+    root: ModuleRef,
+    logger: Logger,
+    prefix: RoutePrefix,
+  ) {
     this.#options = options;
     // With the trailing slash, so `/_dunxious` cannot match a `/_dunx` mount. The
     // bare mount is matched separately.
@@ -32,6 +38,7 @@ export class DashboardMiddleware implements Middleware {
     this.#deps = {
       root,
       options,
+      prefix,
       startedAt: performance.now(),
       page: () => this.#renderPage(),
       board: () => this.#buildBoard(),

--- a/packages/dashboard/src/module.ts
+++ b/packages/dashboard/src/module.ts
@@ -9,6 +9,7 @@ import {
   type ModuleRef,
   type Registration,
 } from '@dunx/core';
+import { RoutePrefix } from '@dunx/http/internal';
 import { DashboardMiddleware } from './middleware.js';
 import { DashboardOptions, type DashboardOptionsInit } from './options.js';
 
@@ -26,9 +27,15 @@ import { DashboardOptions, type DashboardOptionsInit } from './options.js';
  */
 const middleware = (): Registration =>
   provide(DashboardMiddleware, {
-    useFactory: (options: DashboardOptions, root: ModuleRef, logger: Logger) =>
-      new DashboardMiddleware(options, root, logger),
-    inject: [DashboardOptions, ROOT_MODULE, Logger] as const,
+    useFactory: (
+      options: DashboardOptions,
+      root: ModuleRef,
+      logger: Logger,
+      prefix: RoutePrefix,
+    ) => new DashboardMiddleware(options, root, logger, prefix),
+    // `RoutePrefix` is bound by `HttpFactory`'s global wrapper, so this resolves
+    // the instance `listen()` attached to rather than a fresh one reading ''.
+    inject: [DashboardOptions, ROOT_MODULE, Logger, RoutePrefix] as const,
   });
 
 /**

--- a/packages/dashboard/src/prefix.test.ts
+++ b/packages/dashboard/src/prefix.test.ts
@@ -1,0 +1,136 @@
+import { Module } from '@dunx/core';
+import {
+  Controller,
+  Gateway,
+  Get,
+  HttpFactory,
+  OnMessage,
+  Public,
+} from '@dunx/http';
+import { afterAll, beforeAll, expect, it } from 'bun:test';
+import { DashboardMiddleware } from './middleware.js';
+import { DashboardModule } from './module.js';
+import type { Snapshot } from './api/types.js';
+
+/**
+ * The route panel under a global prefix.
+ *
+ * `routesOf` walks prototypes, so it reads the path a `@Get` declared. The prefix
+ * is applied at `listen()`, which meant the panel reported `/notes` for a route
+ * the server answers at `/api/notes`: an operator copying a path out of the
+ * dashboard got a 404. Every other suite here mounts with no prefix, which is why
+ * it went unseen.
+ *
+ * Gateways are the other half and they are **not** prefixed: `listen()` builds the
+ * upgrade table from `ws.paths` untouched, so `/ws` is `/ws` whatever the routes
+ * carry. A fix that prefixed both would break the panel it was fixing.
+ */
+const PREFIX = 'api';
+
+@Controller('/notes')
+class NotesController {
+  @Get('/')
+  @Public()
+  all(): { notes: string[] } {
+    return { notes: [] };
+  }
+}
+
+@Gateway('/ws')
+class FeedGateway {
+  ticks = 0;
+
+  @OnMessage('tick')
+  tick(): void {
+    this.ticks += 1;
+  }
+}
+
+@Module({ controllers: [NotesController], providers: [FeedGateway] })
+class NotesModule {}
+
+@Module({
+  imports: [
+    NotesModule,
+    DashboardModule.forRoot({ path: `/${PREFIX}/_dunx`, pollMs: 0 }),
+  ],
+})
+class AppModule {}
+
+let base = '';
+let app: Awaited<ReturnType<typeof HttpFactory.create>>;
+
+const snapshot = async (): Promise<Snapshot> => {
+  const response = await fetch(`${base}/${PREFIX}/_dunx/api/snapshot`);
+  expect(response.status).toBe(200);
+  return (await response.json()) as Snapshot;
+};
+
+beforeAll(async () => {
+  app = await HttpFactory.create(AppModule, {
+    requestLogging: false,
+    bootLogging: false,
+    prefix: PREFIX,
+  });
+  app.use(DashboardMiddleware);
+  base = (await app.listen(0)).replace(/\/$/, '');
+});
+
+afterAll(async () => {
+  await app.shutdown();
+});
+
+it('serves the app route under the prefix', async () => {
+  const response = await fetch(`${base}/${PREFIX}/notes`);
+
+  expect(response.status).toBe(200);
+  // The unprefixed path is not served, which is what makes reporting it a defect
+  // rather than a shorthand.
+  expect((await fetch(`${base}/notes`)).status).toBe(404);
+});
+
+it('reports the route path the server actually answers', async () => {
+  const { routes } = await snapshot();
+
+  expect(routes.map((route) => route.path)).toContain(`/${PREFIX}/notes`);
+});
+
+it('reports no route path that is not served', async () => {
+  const { routes } = await snapshot();
+
+  for (const route of routes) {
+    const response = await fetch(`${base}${route.path}`, {
+      method: route.method,
+    });
+    // Every path in the panel has to be reachable. A 404 here is the panel
+    // naming something the router does not have.
+    expect(response.status).not.toBe(404);
+  }
+});
+
+it('leaves gateway paths unprefixed, because listen() does', async () => {
+  const { gateways } = await snapshot();
+
+  expect(gateways.map((gateway) => gateway.path)).toEqual(['/ws']);
+});
+
+it('upgrades at the gateway path the panel reported', async () => {
+  const { gateways } = await snapshot();
+  const path = gateways[0]?.path ?? '';
+
+  const upgraded = await new Promise<boolean>((resolve) => {
+    const socket = new WebSocket(`${base}${path}`.replace('http', 'ws'));
+    const timer = setTimeout(() => resolve(false), 2000);
+    socket.addEventListener('open', () => {
+      clearTimeout(timer);
+      socket.close();
+      resolve(true);
+    });
+    socket.addEventListener('error', () => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+
+  expect(upgraded).toBe(true);
+});

--- a/packages/dashboard/src/router.ts
+++ b/packages/dashboard/src/router.ts
@@ -1,4 +1,5 @@
 import type { ModuleRef } from '@dunx/core';
+import type { RoutePrefix } from '@dunx/http/internal';
 import { boardNames, matchBoard, type Board } from './board.js';
 import { redisReport } from './api/redis.js';
 import { runtimeReport } from './api/runtime.js';
@@ -31,6 +32,8 @@ const fail = (status: number, error: string): Response =>
 export interface RouterDeps {
   readonly root: ModuleRef;
   readonly options: DashboardOptions;
+  /** The global prefix `listen()` resolved, which the route panel has to add. */
+  readonly prefix: RoutePrefix;
   readonly startedAt: number;
   /** The HTML page, built lazily so importing this package does not load it. */
   readonly page: () => Promise<string>;
@@ -47,7 +50,7 @@ const handleApi = async (
 
   switch (segments[0]) {
     case 'snapshot':
-      return json(snapshotOf(deps.root, deps.options));
+      return json(snapshotOf(deps.root, deps.options, deps.prefix));
     case 'runtime':
       return json(await runtimeReport(deps.options, deps.startedAt));
     case 'redis':

--- a/packages/http/src/internal.ts
+++ b/packages/http/src/internal.ts
@@ -16,6 +16,7 @@ export {
   joinPath,
   type DiscoveredRoute,
 } from './route/discover.js';
+export { RoutePrefix } from './route/prefix.js';
 export { defaultStatusFor } from './route/marker.js';
 export {
   gatewaysOf,

--- a/packages/http/src/route/prefix.ts
+++ b/packages/http/src/route/prefix.ts
@@ -1,0 +1,27 @@
+import { joinPath } from './discover.js';
+
+/**
+ * The global prefix, as `listen()` resolved it.
+ *
+ * Bound by `HttpFactory`'s global wrapper next to `ClientAddress`, and attached
+ * the same way: a second instance reads an empty prefix, which is a plausible
+ * answer and a wrong one. Routes only, never gateways.
+ * See docs/architecture/http.md, "Who knows the global prefix".
+ */
+export class RoutePrefix {
+  #value = '';
+
+  /** Empty when the app set none. */
+  get value(): string {
+    return this.#value;
+  }
+
+  attach(prefix: string): void {
+    this.#value = prefix;
+  }
+
+  /** Where a discovered route is served. The one place that answers it. */
+  apply(path: string): string {
+    return this.#value === '' ? path : joinPath(this.#value, path);
+  }
+}

--- a/packages/http/src/server/application.ts
+++ b/packages/http/src/server/application.ts
@@ -11,7 +11,8 @@ import {
   type InjectionToken,
   type ModuleRef,
 } from '@dunx/core';
-import { joinPath, type DiscoveredRoute } from '../route/discover.js';
+import type { DiscoveredRoute } from '../route/discover.js';
+import { RoutePrefix } from '../route/prefix.js';
 import type { WebSocketRuntime } from '../ws/adapter.js';
 import { PubSub } from '../ws/pubsub.js';
 import type { PubSubRelay, RelayOptions, RelayPhase } from '../ws/relay.js';
@@ -205,7 +206,10 @@ export class HttpApplication extends ShutdownAware implements HttpApp {
     const middleware = this.#middleware.map((entry) =>
       this.#app.get(entry, this.#root),
     );
-    const prefixed = this.#prefixed();
+    // Before `#prefixed()`, which now reads the same object the dashboard does.
+    const prefix = this.#app.get(RoutePrefix);
+    prefix.attach(this.#globalPrefix);
+    const prefixed = this.#prefixed(prefix);
     const routes = buildRoutes(
       prefixed,
       middleware,
@@ -353,11 +357,11 @@ export class HttpApplication extends ShutdownAware implements HttpApp {
   }
 
   // Collision detection re-runs inside buildRoutes on these final paths.
-  #prefixed(): readonly DiscoveredRoute[] {
-    if (this.#globalPrefix === '') return this.#discovered;
+  #prefixed(prefix: RoutePrefix): readonly DiscoveredRoute[] {
+    if (prefix.value === '') return this.#discovered;
     return this.#discovered.map((route) => ({
       ...route,
-      path: joinPath(this.#globalPrefix, route.path),
+      path: prefix.apply(route.path),
     }));
   }
 

--- a/packages/http/src/server/factory.ts
+++ b/packages/http/src/server/factory.ts
@@ -12,6 +12,7 @@ import {
 } from '@dunx/core';
 import { discoverRoutes, type DiscoveredRoute } from '../route/discover.js';
 import { ClientAddress } from './client-address.js';
+import { RoutePrefix } from '../route/prefix.js';
 import { MetricsMiddleware, RequestMetrics } from './metrics.js';
 import { buildWebSocket } from '../ws/adapter.js';
 import { discoverGateways } from '../ws/discover.js';
@@ -131,7 +132,10 @@ export class HttpFactory {
     // reason `ClientAddress` is: `listen()` hands one instance the live server,
     // and a second scope resolving its own would read `pendingRequests` off no
     // server at all.
-    const services = [PubSub, ClientAddress, RequestMetrics];
+    // `RoutePrefix` is here for that reason too, and it is the one a second
+    // instance fails quietly rather than loudly: an unattached one reads as "no
+    // prefix", which is a plausible answer and a wrong one.
+    const services = [PubSub, ClientAddress, RequestMetrics, RoutePrefix];
     /**
      * Every middleware is bound unconditionally, which is what unties the
      * ordering knot the options provider was blocked on: `requestLogging: false`

--- a/packages/openapi/src/mount.ts
+++ b/packages/openapi/src/mount.ts
@@ -7,9 +7,10 @@ import type { OpenApiDocument } from './types.js';
  * evidence: declared at `/openapi.json`, answered at `/api/openapi.json`, therefore
  * every other route in the table moved by the same `/api`.
  *
- * That inference exists because the global prefix lives on the `HttpApp` and is not
- * readable from inside the container. Given `HttpApp.routes`, this would be the
- * paths themselves and the guess would be gone.
+ * `RoutePrefix` now carries the resolved prefix in the container, so this guess
+ * has an alternative it did not have when it was written. It stays for now
+ * because it also covers `mountAt`, and swapping it is a change to a path with
+ * its own suite rather than a comment fix.
  */
 export const mountPrefix = (pathname: string, declared: string): string => {
   if (pathname === declared || !pathname.endsWith(declared)) return '';

--- a/tools/create-app/templates/features/auth/auth.demo.ts
+++ b/tools/create-app/templates/features/auth/auth.demo.ts
@@ -124,8 +124,13 @@ export class AuthDemo {
     );
   }
 
-  /** better-auth rejects a cookie-bearing state change with no `Origin`
-   * (`MISSING_OR_NULL_ORIGIN`); it has to match `trustedOrigins`. */
+  /**
+   * better-auth rejects a cookie-bearing state change with no `Origin`
+   * (`MISSING_OR_NULL_ORIGIN`); it has to match `trustedOrigins`.
+   *
+   * The check is off when `NODE_ENV` is `test`, so `bun test` cannot see it and
+   * `auth.test.ts` asserts the exemption rather than the protection.
+   */
   private post(
     base: string,
     endpoint: string,

--- a/tools/create-app/templates/features/auth/auth.demo.ts
+++ b/tools/create-app/templates/features/auth/auth.demo.ts
@@ -128,8 +128,8 @@ export class AuthDemo {
    * better-auth rejects a cookie-bearing state change with no `Origin`
    * (`MISSING_OR_NULL_ORIGIN`); it has to match `trustedOrigins`.
    *
-   * The check is off when `NODE_ENV` is `test`, so `bun test` cannot see it and
-   * `auth.test.ts` asserts the exemption rather than the protection.
+   * The check is off when `NODE_ENV` is `test`, so `auth.test.ts` asserts the
+   * exemption in-process and the protection in a spawned `NODE_ENV=production`.
    */
   private post(
     base: string,

--- a/tools/create-app/templates/features/chat/ws-client.ts
+++ b/tools/create-app/templates/features/chat/ws-client.ts
@@ -9,16 +9,22 @@
 export interface Client {
   next(): Promise<string>;
   send(event: string, data: unknown): void;
+  /** An unwrapped frame: binary, or text a gateway is meant to refuse. */
+  sendRaw(frame: string | Uint8Array): void;
   close(): void;
   /** Every frame this socket ever received, so a *second* delivery is visible. */
   readonly received: readonly string[];
 }
 
-/** A real `new WebSocket()`, with a deadline so a stall fails instead of hanging. */
-export const connect = async (base: string): Promise<Client> => {
-  const socket = new WebSocket(
-    new URL('chat', base).href.replace('http', 'ws'),
-  );
+/**
+ * A real `new WebSocket()`, with a deadline so a stall fails instead of hanging.
+ *
+ * `path` so the same helper reaches `/telemetry`, which speaks binary frames.
+ * A second copy of the frame queue for the sake of one segment is what Rule 2
+ * is about.
+ */
+export const connect = async (base: string, path = 'chat'): Promise<Client> => {
+  const socket = new WebSocket(new URL(path, base).href.replace('http', 'ws'));
   const frames: string[] = [];
   const received: string[] = [];
   const waiting: ((frame: string) => void)[] = [];
@@ -59,6 +65,7 @@ export const connect = async (base: string): Promise<Client> => {
         waiting.push(waiter);
       }),
     send: (event, data) => socket.send(JSON.stringify({ event, data })),
+    sendRaw: (frame) => socket.send(frame),
     close: () => socket.close(),
     received,
   };


### PR DESCRIPTION
The soak reported `0 failed` on a run that answered **59.4% of its requests with 429**: every op accepted one, so the rate limiter was the only thing under test. Ops now name work statuses and refusal statuses separately and the run floors the ratio, judges the server's own `RequestMetrics` (per-route p99, status distribution), raises `THROTTLE_LIMIT` so the app is what is loaded, and gives each worker its own `x-api-key` so the throttle subject is exercised. Same 40s window afterwards: 67.6% 200, 13.3% 201, 4.8% 429 all on `/limits/burst`.

Three phases it lacked: a stress burst at 4x concurrency asserting correctness rather than throughput, a recovery round, and a shutdown with traffic actually in flight (`ci.ts` claimed that one; the harness awaited every worker first).

Five suites, 78 to 154 tests in `examples/full` - auth (15), negative (34), throttle (7), gateway (8), dashboard (14).

Writing them found three things, fixed in the second commit:

- **`@dunx/dashboard` reported route paths that 404.** `routesOf` walks prototypes; the global prefix is applied at `listen()`. `RoutePrefix` now carries the resolved value, bound in the global wrapper next to `ClientAddress`. Gateways stay unprefixed and the new suite pins both halves.
- **better-auth's origin check is off under `NODE_ENV=test`**, which `bun test` sets. Measured: unset 403, test 200, development 403, production 403; a wrong `Origin` the same. The suite asserts the exemption in-process and the protection in a spawned `NODE_ENV=production`, covering `MISSING_OR_NULL_ORIGIN` and `INVALID_ORIGIN`.
- **`authorize` had no example.** `DASHBOARD_TOKEN` is unset by default, so `bun start` stays explorable and the boot warning stands; set it and a stranger gets 404, not 403.

Deliberately not done: consolidating `@dunx/openapi`'s prefix inference onto `RoutePrefix`. It also covers `mountAt` and has its own suite; `mount.ts`'s now-stale comment is corrected to say so.

The third commit takes CodeRabbit's six findings. The substantial two: the origin check is now asserted rather than only documented, and the aborted-client test could not fail (it waited past the handler's own completion) - Bun drops aborted requests inside 10ms, so it now requires the release under the 300ms sleep, verified by breaking it.

`bun run ci` green phase by phase (build, static, unit, examples, docs, coverage, browser). All 10 packages clear the 90% floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard routes and reported API paths now reflect configured global prefixes, while WebSocket gateway paths remain unprefixed.
  * WebSocket clients can connect to custom paths and send raw text or binary frames.
  * Optional dashboard token protection returns indistinguishable 404 responses for unauthorized requests.

* **Tests**
  * Added comprehensive authentication, dashboard, WebSocket, throttling, validation, shutdown, and load-testing coverage.

* **Documentation**
  * Expanded guidance for authentication origin checks, route prefixes, WebSockets, and load-test methodology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->