### PR TITLE
feat(http): serve a trailing slash behind strict: false

### DIFF
--- a/docs/architecture/constraints.md
+++ b/docs/architecture/constraints.md
@@ -25,6 +25,51 @@ param route: 200 { id: "42" }   static route: 200 ok   unmatched method: 404
 There is no reason to build a radix tree in JavaScript. dunx's job is to _emit_
 the `routes` object at boot and hand it to Bun.
 
+**That router matches the literal path, so a trailing slash misses**, in both
+directions: with `/users/:id` registered, `/users/1/` reaches the `fetch`
+fallback, and a route declared `/dir/` is not served at `/dir`. Registering both
+spellings is accepted. Bun 1.4.2:
+
+```
+/test  -> 200 R /test     /users/1  -> 200 R /users/:id id=1   /dir/ -> 200 R /dir/
+/test/ -> 404 FALLBACK    /users/1/ -> 404 FALLBACK            /dir  -> 404 FALLBACK
+/both  -> 200 R /both     /both/    -> 200 R /both/
+```
+
+`withTrailingSlashAliases` takes that last line: a second key per route holding
+the same per-method object, so one set of handlers, one preflight, and one
+metrics series, because `buildContext` froze the pattern into the closure. 500
+routes bind in 1.8 ms plain and 3.3 ms aliased, with no per-request difference
+above client overhead. It is opt-in: `strict` defaults to `true`, as hono's does.
+
+The five frameworks, each on its own default:
+
+| Framework                      | `/test/` | `/users/1/` | Option                     |
+| ------------------------------ | -------- | ----------- | -------------------------- |
+| express 5.2.1                  | 200      | 200         | `strict routing`, off      |
+| nest 11.1.28 (express adapter) | 200      | 200         | none of its own            |
+| elysia 1.4.29                  | 200      | 200         | `strictPath`, false        |
+| fastify 5.11.0                 | 404      | 404         | `ignoreTrailingSlash`, off |
+| hono 4.12.33                   | 404      | 404         | `strict`, true             |
+
+None of the five redirects. express and hono strip the slash before lookup,
+which takes being the router; elysia registers both spellings, which is the one
+mechanism open to dunx, since Bun has matched before `fetch` is called.
+
+**Bun resolves dot-segments for `req.url` but matches on the raw target.** Over
+a raw socket, where nothing rewrites the request line:
+
+```
+GET /test      -> 200 MATCHED  seen=/test
+GET /./test    -> 404 FALLBACK seen=/test
+GET /a/../test -> 404 FALLBACK seen=/test
+GET //test     -> 404 FALLBACK seen=//test
+```
+
+The matcher is the stricter of the two, so no request reaches a route whose
+`pathname` disagrees with the path it matched. A probe using `fetch` sees
+`//test` return 200 instead, because `fetch` collapses it before it is sent.
+
 **`server.upgrade(req)` works from inside a `routes` handler.** Bun's own types
 bless it: `Serve.RoutesWithUpgrade` allows `Response | undefined | void` when
 `websocket` is present. So a WebSocket gateway is mounted as a native `GET`

--- a/docs/architecture/constraints.md
+++ b/docs/architecture/constraints.md
@@ -12,7 +12,8 @@ serve HTTP - not drift into a general web framework.
 
 ## Verified constraints
 
-These were measured on Bun 1.3.14, not assumed. They drive most decisions below.
+Measured, not assumed, on Bun 1.3.14 unless an entry names its own version.
+They drive most decisions below.
 
 **Bun already has the router.** `Bun.serve({ routes })` handles path params,
 per-method dispatch, static `Response` values, and 404-on-method-miss in native
@@ -36,9 +37,11 @@ spellings is accepted. Bun 1.4.2:
 /both  -> 200 R /both     /both/    -> 200 R /both/
 ```
 
-`withTrailingSlashAliases` takes that last line: a second key per route holding
-the same per-method object, so one set of handlers, one preflight, and one
-metrics series, because `buildContext` froze the pattern into the closure. 500
+`withTrailingSlashAliases` takes that last line: a second key holding the same
+per-method object, so one set of handlers, one preflight, and one metrics
+series, because `buildContext` froze the pattern into the closure. Every route
+gets one except `/` and a wildcard mount, neither of which has a slashed
+spelling to add. 500
 routes bind in 1.8 ms plain and 3.3 ms aliased, with no per-request difference
 above client overhead. It is opt-in: `strict` defaults to `true`, as hono's does.
 

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -183,10 +183,10 @@ radius: it doubles a table that collision detection, gateway-path checking and
 the CORS `OPTIONS` mounting all walk.
 
 None of the three walk it. Collision detection and the gateway-path check both
-read the discovered routes rather than the table, so when they run relative to
-the alias does not matter. The preflight is mounted while the table is built, so
-an alias added afterwards inherits it. `withUpgradeRoutes` then assigns each
-gateway path outright, so an upgrade wins a key an alias took.
+read the discovered routes rather than the table, so alias insertion order does
+not affect them. The preflight is mounted while the table is built, so an alias
+added afterwards inherits it. `withUpgradeRoutes` then assigns each gateway path
+outright, so an upgrade wins a key an alias took.
 
 The alias is a key rather than a route: one per-method object under two names,
 so the metrics series, the request log and the OpenAPI document all say

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -192,6 +192,10 @@ The alias is a key rather than a route: one per-method object under two names,
 so the metrics series, the request log and the OpenAPI document all say
 `/t/:id`.
 
+`/` and any path holding a `*` are left alone. `//` is a path Bun matches as
+neither, and a wildcard mount already matches its own trailing slash, so
+`@dunx/auth` at `/api/auth/*` serves `/api/auth/` without one.
+
 The default stays strict because that is what `Bun.serve` does. An earlier
 version of this note said "Nest, Express and Fastify all normalise", which is
 wrong about Fastify - its `ignoreTrailingSlash` is off by default, and hono's

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -182,11 +182,11 @@ option, and the one `strict: false` takes. It was first rejected as blast
 radius: it doubles a table that collision detection, gateway-path checking and
 the CORS `OPTIONS` mounting all walk.
 
-None of the three walk it. Collisions and gateway paths are checked against the
-discovered routes, before the table exists, and the preflight is mounted while
-the table is built. An alias added after all of them inherits the preflight and
-is walked by nothing, and `withUpgradeRoutes` still assigns each gateway path
-outright, so an upgrade wins a key an alias took.
+None of the three walk it. Collision detection and the gateway-path check both
+read the discovered routes rather than the table, so when they run relative to
+the alias does not matter. The preflight is mounted while the table is built, so
+an alias added afterwards inherits it. `withUpgradeRoutes` then assigns each
+gateway path outright, so an upgrade wins a key an alias took.
 
 The alias is a key rather than a route: one per-method object under two names,
 so the metrics series, the request log and the OpenAPI document all say

--- a/docs/architecture/http.md
+++ b/docs/architecture/http.md
@@ -162,12 +162,10 @@ the path the panel reports.
 there is no `listen()` to have resolved anything. It reports what the code
 declares.
 
-### Declined: trailing-slash normalisation
+### Declined as the default: trailing-slash normalisation
 
-`GET /t` is a 200, and `GET /t/` is a 404. Nest, Express and Fastify all
-normalise, so this is the one thing that breaks a ported client - it shows up
-as a 404 that reads like a missing route. It stays a 404 here, because of
-where the two candidate implementations would have to live.
+`GET /t` is a 200 and `GET /t/` is a 404. That is still the default, and
+`strict: false` on `HttpFactory.create` is how an app changes it.
 
 `joinPath` already normalises the **declared** side, so `@Get('sub/')`
 becomes `/t/sub`, and both spellings are never live at once.
@@ -176,15 +174,30 @@ The inbound side belongs to Bun. By the time anything in dunx can see that
 nothing matched, it is inside the `fetch` fallback, which holds middleware
 and the error mapper and **no route patterns**. Stripping the slash and
 re-dispatching there would mean matching `/t/7/` against `/t/:id` in
-JavaScript: exactly the router this repo will not write.
+JavaScript: exactly the router this repo will not write. That half stays
+declined, and it is what express and hono do internally.
 
-Registering `/t/` as a second entry in the `Bun.serve` table was the other
-option - native, and free per request - and was rejected as blast radius: it
-doubles a table that collision detection, gateway-path checking and the CORS
-`OPTIONS` mounting all walk, to buy an alias a proxy rewrite can supply.
+Registering `/t/` as a second entry in the `Bun.serve` table is the other
+option, and the one `strict: false` takes. It was first rejected as blast
+radius: it doubles a table that collision detection, gateway-path checking and
+the CORS `OPTIONS` mounting all walk.
 
-So it is documented in guide 05 and pinned by a test in `server.test.ts`, which is
-what makes it a decision rather than an oversight.
+None of the three walk it. Collisions and gateway paths are checked against the
+discovered routes, before the table exists, and the preflight is mounted while
+the table is built. An alias added after all of them inherits the preflight and
+is walked by nothing, and `withUpgradeRoutes` still assigns each gateway path
+outright, so an upgrade wins a key an alias took.
+
+The alias is a key rather than a route: one per-method object under two names,
+so the metrics series, the request log and the OpenAPI document all say
+`/t/:id`.
+
+The default stays strict because that is what `Bun.serve` does. An earlier
+version of this note said "Nest, Express and Fastify all normalise", which is
+wrong about Fastify - its `ignoreTrailingSlash` is off by default, and hono's
+`strict` is on. The field is three to two, and `strict` is hono's name for this
+switch. The per-framework table is in
+[constraints](./constraints.md).
 
 ## Multi-node websocket fan-out (`@dunx/http`)
 

--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -63,20 +63,25 @@ request logging, throttling and CORS all get a look at a method miss.
 
 **Paths are matched exactly, so a trailing slash is a different path.** `GET /t`
 is a 200 and `GET /t/` is a 404. The same goes for `/t/sub/` and `POST /t/`.
-Most frameworks normalise this, so it is the common break in a ported client. It
-shows up as a 404 that reads like a missing route.
+Nest, Express and Elysia accept both spellings; Fastify and Hono do not. A
+client ported from one of the first three hits a 404 that reads like a missing
+route.
 
 The declared side is already normalised: `@Get('/')` inside `@Controller('t')` is
 `/t`, never `/t/`, so both spellings are never live at once. Route discovery
 strips it too, so `@Get('sub/')` is `/t/sub`.
 
-Send the path without the trailing slash. For a caller you do not control, put
-the normalisation in front of dunx, where a reverse-proxy rewrite is one line.
+`strict: false` serves both:
 
-The inbound URL is the only remaining half, and dunx could only touch it in the
-`fetch` fallback below. That runs after Bun has matched nothing, so it holds no
-patterns to try `/t/7/` against. Matching there would mean a second JavaScript
-router beside Bun's.
+```ts
+const app = await HttpFactory.create(AppModule, { strict: false });
+```
+
+It registers a second key per route ending in `/`, pointing at the handlers the
+first one already has, so the request log, the metrics series and the OpenAPI
+document all still say `/t/:id`. `strict` defaults to `true`, which is what
+`Bun.serve` matches on its own and what Hono defaults to. A reverse-proxy
+rewrite in front of dunx does the same job for a caller you do not control.
 
 **CORS preflight is mounted, not inferred.** An `OPTIONS` request does reach the
 fallback. Answering preflight there would mean reconstructing which verbs the path

--- a/docs/guide/05-controllers.md
+++ b/docs/guide/05-controllers.md
@@ -77,11 +77,14 @@ strips it too, so `@Get('sub/')` is `/t/sub`.
 const app = await HttpFactory.create(AppModule, { strict: false });
 ```
 
-It registers a second key per route ending in `/`, pointing at the handlers the
-first one already has, so the request log, the metrics series and the OpenAPI
-document all still say `/t/:id`. `strict` defaults to `true`, which is what
-`Bun.serve` matches on its own and what Hono defaults to. A reverse-proxy
-rewrite in front of dunx does the same job for a caller you do not control.
+It registers a second key ending in `/`, pointing at the handlers the first one
+already has, so the request log, the metrics series and the OpenAPI document all
+still say `/t/:id`. Every route gets one except `/` and a wildcard mount, which
+already matches its own trailing slash.
+
+`strict` defaults to `true`, which is what `Bun.serve` matches on its own and
+what Hono defaults to. A reverse-proxy rewrite in front of dunx does the same
+job for a caller you do not control.
 
 **CORS preflight is mounted, not inferred.** An `OPTIONS` request does reach the
 fallback. Answering preflight there would mean reconstructing which verbs the path

--- a/examples/full/src/main.ts
+++ b/examples/full/src/main.ts
@@ -76,6 +76,7 @@ export const createApp = async (): Promise<HttpApp> => {
       // `http` feature, and an override there would turn metrics on for every
       // scaffold that picked `http` without picking `stats`.
       metrics: true,
+      strict: false,
     },
   );
 

--- a/examples/full/src/service.test.ts
+++ b/examples/full/src/service.test.ts
@@ -118,6 +118,14 @@ it('serves the ledger over drizzle, seeded at onInit', async () => {
   expect(typeof page.balance).toBe('number');
 });
 
+it('serves a trailing slash, under the global prefix, on strict: false', async () => {
+  const plain = await json<{ balance: number }>('ledger');
+  const slashed = await json<{ balance: number }>('ledger/');
+
+  expect(slashed.status).toBe(200);
+  expect(slashed.body.balance).toBe(plain.body.balance);
+});
+
 it('answers a bad cursor with a 400 that nothing in this app maps', async () => {
   const { status, body } = await json<{ error: string; status: number }>(
     'ledger/page?cursor=not-a-cursor',

--- a/packages/http/src/server/application.ts
+++ b/packages/http/src/server/application.ts
@@ -30,6 +30,7 @@ import {
   assertNoGatewayCollisions,
   buildFallback,
   buildRoutes,
+  withTrailingSlashAliases,
 } from './routes.js';
 import { ServerBinding } from './binding.js';
 import { defaultSettings, type AppSettings } from './settings.js';
@@ -78,6 +79,7 @@ export class HttpApplication extends ShutdownAware implements HttpApp {
   readonly #relayChannel: string | undefined;
   readonly #relayResubscribe: RelayOptions['resubscribe'];
   readonly #notFound: 'guarded' | 'public';
+  readonly #strict: boolean;
   readonly #bootLogging: boolean;
   readonly #binding: ServerBinding;
   readonly #split: boolean;
@@ -119,6 +121,7 @@ export class HttpApplication extends ShutdownAware implements HttpApp {
     this.#relayChannel = options.relayChannel;
     this.#relayResubscribe = options.relayResubscribe;
     this.#notFound = options.notFound ?? 'public';
+    this.#strict = options.strict ?? true;
     this.#bootLogging = options.bootLogging ?? true;
     this.#binding = new ServerBinding({
       http2: options.http2,
@@ -210,7 +213,7 @@ export class HttpApplication extends ShutdownAware implements HttpApp {
     const prefix = this.#app.get(RoutePrefix);
     prefix.attach(this.#globalPrefix);
     const prefixed = this.#prefixed(prefix);
-    const routes = buildRoutes(
+    const built = buildRoutes(
       prefixed,
       middleware,
       this.#onError,
@@ -219,6 +222,9 @@ export class HttpApplication extends ShutdownAware implements HttpApp {
       (guard, from) =>
         from === undefined ? this.#app.get(guard) : this.#app.get(guard, from),
     );
+    // Before `withUpgradeRoutes` merges the gateways in `bind`, which assigns
+    // each gateway path outright, so an upgrade still wins a key an alias took.
+    const routes = this.#strict ? built : withTrailingSlashAliases(built);
 
     const ws = this.#websocket;
     // Only when the upgrades share the routes table. Under `gatewayPort` a

--- a/packages/http/src/server/options-provider.ts
+++ b/packages/http/src/server/options-provider.ts
@@ -69,6 +69,12 @@ export abstract class HttpOptionsProvider {
   readonly trustProxy: boolean = false;
 
   /**
+   * Match a path exactly as declared, so `/users/1/` is not `/users/1`. On by
+   * default, which is `Bun.serve`'s own behaviour and hono's.
+   */
+  readonly strict: boolean = true;
+
+  /**
    * Install `SIGTERM`/`SIGINT` handlers that shut the app down. Off by default,
    * because installing a signal handler changes how the process terminates and
    * that is the app's decision to make.
@@ -185,6 +191,7 @@ export function resolveHttpOptions(
     notFound: settings.notFound,
     bootLogging: settings.bootLogging,
     trustProxy: settings.trustProxy,
+    strict: settings.strict,
     shutdownHooks: settings.shutdownHooks,
     relayChannel: settings.relayChannel,
     prefix: settings.prefix,

--- a/packages/http/src/server/options.ts
+++ b/packages/http/src/server/options.ts
@@ -44,8 +44,10 @@ export interface HttpOptions extends AppOptions {
    *
    * **`true` by default**, which is what `Bun.serve({ routes })` matches on its
    * own, and hono's name and default for the same switch. `false` serves both
-   * spellings, as Nest, express and elysia do. Not an `app.set()` setting: the
-   * route table is built once, at `listen()`.
+   * spellings, as Nest, express and elysia do - every route but `/` and a
+   * wildcard mount, which already matches its own trailing slash.
+   *
+   * Not an `app.set()` setting: the route table is built once, at `listen()`.
    */
   readonly strict?: boolean;
   /**

--- a/packages/http/src/server/options.ts
+++ b/packages/http/src/server/options.ts
@@ -40,6 +40,15 @@ export interface HttpOptions extends AppOptions {
   /** `app.set('trust proxy', ...)` as a field. */
   readonly trustProxy?: boolean;
   /**
+   * Match a path exactly as declared, so `/users/1/` is not `/users/1`.
+   *
+   * **`true` by default**, which is what `Bun.serve({ routes })` matches on its
+   * own, and hono's name and default for the same switch. `false` serves both
+   * spellings, as Nest, express and elysia do. Not an `app.set()` setting: the
+   * route table is built once, at `listen()`.
+   */
+  readonly strict?: boolean;
+  /**
    * Calls `enableShutdownHooks` at construction. `true` takes the default signals;
    * an object names them and tunes the force-exit.
    */

--- a/packages/http/src/server/routes.ts
+++ b/packages/http/src/server/routes.ts
@@ -334,3 +334,28 @@ export const buildRoutes = (
 
   return routes;
 };
+
+/**
+ * A second key per route ending in `/`, holding the handlers the first one has.
+ *
+ * `Bun.serve({ routes })` matches the literal path, so `/users/1/` misses when
+ * `/users/:id` is what was registered. Opt in with `strict: false`. The
+ * measurements, and what the other frameworks do, are in
+ * docs/architecture/http.md.
+ *
+ * A key rather than a copy: one per-method object under two names, so the
+ * pattern `buildContext` froze still labels the metrics series and the log line.
+ * It runs after the CORS preflight is mounted, so the alias carries `OPTIONS`.
+ *
+ * `/` and any `*` path are skipped - `//` is neither, and a wildcard already
+ * matches its own trailing slash.
+ */
+export const withTrailingSlashAliases = (routes: BunRoutes): BunRoutes => {
+  const aliased: BunRoutes = { ...routes };
+  for (const [path, byMethod] of Object.entries(routes)) {
+    if (path.endsWith('/') || path.includes('*')) continue;
+    // `??=`, so a declared route always wins over an alias for the same key.
+    aliased[`${path}/`] ??= byMethod;
+  }
+  return aliased;
+};

--- a/packages/http/src/server/server.test.ts
+++ b/packages/http/src/server/server.test.ts
@@ -242,12 +242,9 @@ describe('HttpFactory', () => {
   });
 
   /**
-   * Pinned rather than fixed. Nest, Express and Fastify all normalise a trailing
-   * slash, so a ported client hits a 404 that looks like a missing route - but
-   * `Bun.serve({ routes })` owns matching, and the only place dunx could
-   * normalise is the `fetch` fallback, which by then has no pattern to match
-   * `/users/1/` against without becoming the JavaScript router this repo refuses
-   * to write. So the behaviour is documented in guide 05 and asserted here.
+   * `Bun.serve({ routes })` owns matching and matches the literal path, so this
+   * is Bun's behaviour and hono's default. `strict: false` serves both
+   * spellings, asserted in `trailing-slash.test.ts`.
    */
   it('matches paths exactly - a trailing slash is a different path', async () => {
     await withApp(async (_app, url) => {
@@ -255,8 +252,6 @@ describe('HttpFactory', () => {
       expect((await fetch(new URL('users/', url))).status).toBe(404);
       expect((await fetch(new URL('users/42', url))).status).toBe(200);
       expect((await fetch(new URL('users/42/', url))).status).toBe(404);
-      // The declared side is normalised, though: `@Get('/')` under a prefix is
-      // `/users`, never `/users/`, so both spellings are never both live.
       expect((await fetch(new URL('users//', url))).status).toBe(404);
     });
   });

--- a/packages/http/src/server/trailing-slash.test.ts
+++ b/packages/http/src/server/trailing-slash.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test';
+import { Module } from '@dunx/core';
+import { Controller, Get } from '../route/decorators.js';
+import { HttpFactory } from './factory.js';
+import { RequestMetrics } from './metrics.js';
+import { withTrailingSlashAliases } from './routes.js';
+import type { BunRoutes } from './routes.js';
+import type { RouteHandler } from './middleware.js';
+import type { BunRequest } from 'bun';
+
+/*
+ * A trailing slash is a 404 by default, which is what `Bun.serve` matches and
+ * what hono defaults to. `strict: false` serves both spellings.
+ */
+
+@Controller('users')
+class UsersController {
+  @Get()
+  list(): readonly string[] {
+    return ['ada'];
+  }
+
+  /* No params schema, so the reader hands over `req` alone. */
+  @Get(':id')
+  one({ req }: { readonly req: BunRequest }): { readonly id: string } {
+    return { id: req.params['id'] ?? '' };
+  }
+}
+
+@Module({ controllers: [UsersController] })
+class AppModule {}
+
+const handler: RouteHandler = async () => new Response('ok');
+
+describe('withTrailingSlashAliases', () => {
+  test('adds a slashed key for a static and a parameterised path', () => {
+    const aliased = withTrailingSlashAliases({
+      '/users': { GET: handler },
+      '/users/:id': { GET: handler },
+    });
+
+    expect(Object.keys(aliased).sort()).toEqual([
+      '/users',
+      '/users/',
+      '/users/:id',
+      '/users/:id/',
+    ]);
+  });
+
+  /* One object under two keys: one set of handlers, one preflight, one series. */
+  test('the alias is the same object, not a copy', () => {
+    const byMethod = { GET: handler };
+    const aliased = withTrailingSlashAliases({ '/users': byMethod });
+
+    expect(aliased['/users/']).toBe(byMethod);
+  });
+
+  /* Its alias would be `//`, which Bun matches as neither. */
+  test('the root gets no alias', () => {
+    expect(
+      Object.keys(withTrailingSlashAliases({ '/': { GET: handler } })),
+    ).toEqual(['/']);
+  });
+
+  /* `@dunx/auth` mounts `<basePath>/*`, which Bun matches at `<basePath>/`. */
+  test('a wildcard mount gets no alias', () => {
+    expect(
+      Object.keys(
+        withTrailingSlashAliases({ '/api/auth/*': { GET: handler } }),
+      ),
+    ).toEqual(['/api/auth/*']);
+  });
+
+  test('a declared route is never replaced by an alias', () => {
+    const declared: RouteHandler = async () => new Response('declared');
+    const routes: BunRoutes = {
+      '/x': { GET: handler },
+      '/x/': { GET: declared },
+    };
+
+    expect(withTrailingSlashAliases(routes)['/x/']?.GET).toBe(declared);
+  });
+});
+
+interface Served {
+  readonly status: number;
+  readonly body: string;
+}
+
+const serve = async (
+  paths: readonly string[],
+  strict?: boolean,
+): Promise<Served[]> => {
+  const app = await HttpFactory.create(AppModule, {
+    port: 0,
+    requestLogging: false,
+    bootLogging: false,
+    metrics: true,
+    ...(strict !== undefined && { strict }),
+  });
+  const url = await app.listen(0);
+  const served: Served[] = [];
+  for (const path of paths) {
+    const response = await fetch(new URL(path, url));
+    served.push({ status: response.status, body: await response.text() });
+  }
+  const { routes } = app.get(RequestMetrics).snapshot();
+  await app.shutdown();
+  // Last entry carries the metrics labels, so one boot answers both questions.
+  return [
+    ...served,
+    {
+      status: routes.length,
+      body: routes
+        .map((r) => r.route)
+        .sort()
+        .join(','),
+    },
+  ];
+};
+
+describe('a trailing slash', () => {
+  /* The declined decision in architecture/http.md stands as the default. */
+  test('is a 404 by default', async () => {
+    const [list, listSlash, one, oneSlash] = await serve([
+      '/users',
+      '/users/',
+      '/users/1',
+      '/users/1/',
+    ]);
+
+    expect([list?.status, one?.status]).toEqual([200, 200]);
+    expect([listSlash?.status, oneSlash?.status]).toEqual([404, 404]);
+  });
+
+  test('serves the same route under strict: false', async () => {
+    const [list, listSlash, one, oneSlash] = await serve(
+      ['/users', '/users/', '/users/1', '/users/1/'],
+      false,
+    );
+
+    expect([list?.status, listSlash?.status]).toEqual([200, 200]);
+    expect(listSlash?.body).toBe(list?.body);
+    expect([one?.status, oneSlash?.status]).toEqual([200, 200]);
+    expect(oneSlash?.body).toBe('{"id":"1"}');
+  });
+
+  /* Two spellings are one series, not `/users/:id` and `/users/:id/`. */
+  test('is counted under the path as declared', async () => {
+    const served = await serve(['/users/1', '/users/1/', '/users/'], false);
+    const labels = served[served.length - 1];
+
+    expect(labels?.body).toBe('/users,/users/:id');
+    expect(labels?.status).toBe(2);
+  });
+});


### PR DESCRIPTION
`Bun.serve({ routes })` matches the literal path, so `GET /t/` is a 404 with `/t`
registered. That stays the default. `strict: false` registers a second key per
route ending in `/`, pointing at the handlers the first one already has.

`architecture/http.md` declined this, and the decline stands as the default. Two
parts of the note it rested on do not, and the section records both:

- It rejected the alias as blast radius, because collision detection, the
  gateway-path check and the CORS `OPTIONS` mounting all walk the table. None of
  them do, so the alias is applied last, at the call site, and inherits the
  preflight.
- It said "Nest, Express and Fastify all normalise". Measured on defaults:
  express, nest and elysia serve the slash; fastify and hono 404. Three to two,
  and `strict` is hono's name for this switch.

The alias is a key rather than a route, so the metrics series, the request log
and the OpenAPI document all still say `/users/:id` - asserted, because a second
route would have split them.

Two calls worth a look: this is an `HttpOptions` field with no `app.set()` twin
(the table is built once, at `listen()`), and `examples/full` sets `strict: false`
to exercise it, so the example no longer shows the default.

Measurements and the per-framework table are in `architecture/constraints.md`,
which also picks up an unrelated find: Bun resolves dot-segments for `req.url`
but matches on the raw target.

Every phase green run separately. Note `examples/` was already at exactly 17.000%
of the comment-density budget on main, zero headroom, so this adds no comment
line there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional trailing-slash routing. When strict routing is disabled, routes accept both slashed and unslashed paths.
  * Strict routing remains enabled by default for exact path matching.
  * Canonical paths remain consistent in logs, metrics, and OpenAPI output.
  * Explicitly defined routes take precedence over generated aliases.

* **Documentation**
  * Updated routing guides and architecture references with configuration details and proxy behavior guidance.

* **Tests**
  * Added coverage for static, parameterized, wildcard, root, and prefixed routes, including response and metrics consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->