### PR TITLE
docs: reference the live demo where a reader is already looking

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ together, on Bun's own primitives.
 [![CI](https://github.com/petarzarkov/dunx/actions/workflows/ci.yml/badge.svg)](https://github.com/petarzarkov/dunx/actions/workflows/ci.yml)
 [![coverage](https://dunx.win/badges/coverage.svg)](https://dunx.win/coverage)
 [![docs](https://img.shields.io/badge/docs-dunx.win-blue)](https://dunx.win)
+[![demo](https://img.shields.io/badge/demo-demo.dunx.win-brightgreen)](https://demo.dunx.win)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Bun](https://img.shields.io/badge/Bun-%E2%89%A51.4-black.svg)](https://bun.sh)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-EA4AAA.svg?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/petarzarkov)
@@ -134,6 +135,10 @@ specifier is a compile error rather than a runtime surprise.
 
 ## Documentation
 
+- **[The live demo](https://demo.dunx.win)** - `examples/full` running on a
+  Raspberry Pi 5: the API explorer, the ops dashboard, bull-board, and a page
+  that drives the websocket gateway, the rate limiter and the queue from a
+  browser
 - **[The guide](https://dunx.win)** - twenty-one pages,
   introduction through agent tooling
 - **[Migrating from NestJS](docs/MIGRATION-FROM-NEST.md)** - what maps across and

--- a/docs/guide/01-introduction.md
+++ b/docs/guide/01-introduction.md
@@ -4,6 +4,10 @@ dunx is a dependency injection framework for [Bun](https://bun.com). It gives yo
 modules, constructor injection, class-based controllers, lifecycle hooks and
 guards. HTTP is served through `Bun.serve`, not through a server dunx wrote.
 
+There is a running app at [demo.dunx.win](https://demo.dunx.win) if you would
+rather click than read: it is `examples/full`, which uses every package in this
+guide, and its API explorer, ops dashboard and queue board are all open.
+
 The architecture follows the pattern Spring and Angular established. A container
 owns object lifetimes. Metadata replaces wiring code. Modules draw domain
 boundaries. If you have worked with either framework, the shape is familiar:

--- a/docs/guide/10-openapi.md
+++ b/docs/guide/10-openapi.md
@@ -24,6 +24,10 @@ const app = await HttpFactory.create(
 );
 ```
 
+The page that produces is at
+[demo.dunx.win/api/docs](https://demo.dunx.win/api/docs), generated from that
+example's own schemas.
+
 `forRoot` **wraps** the root it documents and returns it, so `HttpFactory.create`
 is still handed one module ref and the root is named once. That is also why the
 document describes the documentation routes: they are routes, and pretending

--- a/docs/guide/10-openapi.md
+++ b/docs/guide/10-openapi.md
@@ -24,7 +24,7 @@ const app = await HttpFactory.create(
 );
 ```
 
-The page that produces is at
+The page it produces is at
 [demo.dunx.win/api/docs](https://demo.dunx.win/api/docs), generated from that
 example's own schemas.
 

--- a/docs/guide/15-queues.md
+++ b/docs/guide/15-queues.md
@@ -543,6 +543,9 @@ release and was deleted; bull-board 8.6.0 ships a `Bun.serve` adapter, which
 removed the only reason to hand-roll one. `commands: false` maps onto
 bull-board's `readOnlyMode`.
 
+A read-only one is at
+[demo.dunx.win/api/dashboard/queues](https://demo.dunx.win/api/dashboard/queues).
+
 The board is built on the **first request for the queues page**, never at boot, so
 an app that never opens it holds no broker socket and exits cleanly against an
 absent Redis.

--- a/docs/guide/22-metrics.md
+++ b/docs/guide/22-metrics.md
@@ -149,6 +149,10 @@ The JSON sibling is `GET {path}/api/stats`, behind the same `authorize` as every
 other panel. An unauthenticated endpoint listing every route and its error rate is
 reconnaissance, so there is no public `/metrics`.
 
+The Stats panel is visible at
+[demo.dunx.win/api/dashboard](https://demo.dunx.win/api/dashboard), a demo that
+mounts the page with no `authorize` and a read-only board.
+
 ## What it costs
 
 **+35.2 ns per request** in the shipped configuration. `RequestLoggingMiddleware`

--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -3,6 +3,14 @@
 One long-running backend service that uses every part of dunx, so you can open it
 and poke at it rather than read about it.
 
+It is running at **[demo.dunx.win](https://demo.dunx.win)**, so you can poke at it
+without cloning anything: [the API explorer](https://demo.dunx.win/api/docs),
+[the dashboard](https://demo.dunx.win/api/dashboard) and
+[bull-board](https://demo.dunx.win/api/dashboard/queues).
+
+The database there is in memory and reseeds on restart, so nothing you create
+lasts. That deployment is this directory's `Dockerfile` and `compose.demo.yml`.
+
 **Start smaller if this is your first look.** [`examples/minimal`](../minimal) is
 five files and two minutes; [`examples/databases`](../databases) is database setup
 on four configurations; [`examples/testing`](../testing) is the test story. This one

--- a/internal/docs/src/App.tsx
+++ b/internal/docs/src/App.tsx
@@ -160,6 +160,15 @@ const Navigation = ({
       active={route.kind === RouteKind.Coverage}
       onClick={onNavigate}
     />
+    <NavLink
+      component="a"
+      href="https://demo.dunx.win"
+      target="_blank"
+      rel="noreferrer"
+      label="Live demo"
+      description="examples/full, deployed"
+      onClick={onNavigate}
+    />
   </>
 );
 

--- a/internal/docs/src/pages/Home.tsx
+++ b/internal/docs/src/pages/Home.tsx
@@ -32,6 +32,9 @@ const INTEGRATIONS = [
   { name: 'bullmq', role: 'queues' },
 ];
 
+/** `examples/full`, deployed. Declared once here and used by the button. */
+const DEMO_URL = 'https://demo.dunx.win';
+
 const STEPS = [
   {
     title: 'Install the packages',
@@ -182,6 +185,15 @@ const GetStarted = (): React.JSX.Element => (
       </SimpleGrid>
 
       <Group>
+        <Button
+          component="a"
+          href={DEMO_URL}
+          target="_blank"
+          rel="noreferrer"
+          variant="filled"
+        >
+          Open the live demo
+        </Button>
         <Button
           component="a"
           href={href(RouteKind.Guide, 'migration-from-nest')}

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -6,6 +6,10 @@ config keys and the process itself, **with bull-board mounted for the queues**.
 
 Every panel reads data dunx already computes, so the page is cheap.
 
+There is one running at
+**[demo.dunx.win/api/dashboard](https://demo.dunx.win/api/dashboard)**, mounted
+by `examples/full` with `commands: false` so the board is read-only.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## What changed

`examples/full` is deployed at demo.dunx.win and nothing in the repo pointed at
it. This adds the references: a README badge and Documentation entry, a note in
`examples/full/README.md` and `packages/dashboard/README.md`, a home-page call to
action and a Project nav entry on the site, and a link in four guides to the
running equivalent of what each describes.

## Why

The demo is only useful if a reader finds it. The guide pages are where someone
is already reading about the explorer, the queue board and the Stats panel.

Not added to `Built with dunx` on the home page: that section is for
applications outside this repository, which its own comment says.

## Checks

- [x] `bun run build`
- [x] `bun run lint:check`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test:cov`
- [x] Tests cover the change. A bug fix has a test that fails without the fix.
- [x] Conventional commit messages (`feat:`, `fix:`, `docs:`, ...).
- [x] No em or en dashes. No `enum`, no `any`, no `Dunx`-prefixed identifiers.
- [x] New runtime dependency? None.
- [x] Docs updated if the public surface changed (`docs/guide/`, package README).

`bun run ci` green at 13 of 13. Two guards shaped the wording: a paragraph in
`examples/full/README.md` was over the 420-character cap and is split, and a
sentence in `22-metrics.md` used a "knowing" shape ("on purpose") that put the
page over its budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added links to the live full-example demo throughout the README and guides.
  - Documented access to the API explorer, operations dashboard, queue board, metrics dashboard, and generated OpenAPI documentation.
  - Clarified that demo dashboards provide read-only access and that demo data resets when the deployment restarts.
  - Added live demo links and access buttons to the documentation homepage, sidebar, full example, and dashboard documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->