### PR TITLE
refactor(http/client): simplify the retry jitter and Retry-After parse

### DIFF
--- a/.github/workflows/dunxonu-review.yml
+++ b/.github/workflows/dunxonu-review.yml
@@ -72,8 +72,11 @@ jobs:
             ineligible: count it as already reviewed only if a review covers
             that exact commit. Review the changes since your own last review,
             and do not repeat a finding you have already posted.
-          # The action starts the inline-comment MCP server only when
-          # --allowedTools names it, even though the skill's own frontmatter
-          # already grants the tool.
+          # --allowedTools REPLACES the skill's own allowed-tools frontmatter
+          # rather than adding to it, so every tool the skill declares has to be
+          # named here or the call is denied in a non-interactive run. Naming
+          # only the MCP tool cost a whole review: 13 turns, one denial, nothing
+          # posted. The first eight are the skill's frontmatter verbatim; the
+          # git commands are what its blame-and-history reviewer needs.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Bash(git diff:*)"

--- a/.github/workflows/dunxonu-review.yml
+++ b/.github/workflows/dunxonu-review.yml
@@ -73,6 +73,11 @@ jobs:
             ineligible: count it as already reviewed only if a review covers
             that exact commit. Review the changes since your own last review,
             and do not repeat a finding you have already posted.
+
+            Run every subagent synchronously and use its result in the same
+            turn. This run ends when you stop producing output, so a background
+            agent's completion notification can never reach you: launching one
+            and waiting for it ends the review having done nothing.
           # --allowedTools REPLACES the skill's own allowed-tools frontmatter
           # rather than adding to it, so every tool the skill declares has to be
           # named here or the call is denied in a non-interactive run. Naming

--- a/.github/workflows/dunxonu-review.yml
+++ b/.github/workflows/dunxonu-review.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.DUNXONU_TOKEN }}
+          show_full_output: true # TEMPORARY: diagnosing the skipped review
           plugin_marketplaces: https://github.com/anthropics/claude-code.git
           plugins: code-review@claude-code-plugins
           # The skill's own eligibility check refuses a pull request it has

--- a/.github/workflows/dunxonu.yml
+++ b/.github/workflows/dunxonu.yml
@@ -67,10 +67,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The toolchain, so an answer that has to run `bun run ci` can. The review
-      # workflow needs none of this; a fix does.
-      - if: steps.addressed.outputs.how != 'no'
-        uses: ./.github/actions/setup
+      # No `./.github/actions/setup` here. The action runs its own nested
+      # oven-sh/setup-bun pinned to a different version, and setup-bun prepends
+      # to PATH, so the action's Bun shadows whatever we installed first. A gate
+      # run here would have used that Bun against a lockfile this repo pins to
+      # another one. CI runs the gates on whatever dunxonu pushes, under the
+      # pinned version, which is where that signal belongs.
 
       # A mention states what it wants, so interactive mode reads it and replies
       # on its own. No prompt: that is what selects interactive mode.

--- a/packages/http/src/client/retry.ts
+++ b/packages/http/src/client/retry.ts
@@ -13,10 +13,7 @@ import { FetchError, FetchTransportError } from './errors.js';
  * is a CSPRNG, and costs nothing.
  */
 const uniform = (): number => {
-  const buffer = new Uint32Array(1);
-  crypto.getRandomValues(buffer);
-  // 2**32 rather than 0xffffffff, so the result is [0, 1) and never exactly 1.
-  return (buffer[0] ?? 0) / 2 ** 32;
+  return Math.random();
 };
 
 export interface BackoffOptions {
@@ -34,7 +31,7 @@ export interface BackoffOptions {
 export const backoffDelay = (
   attempt: number,
   { baseMs, power = 2, jitterMs = 1000, maxMs = 30_000 }: BackoffOptions,
-): number => Math.min(baseMs * power ** attempt + uniform() * jitterMs, maxMs);
+): number => Math.min(baseMs * power ** attempt, maxMs) + uniform() * jitterMs;
 
 /**
  * The wait an upstream asked for, in ms, or undefined.
@@ -52,7 +49,7 @@ export const retryAfterMs = (
   if (header === null) return undefined;
 
   const seconds = Number(header);
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  if (!Number.isNaN(seconds)) return Math.max(0, seconds * 1000);
 
   const at = Date.parse(header);
   return Number.isNaN(at) ? undefined : Math.max(0, at - now);


### PR DESCRIPTION
Three small simplifications to `packages/http/src/client/retry.ts`: the jitter source, the backoff cap, and the `Retry-After` numeric check.

Branch is `test/dunxonu-review` - a throwaway for exercising the review workflow, not for merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Retry delays now apply jitter after the backoff limit, allowing a small randomized adjustment beyond the capped delay.
  - Numeric `Retry-After` values are now accepted more broadly, including non-finite numeric values.
  - Retry jitter behavior is more consistent across requests through standardized randomization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->