### PR TITLE
fix(docs): an item on every breadcrumb crumb

### DIFF
--- a/internal/docs/scripts/built-pages.test.ts
+++ b/internal/docs/scripts/built-pages.test.ts
@@ -52,11 +52,25 @@ describe.skipIf(!built)('the built pages', () => {
     expect(page).toContain('name="twitter:card" content="summary_large_image"');
     const blocks = page.match(/application\/ld\+json/g) ?? [];
     expect(blocks.length).toBeGreaterThan(0);
+    let trails = 0;
     for (const json of page.matchAll(
       /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
     )) {
       expect(() => JSON.parse(json[1] ?? '')).not.toThrow();
+      const block = JSON.parse(json[1] ?? '') as {
+        '@type': string;
+        itemListElement?: { item?: string }[];
+      };
+      if (block['@type'] !== 'BreadcrumbList') continue;
+      trails++;
+      // Search Console raised `Missing field "item" (in "itemListElement")`
+      // against these pages. `crumbsOf` is what fixed it; this is the document
+      // Google fetches.
+      for (const item of block.itemListElement ?? []) {
+        expect(item).toHaveProperty('item');
+      }
     }
+    expect(trails).toBe(1);
   });
 
   /**

--- a/internal/docs/scripts/json-ld.test.ts
+++ b/internal/docs/scripts/json-ld.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import type { SiteIndex } from './extract/model';
+import { crumbsOf, jsonLdFor, type Entity } from './json-ld';
+import { clamp, pagesOf, SITE_ORIGIN } from './pages';
+
+const entity: Entity = {
+  origin: SITE_ORIGIN,
+  repoUrl: 'https://github.com/petarzarkov/dunx',
+  version: '3.4.1',
+};
+
+const index = {
+  generatedAt: '2026-09-07T00:00:00.000Z',
+  repoUrl: 'https://github.com/petarzarkov/dunx',
+  guides: [
+    {
+      slug: 'controllers',
+      category: 'guide',
+      section: 'Fundamentals',
+      order: 5,
+      source: 'docs/guide/05-controllers.md',
+      title: 'Controllers',
+      summary: 'A controller is a provider with routes on it.',
+      headings: [],
+    },
+  ],
+  packages: [
+    {
+      name: '@dunx/http',
+      dir: 'http',
+      description: 'The Bun.serve adapter.',
+      subpaths: ['.'],
+      exports: [],
+    },
+  ],
+} as unknown as SiteIndex;
+
+const releases = [{ version: '3.4.1', date: '2026-09-07' }];
+
+interface ListItem {
+  readonly '@type': string;
+  readonly position: number;
+  readonly name: string;
+  readonly item?: string;
+}
+
+const blocksFor = (path: string, title: string, kind: 'article' | 'website') =>
+  jsonLdFor({
+    entity,
+    path,
+    title,
+    description: clamp('Whatever this page is about.'),
+    kind,
+  }).map(
+    (json) =>
+      JSON.parse(json.replace(/\\u003c/g, '<')) as Record<string, unknown>,
+  );
+
+const trailFor = (
+  path: string,
+  title: string,
+  kind: 'article' | 'website',
+): ListItem[] => {
+  const list = blocksFor(path, title, kind).find(
+    (block) => block['@type'] === 'BreadcrumbList',
+  );
+  return (list?.['itemListElement'] ?? []) as ListItem[];
+};
+
+describe('the breadcrumb trail', () => {
+  /**
+   * Search Console reported `Missing field "item" (in "itemListElement")` as a
+   * critical Breadcrumbs issue on dunx.win. Google requires `item` on every
+   * `ListItem` but the last, and `/guide` and `/api` have no page of their own,
+   * so the section crumb used to be published with a name and no URL.
+   */
+  test('gives every crumb an item, on every page the site publishes', () => {
+    for (const page of pagesOf(index, releases)) {
+      const trail = trailFor(page.path, page.title, page.kind);
+      for (const item of trail) {
+        expect({ path: page.path, ...item }).toHaveProperty('item');
+      }
+    }
+  });
+
+  test('numbers the positions from one, with no gaps', () => {
+    for (const page of pagesOf(index, releases)) {
+      const trail = trailFor(page.path, page.title, page.kind);
+      expect(trail.map((item) => item.position)).toEqual(
+        trail.map((_, i) => i + 1),
+      );
+    }
+  });
+
+  test('publishes no URL that is not a page of the site', () => {
+    const served = new Set(
+      pagesOf(index, releases).map((page) => `${SITE_ORIGIN}${page.path}`),
+    );
+    served.add(`${SITE_ORIGIN}/`);
+    for (const page of pagesOf(index, releases)) {
+      for (const item of trailFor(page.path, page.title, page.kind)) {
+        expect([...served]).toContain(item.item ?? '(no item)');
+      }
+    }
+  });
+
+  test('starts at the site root and ends at the page itself', () => {
+    const trail = trailFor(
+      '/guide/controllers',
+      'Controllers | dunx',
+      'article',
+    );
+    expect(trail[0]).toMatchObject({ name: 'dunx', item: `${SITE_ORIGIN}/` });
+    expect(trail.at(-1)).toMatchObject({
+      item: `${SITE_ORIGIN}/guide/controllers`,
+    });
+  });
+
+  test('keeps a routable section in the trail', () => {
+    expect(crumbsOf('/releases/3.4.1', 'dunx 3.4.1 | Releases')).toEqual([
+      { name: 'Releases', path: '/releases' },
+      { name: 'dunx 3.4.1', path: '/releases/3.4.1' },
+    ]);
+  });
+
+  /** `dunx > Controllers | dunx` said the site name twice. */
+  test('labels the leaf with the title, not the whole document title', () => {
+    expect(crumbsOf('/guide/controllers', 'Controllers | dunx')).toEqual([
+      { name: 'Controllers', path: '/guide/controllers' },
+    ]);
+    expect(crumbsOf('/api/http', '@dunx/http | dunx')).toEqual([
+      { name: '@dunx/http', path: '/api/http' },
+    ]);
+    // Nothing to strip, and a title that is only a suffix keeps itself.
+    expect(crumbsOf('/api/http', '@dunx/http')[0]?.name).toBe('@dunx/http');
+    expect(crumbsOf('/api/http', '| dunx')[0]?.name).toBe('| dunx');
+  });
+
+  test('is absent from the landing page, which describes the software', () => {
+    const blocks = blocksFor('/', 'dunx', 'website');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.['@type']).toBe('SoftwareApplication');
+  });
+
+  test('is absent from a path no section claims', () => {
+    expect(crumbsOf('/nope/deep', 'Nope')).toEqual([]);
+    expect(trailFor('/404', 'Not found', 'website')).toEqual([]);
+  });
+});

--- a/internal/docs/scripts/json-ld.ts
+++ b/internal/docs/scripts/json-ld.ts
@@ -10,8 +10,8 @@
  *
  * A guide or a reference page gets `TechArticle` plus the breadcrumb trail its
  * URL already implies. Neither is a ranking factor on its own; both change how
- * the result is drawn, and the breadcrumb is what puts `dunx.win > Guide` under
- * the title instead of a bare URL.
+ * the result is drawn, and the breadcrumb is what puts `dunx.win > Releases`
+ * under the title instead of a bare URL.
  */
 
 export interface Entity {
@@ -24,10 +24,14 @@ export interface Entity {
 export interface Crumb {
   readonly name: string;
   /**
-   * Absent when the section has no page of its own, which is what keeps a
-   * breadcrumb from publishing a URL that answers 404.
+   * Required, so a crumb cannot reach {@link breadcrumbs} without one. Google
+   * treats a `ListItem` with no `item` as a critical Breadcrumbs error on every
+   * position but the last, and it reported one against dunx.win: `/guide` and
+   * `/api` have no page of their own, and the section crumb was being published
+   * with a name and nothing to click. A section like that is left out of the
+   * trail now rather than published without a URL.
    */
-  readonly path?: string;
+  readonly path: string;
 }
 
 /**
@@ -82,24 +86,34 @@ const techArticle = (
 });
 
 /**
- * The label for a first path segment, and whether that section is a page.
+ * The first path segments the site serves, and the crumb each one contributes.
  *
  * `pagesOf` writes `/releases`, but there is no `/guide` or `/api` file and
  * `_redirects` carries no catch-all, so both answer with `404.html`. A crumb
- * linking one would put a dead URL in the structured data.
+ * linking one would put a dead URL in the structured data, and a crumb naming
+ * one without a URL is the error Google raised. Neither contributes a crumb:
+ * `Record<string, Crumb | undefined>` and no entry is how a known section says
+ * it has no page.
  */
-const SECTIONS: Record<
-  string,
-  { readonly name: string; readonly routable: boolean }
-> = {
-  guide: { name: 'Guide', routable: false },
-  api: { name: 'Reference', routable: false },
-  releases: { name: 'Releases', routable: true },
+const SECTIONS: Record<string, Crumb | undefined> = {
+  guide: undefined,
+  api: undefined,
+  releases: { name: 'Releases', path: '/releases' },
 };
 
 /**
- * `/guide/controllers` becomes `dunx > Guide > Controllers`, with `Guide`
- * carrying no link.
+ * A page title as a breadcrumb label: `Controllers | dunx` is the `<title>`, and
+ * a trail reading `dunx > Controllers | dunx` says the site name twice. Only the
+ * last ` | ` segment goes, so `@dunx/http` keeps its slash and `dunx 3.4.1 |
+ * Releases` becomes `dunx 3.4.1`.
+ */
+const label = (title: string): string =>
+  title.replace(/\s*\|\s*[^|]+$/, '').trim() || title;
+
+/**
+ * `/releases/3.4.1` becomes `dunx > Releases > 3.4.1`, and
+ * `/guide/controllers` becomes `dunx > Controllers`, because the guide has no
+ * index page to point the middle crumb at.
  *
  * Built from the path rather than passed in, so a route added to `pagesOf` gets
  * a trail without a second list to update.
@@ -107,20 +121,18 @@ const SECTIONS: Record<
 export const crumbsOf = (path: string, title: string): Crumb[] => {
   const segments = path.split('/').filter((segment) => segment !== '');
   const first = segments[0];
-  if (first === undefined) return [];
+  if (first === undefined || !Object.hasOwn(SECTIONS, first)) return [];
 
   const section = SECTIONS[first];
-  if (section === undefined) return [];
 
   // A one-segment path is the section's own page, and having been handed to this
   // function at all is what says it was rendered.
-  if (segments.length === 1) return [{ name: section.name, path }];
+  if (segments.length === 1) {
+    return section === undefined ? [] : [{ name: section.name, path }];
+  }
 
-  const parent: Crumb = section.routable
-    ? { name: section.name, path: `/${first}` }
-    : { name: section.name };
-
-  return [parent, { name: title, path }];
+  const leaf: Crumb = { name: label(title), path };
+  return section === undefined ? [leaf] : [section, leaf];
 };
 
 const breadcrumbs = (
@@ -140,11 +152,7 @@ const breadcrumbs = (
       '@type': 'ListItem',
       position: index + 2,
       name: crumb.name,
-      // schema.org allows a ListItem with a name and no `item`, which is the
-      // spelling for a step in the trail that is not itself a page.
-      ...(crumb.path === undefined
-        ? {}
-        : { item: `${entity.origin}${crumb.path}` }),
+      item: `${entity.origin}${crumb.path}`,
     })),
   ],
 });


### PR DESCRIPTION
Search Console: `Missing field "item" (in "itemListElement")`, critical, on dunx.win.

Google requires `item` on every `ListItem` but the last. `/guide` and `/api` have no page of their own, so `crumbsOf` published the section crumb with a name and no URL, and every guide and reference page carried one. A section with no page is now left out of the trail, and `Crumb.path` is required so a crumb cannot reach `breadcrumbs()` without one.

| Path | Before | After |
|---|---|---|
| `/guide/controllers` | `dunx > Guide(no item) > Controllers \| dunx` | `dunx > Controllers` |
| `/api/http` | `dunx > Reference(no item) > @dunx/http \| dunx` | `dunx > @dunx/http` |
| `/releases/3.4.1` | `dunx > Releases > dunx 3.4.1 \| Releases` | `dunx > Releases > dunx 3.4.1` |

The leaf label is the second fix: it was the document title, so the trail said the site name twice.

`scripts/json-ld.test.ts` is new and drives every page `pagesOf` publishes; `built-pages.test.ts` asserts it against the document Google fetches. 97 trails in the built site, none missing an item. `bun run ci` green with valkey, postgres and MinIO up.

Not done here: `/benchmarks` and `/coverage` still emit no breadcrumb, because no section claims them. That predates this and is not what was reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation breadcrumb structured data with valid URLs for every breadcrumb item.
  - Excluded unroutable sections from breadcrumb trails.
  - Corrected breadcrumb labels by removing trailing site-name text.
  - Ensured breadcrumb trails start at the site root, end at the current page, and use sequential positions.
- **Tests**
  - Added comprehensive validation for breadcrumb structure, URLs, labels, and page coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->