### PR TITLE
fix(infra): give bullmq's duplicate connections a teardown owner

### DIFF
--- a/internal/notes/roadmap/queue-shutdown-sigterm.md
+++ b/internal/notes/roadmap/queue-shutdown-sigterm.md
@@ -80,11 +80,12 @@ bisecting the stack a layer at a time found a leak in `Bun.RedisClient` on its o
 and a second, separate one in bullmq's Bun adapter. Neither is reachable from
 userland. All three have a minimal reproduction, ready to file.
 
-| #                                                                          | Symptom                                                                       | Layer  |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------ |
-| [A](#leak-a---bun-a-connect-that-never-completes-outlives-close)           | ~~a pending connect outlives `close()`~~ **fixed in Bun 1.4**                 | Bun    |
-| [B](#leak-b---bullmq-disconnect-cannot-cancel-its-own-reconnect)           | a `Worker` on an unreachable server holds the loop after `close()`            | bullmq |
-| [C](#defect-c---no-connection-is-ever-named-so-getworkers-is-always-empty) | ~~`getWorkers()` always `[]`~~ **fixed - was dunx's own `duplicate` wrapper** | dunx   |
+| #                                                                          | Symptom                                                                               | Layer  |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------ |
+| [A](#leak-a---bun-a-connect-that-never-completes-outlives-close)           | ~~a pending connect outlives `close()`~~ **fixed in Bun 1.4**                         | Bun    |
+| [B](#leak-b---bullmq-disconnect-cannot-cancel-its-own-reconnect)           | a `Worker` on an unreachable server holds the loop after `close()`                    | bullmq |
+| [C](#defect-c---no-connection-is-ever-named-so-getworkers-is-always-empty) | ~~`getWorkers()` always `[]`~~ **fixed - was dunx's own `duplicate` wrapper**         | dunx   |
+| [D](#defect-d---a-duplicate-connection-had-no-teardown-owner)              | ~~a duplicate socket outlived shutdown~~ **fixed - dunx's `duplicate` wrapper again** | dunx   |
 
 ## The measurement that separated them
 
@@ -187,6 +188,47 @@ A userland escape hatch exists but is a cast through `unknown` into a field bull
 does not export - `closing = true` plus `clearTimeout(reconnectTimer)`. That is a
 fork by another name and it would break on a patch release, so it is **not** in
 `@dunx/infra/queue`. Fix it upstream, or wait for it.
+
+## Defect D - a duplicate connection had no teardown owner
+
+> **FIXED, and dunx's own, in the same wrapper as C.** `QueueConnection` recorded
+> only the clients `client()` built. bullmq calls `duplicate()` for any connection
+> it may block on, so that socket belonged to nobody: `onShutdown` never reached
+> it, and `open` under-reported by one per blocking object.
+
+Measured against a live broker, counting `duplicate()` calls on the client handed
+over:
+
+| bullmq object | `duplicate()` calls |
+| ------------- | ------------------- |
+| `Queue`       | 0                   |
+| `Worker`      | 1                   |
+| `QueueEvents` | 1                   |
+
+So this predates `JobEvents` by as long as `WorkerFactory` has existed. Sockets
+held by one `QueueConnection`, before and after `onShutdown`:
+
+| object        | before | after |
+| ------------- | ------ | ----- |
+| `Worker`      | 2      | 0     |
+| `QueueEvents` | 2      | 0     |
+
+Both read 1 before the fix, and the second socket was left open.
+
+The fix is not a force-close of a captured `raw`, which is what the review first
+suggested. A duplicate is constructed with **no `raw` at all**: bullmq builds one
+from a `rawFactory` on first connect, which is how it stopped sending duplicates
+to the default server ([#4582](https://github.com/taskforcesh/bullmq/issues/4582)).
+So the socket is read off the adapter at teardown instead of captured when the
+client is handed out - `undefined` immediately, a `Bun.RedisClient` once
+connected. `disconnect()` is raw-safe, so a duplicate that never connected tears
+down without a socket to close.
+
+**This does not touch leak B.** A `Worker` on an unreachable broker still holds
+the loop after `close()`, `ShutdownHooks`' forced exit still stands, and the
+numbers above are sockets released rather than a process that now exits. What
+changed is ownership: every adapter a `QueueConnection` hands out or bullmq
+derives from one is now disconnected and closed by it.
 
 ## Defect C - no connection is ever named, so `getWorkers()` is always empty
 

--- a/internal/notes/roadmap/queue-shutdown-sigterm.md
+++ b/internal/notes/roadmap/queue-shutdown-sigterm.md
@@ -226,9 +226,16 @@ down without a socket to close.
 
 **This does not touch leak B.** A `Worker` on an unreachable broker still holds
 the loop after `close()`, `ShutdownHooks`' forced exit still stands, and the
-numbers above are sockets released rather than a process that now exits. What
-changed is ownership: every adapter a `QueueConnection` hands out or bullmq
-derives from one is now disconnected and closed by it.
+numbers above are sockets released rather than a process that now exits.
+
+What changed is ownership: every adapter a `QueueConnection` hands out or bullmq
+derives from one is disconnected and closed by it, within a bounded teardown.
+`onShutdown` makes at most `TEARDOWN_PASSES` passes, taking each pass's adapters
+out before walking them, so one derived during a pass belongs to the next. The
+bound is what iterating the live array lacked: an adapter that derived another on
+every `disconnect()` would have been walked forever, and a livelocked shutdown is
+worse than a leaked socket. Anything still arriving after the last pass is logged
+and left to the runtime, which is the one case ownership does not cover.
 
 ## Defect C - no connection is ever named, so `getWorkers()` is always empty
 

--- a/packages/infra/src/queue/connection.test.ts
+++ b/packages/infra/src/queue/connection.test.ts
@@ -102,3 +102,93 @@ describe('the raw client bullmq reconnects with', () => {
     source.onShutdown();
   });
 });
+
+/**
+ * bullmq calls `duplicate()` for any connection it may block on - `Worker` and
+ * `QueueEvents` each once, `Queue` never - and `#open` used to hold only the
+ * clients `client()` built, so that socket had no teardown owner.
+ *
+ * Nothing here waits on a broker: a duplicate reports its own `disconnect`, and
+ * whether it ever connected is irrelevant to who owns it.
+ */
+describe('duplicate ownership', () => {
+  /** Replaces `disconnect` with a recorder, returning what it recorded. */
+  const watchDisconnect = (client: unknown): { calls: number } => {
+    const spy = { calls: 0 };
+    const target = client as { disconnect: () => void };
+    const inner = target.disconnect.bind(target);
+    target.disconnect = (): void => {
+      spy.calls += 1;
+      inner();
+    };
+    return spy;
+  };
+
+  it('tears down a duplicate, which used to belong to nobody', () => {
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => unknown;
+    };
+    const copy = client.duplicate({ connectionName: 'bull:cXVldWU=' });
+
+    const watched = watchDisconnect(copy);
+    source.onShutdown();
+
+    expect(watched.calls).toBe(1);
+  });
+
+  it('tears down a duplicate of a duplicate', () => {
+    const source = connection();
+    const first = source.client() as unknown as {
+      duplicate: (options: unknown) => { duplicate: (o: unknown) => unknown };
+    };
+    const second = first.duplicate({});
+    const third = second.duplicate({});
+
+    const watched = [watchDisconnect(second), watchDisconnect(third)];
+    source.onShutdown();
+
+    expect(watched.map((w) => w.calls)).toEqual([1, 1]);
+  });
+
+  it('tears down a duplicate that never got a socket', () => {
+    // A duplicate is built with no `raw`: bullmq creates one from a `rawFactory`
+    // on first connect. So teardown has to cope with there being nothing to
+    // close, which is the case for every duplicate that never connected.
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => { raw?: unknown };
+    };
+    const copy = client.duplicate({});
+
+    expect(copy.raw).toBeUndefined();
+    expect(() => source.onShutdown()).not.toThrow();
+  });
+
+  it('does not count an unconnected duplicate as an open socket', () => {
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => unknown;
+    };
+    client.duplicate({});
+
+    // Nothing reached the broker at `127.0.0.1:1`, so nothing is open - the
+    // count is sockets, not adapters.
+    expect(source.open).toBe(0);
+    source.onShutdown();
+  });
+
+  it('forgets every adapter once shut down, so a second call is a no-op', () => {
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => unknown;
+    };
+    const copy = client.duplicate({});
+
+    source.onShutdown();
+    const watched = watchDisconnect(copy);
+    source.onShutdown();
+
+    expect(watched.calls).toBe(0);
+  });
+});

--- a/packages/infra/src/queue/connection.test.ts
+++ b/packages/infra/src/queue/connection.test.ts
@@ -232,28 +232,30 @@ describe('teardown robustness', () => {
 
     // `disconnect()` with no argument cannot reconnect, but a `close`/`end`
     // listener could duplicate, and that adapter still needs an owner.
+    //
+    // Recorded as it is created, not afterwards: asserting that a second
+    // `onShutdown` disconnects nothing would also pass for a regression that
+    // dropped the late adapter from `#open` without tearing it down.
     let late: { disconnect: () => void } | undefined;
+    let lateCalls = 0;
     const inner = first.disconnect.bind(first);
     first.disconnect = (): void => {
-      late ??= client.duplicate({});
+      if (late === undefined) {
+        const derived = client.duplicate({}) as { disconnect: () => void };
+        const derivedInner = derived.disconnect.bind(derived);
+        derived.disconnect = (): void => {
+          lateCalls += 1;
+          derivedInner();
+        };
+        late = derived;
+      }
       inner();
     };
 
     source.onShutdown();
 
-    let closed = 0;
-    const lateInner = late?.disconnect.bind(late);
-    if (late && lateInner) {
-      late.disconnect = (): void => {
-        closed += 1;
-        lateInner();
-      };
-      // Already disconnected by the second pass, so a further call is the no-op
-      // bullmq's `closed` guard makes it.
-      source.onShutdown();
-    }
     expect(late).toBeDefined();
-    expect(closed).toBe(0);
+    expect(lateCalls).toBe(1);
   });
 
   it('stops rather than livelocking on an adapter that always duplicates', () => {

--- a/packages/infra/src/queue/connection.test.ts
+++ b/packages/infra/src/queue/connection.test.ts
@@ -192,3 +192,92 @@ describe('duplicate ownership', () => {
     expect(watched.calls).toBe(0);
   });
 });
+
+/**
+ * Teardown is the last step of shutdown, so nothing in it may abandon what
+ * follows. Both cases here are deterministic: the adapters are real, only their
+ * `disconnect` is replaced, and no broker is involved.
+ */
+describe('teardown robustness', () => {
+  it('does not orphan the adapters after one that throws', () => {
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => { disconnect: () => void };
+    };
+    const thrower = client.duplicate({});
+    const after = client.duplicate({});
+
+    thrower.disconnect = (): never => {
+      throw new Error('already torn down');
+    };
+    let reached = 0;
+    const inner = after.disconnect.bind(after);
+    after.disconnect = (): void => {
+      reached += 1;
+      inner();
+    };
+
+    // The pass used to stop at the throw, and `#open` had already been emptied,
+    // so nothing later would retry the rest.
+    expect(() => source.onShutdown()).not.toThrow();
+    expect(reached).toBe(1);
+  });
+
+  it('tears down an adapter that arrives during teardown', () => {
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => { disconnect: () => void };
+    };
+    const first = client.duplicate({});
+
+    // `disconnect()` with no argument cannot reconnect, but a `close`/`end`
+    // listener could duplicate, and that adapter still needs an owner.
+    let late: { disconnect: () => void } | undefined;
+    const inner = first.disconnect.bind(first);
+    first.disconnect = (): void => {
+      late ??= client.duplicate({});
+      inner();
+    };
+
+    source.onShutdown();
+
+    let closed = 0;
+    const lateInner = late?.disconnect.bind(late);
+    if (late && lateInner) {
+      late.disconnect = (): void => {
+        closed += 1;
+        lateInner();
+      };
+      // Already disconnected by the second pass, so a further call is the no-op
+      // bullmq's `closed` guard makes it.
+      source.onShutdown();
+    }
+    expect(late).toBeDefined();
+    expect(closed).toBe(0);
+  });
+
+  it('stops rather than livelocking on an adapter that always duplicates', () => {
+    const source = connection();
+    const client = source.client() as unknown as {
+      duplicate: (options: unknown) => { disconnect: () => void };
+    };
+
+    // Pathological: every teardown derives another adapter. Walking the live
+    // array would never finish.
+    const arm = (adapter: { disconnect: () => void }): void => {
+      const inner = adapter.disconnect.bind(adapter);
+      adapter.disconnect = (): void => {
+        arm(client.duplicate({}));
+        inner();
+      };
+    };
+    arm(client.duplicate({}));
+
+    const started = Bun.nanoseconds();
+    source.onShutdown();
+    const ms = (Bun.nanoseconds() - started) / 1e6;
+
+    expect(ms).toBeLessThan(1_000);
+    expect(source.open).toBe(0);
+  });
+});

--- a/packages/infra/src/queue/connection.ts
+++ b/packages/infra/src/queue/connection.ts
@@ -52,7 +52,8 @@ export class QueueConnection implements OnShutdown {
   readonly #options: QueueOptions;
   readonly #logger: Logger;
   readonly #client: new (url?: string) => Bun.RedisClient;
-  readonly #open: { adapter: IRedisClient; raw: Bun.RedisClient }[] = [];
+  /** Every adapter this connection handed out or bullmq derived from one. */
+  readonly #open: IRedisClient[] = [];
 
   constructor(options: QueueOptions, logger: Logger) {
     this.#options = options;
@@ -68,6 +69,12 @@ export class QueueConnection implements OnShutdown {
    * `QueueBase` forwards connection errors onto the `Queue`, so that needs one too.
    */
   #handleErrors(adapter: IRedisClient): IRedisClient {
+    // Recorded here rather than in `client()`, which is what gives a duplicate a
+    // teardown owner: bullmq calls `duplicate()` for anything it may block on -
+    // `Worker` and `QueueEvents` each once, `Queue` never - and that socket used
+    // to belong to nobody. Duplicates of duplicates land here too.
+    this.#open.push(adapter);
+
     adapter.on('error', (error: unknown) => {
       this.#logger.warn('the queue connection reported an error', error);
     });
@@ -103,14 +110,29 @@ export class QueueConnection implements OnShutdown {
     // it closes a connection it did not create, and an 'error' on a listener-less
     // emitter throws rather than being ignored - which used to fail shutdown on
     // its last step. Measured on bullmq 6.0.5.
-    const adapter = this.#handleErrors(createBunRedisClient(raw));
-    this.#open.push({ adapter, raw });
-    return adapter;
+    return this.#handleErrors(createBunRedisClient(raw));
   }
 
-  /** How many sockets this connection currently holds open. */
+  /**
+   * The socket an adapter holds, if it has one yet.
+   *
+   * Read at teardown rather than captured when the client is handed out. A
+   * duplicate is constructed with no `raw` at all - bullmq builds it from a
+   * `rawFactory` on first connect, which is how it stopped sending duplicates to
+   * the default server (taskforcesh/bullmq#4582) - so there is nothing to
+   * capture at the time the wrapper sees it. Measured: `undefined` immediately,
+   * a `Bun.RedisClient` once connected.
+   */
+  #socketOf(adapter: IRedisClient): Bun.RedisClient | undefined {
+    const { raw } = adapter as { raw?: unknown };
+    return raw instanceof Bun.RedisClient ? raw : undefined;
+  }
+
+  /** How many sockets this connection currently holds open, duplicates included. */
   get open(): number {
-    return this.#open.filter(({ raw }) => raw.connected).length;
+    return this.#open.filter(
+      (adapter) => this.#socketOf(adapter)?.connected === true,
+    ).length;
   }
 
   /**
@@ -124,10 +146,13 @@ export class QueueConnection implements OnShutdown {
    * internal/notes/roadmap/queue-shutdown-sigterm.md.
    */
   onShutdown(): void {
-    for (const { adapter, raw } of this.#open) {
+    // Drained first: `disconnect()` can schedule a reconnect, and a reconnect
+    // duplicates, so iterating the live array could append to what it is walking.
+    for (const adapter of this.#open.splice(0)) {
       adapter.disconnect();
-      raw.close();
+      // `disconnect()` is raw-safe and closes nothing for a duplicate that never
+      // connected, so this is the half that releases a socket either way.
+      this.#socketOf(adapter)?.close();
     }
-    this.#open.length = 0;
   }
 }

--- a/packages/infra/src/queue/connection.ts
+++ b/packages/infra/src/queue/connection.ts
@@ -40,6 +40,20 @@ const boundClientClass = (
 };
 
 /**
+ * How many drain passes `onShutdown` makes.
+ *
+ * `disconnect()` with no argument cannot itself hand back a duplicate: only
+ * `disconnect(true)` reaches `_scheduleReconnect`, and the no-argument branch
+ * closes the socket and emits `close` and `end`. A listener on those could still
+ * duplicate, so an adapter arriving mid-teardown is owned rather than dropped.
+ *
+ * The bound is what a plain loop over the live array did not have: an adapter
+ * that duplicated on every `disconnect()` would have been walked forever, and a
+ * livelocked shutdown is worse than a leaked socket.
+ */
+const TEARDOWN_PASSES = 4;
+
+/**
  * Where the ioredis boundary is drawn. bullmq takes either a connection
  * description it builds a client from, or a built client implementing
  * `IRedisClient`; dunx does the second over `Bun.RedisClient`, so every byte of
@@ -146,13 +160,46 @@ export class QueueConnection implements OnShutdown {
    * internal/notes/roadmap/queue-shutdown-sigterm.md.
    */
   onShutdown(): void {
-    // Drained first: `disconnect()` can schedule a reconnect, and a reconnect
-    // duplicates, so iterating the live array could append to what it is walking.
-    for (const adapter of this.#open.splice(0)) {
+    for (
+      let pass = 0;
+      pass < TEARDOWN_PASSES && this.#open.length > 0;
+      pass++
+    ) {
+      // Taken out before the pass walks them, so an adapter that arrives during
+      // it belongs to the next pass rather than to the array being iterated.
+      for (const adapter of this.#open.splice(0)) this.#tearDown(adapter);
+    }
+
+    if (this.#open.length > 0) {
+      this.#logger.warn(
+        `${this.#open.length} queue connection(s) were still being derived after ` +
+          `${TEARDOWN_PASSES} teardown passes, and are left to the runtime`,
+      );
+      this.#open.length = 0;
+    }
+  }
+
+  /**
+   * Both halves, in this order, and neither aborting the other.
+   *
+   * A throw used to end the whole pass: the adapters after it were neither
+   * disconnected nor closed, and having already been taken out of `#open` no
+   * later call would retry them, so their sockets leaked for the life of the
+   * process. An `error` on a listener-less emitter failing shutdown on its last
+   * step is the same shape, and is why `#handleErrors` exists.
+   */
+  #tearDown(adapter: IRedisClient): void {
+    try {
       adapter.disconnect();
+    } catch (error) {
+      this.#logger.warn('a queue connection failed to disconnect', error);
+    }
+    try {
       // `disconnect()` is raw-safe and closes nothing for a duplicate that never
       // connected, so this is the half that releases a socket either way.
       this.#socketOf(adapter)?.close();
+    } catch (error) {
+      this.#logger.warn('a queue socket failed to close', error);
     }
   }
 }


### PR DESCRIPTION
Closes #65.

## What changed

`QueueConnection` recorded only the clients `client()` built. bullmq calls
`duplicate()` for any connection it may block on, so that socket belonged to
nobody: `onShutdown` never reached it, and `open` under-reported by one per
blocking object.

Every adapter is now recorded in `#handleErrors` rather than in `client()`, which
covers duplicates of duplicates as well, and the socket is read off the adapter at
teardown instead of captured when the client is handed out.

## Why that shape

A force-close of a captured `raw` does not work, which the issue records. A
duplicate is constructed with **no `raw` at all**: bullmq builds one from a
`rawFactory` on first connect, which is how it stopped sending duplicates to the
default server ([bullmq#4582](https://github.com/taskforcesh/bullmq/issues/4582)).
Reading it at teardown handles that with no promise to await inside a synchronous
wrapper. `disconnect()` guards on `this.raw`, so a duplicate that never connected
tears down with nothing to close.

`onShutdown` drains the array before walking it, because `disconnect()` can
schedule a reconnect and a reconnect duplicates.

## Measurements

`duplicate()` calls on the client handed over, live broker:

| bullmq object | calls |
| ------------- | ----- |
| `Queue`       | 0     |
| `Worker`      | 1     |
| `QueueEvents` | 1     |

So this predates `JobEvents` by as long as `WorkerFactory` has existed. Sockets
held by one `QueueConnection`:

| object        | before shutdown | after |
| ------------- | --------------- | ----- |
| `Worker`      | 2               | 0     |
| `QueueEvents` | 2               | 0     |

Both read 1 before this change, and the second socket was left open.

**Leak B is untouched.** A `Worker` on an unreachable broker still holds the loop
after `close()`, and `ShutdownHooks`' forced exit still stands. The numbers above
are sockets released, not a process that now exits. Defect D in
`internal/notes/roadmap/queue-shutdown-sigterm.md` records that boundary.

## Checks

- [x] `bun run build`
- [x] `bun run lint:check`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test:cov`
- [x] Tests cover the change. Two of the six fail against the previous implementation.
- [x] Conventional commit messages.
- [x] No em or en dashes. No `enum`, no `any`, no `Dunx`-prefixed identifiers.
- [x] New runtime dependency? None.
- [x] Docs updated: the SIGTERM roadmap note gains defect D.

`bun run ci` is 13/13 with valkey, postgres and MinIO up.

Tests depend on no broker, per the issue's acceptance criteria: a duplicate
reports its own `disconnect`, and whether it ever connected is irrelevant to who
owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed queue shutdown so duplicated and derived connections are properly closed.
  - Corrected connection counts to include active sockets created for workers and event listeners.
  - Improved shutdown reliability when connections are created late or when one connection fails to disconnect.
  - Prevented unconnected duplicate connections from being counted as open.
  - Ensured repeated shutdown attempts complete safely without reopening or leaking connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->