### PR TITLE
fix(review): scope a re-review to what changed, so a pull request can converge

### DIFF
--- a/.github/workflows/dunxonu-review.yml
+++ b/.github/workflows/dunxonu-review.yml
@@ -127,6 +127,19 @@ jobs:
       # original defect this workflow had: it reported success while discarding
       # nine findings, and a review gate that can pass without reviewing is worse
       # than no gate.
+      #
+      # `post-review.ts` also decides *what* this review may report on, and that
+      # is the half that makes a pull request converge. The reviewer above always
+      # sees the whole diff - the slash command takes a pull request, not a range,
+      # and an appended instruction to narrow it would lose to the command's own,
+      # the way two other appended instructions already have. So the narrowing is
+      # done after the fact, deterministically: findings in files untouched since
+      # this account's previous review on the pull request are counted in the body
+      # instead of posted again.
+      #
+      # Without it the reviewer is re-rolled against unchanged code on every push.
+      # Measured on #70: five rounds, 24 findings, never an approval, and round 3
+      # reporting two files `git log` shows were untouched since the first push.
       - name: Submit the review
         env:
           GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}

--- a/scripts/post-review.test.ts
+++ b/scripts/post-review.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'bun:test';
 import {
   buildReview,
   commentableLines,
+  COMPARE_FILE_CAP,
   type Commentable,
+  scopeFromCompare,
 } from './post-review.js';
 
 const finding = (over: Record<string, unknown> = {}) => ({
@@ -260,5 +262,31 @@ describe('scoping a review to what changed since the last one', () => {
     );
     expect(review.event).toBe('COMMENT');
     expect(review.body).toContain('Actionable comment');
+  });
+});
+
+/*
+ * The compare endpoint caps its file list at 300 and does not page past it, so a
+ * bigger change comes back silently short. Narrowing the scope to a truncated
+ * list would suppress genuinely new findings and could then approve - the exact
+ * failure the scoping exists to prevent, which is why this widens instead.
+ */
+describe('scope from a compare result', () => {
+  it('scopes to the files it was given', () => {
+    expect(scopeFromCompare(['a.ts', 'b.ts'])).toEqual(
+      new Set(['a.ts', 'b.ts']),
+    );
+  });
+
+  it('scopes to nothing changed, which is still a scope', () => {
+    expect(scopeFromCompare([])).toEqual(new Set());
+  });
+
+  it('widens to the whole diff when the list may be truncated', () => {
+    const many = Array.from({ length: COMPARE_FILE_CAP }, (_, i) => `f${i}.ts`);
+    expect(scopeFromCompare(many)).toBeNull();
+    expect(
+      scopeFromCompare(many.slice(0, COMPARE_FILE_CAP - 1)),
+    ).not.toBeNull();
   });
 });

--- a/scripts/post-review.test.ts
+++ b/scripts/post-review.test.ts
@@ -183,3 +183,82 @@ describe('reading the diff', () => {
     expect(lines.has('binary.png')).toBe(false);
   });
 });
+
+/*
+ * The reviewer runs against the full diff on every push and is not deterministic
+ * over it, so unchanged code gets a fresh chance to yield a finding on each run.
+ * Measured on #70: five rounds, 24 findings, never an approval, with round 3
+ * reporting two files `git log` shows were untouched since the first push.
+ *
+ * Scoping later reviews to what actually changed is what lets a pull request
+ * converge.
+ */
+describe('scoping a review to what changed since the last one', () => {
+  const both = diff({ 'a.ts': [10], 'b.ts': [3] });
+
+  it('reports everything when there is no previous review', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      both,
+      null,
+    );
+    expect(review.comments).toHaveLength(2);
+    expect(review.event).toBe('COMMENT');
+  });
+
+  it('drops findings in files untouched since the last review', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      both,
+      new Set(['b.ts']),
+    );
+    expect(review.comments).toHaveLength(1);
+    expect(review.comments[0]?.path).toBe('b.ts');
+  });
+
+  it('says how many it carried rather than hiding them', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      both,
+      new Set(['b.ts']),
+    );
+    expect(review.body).toContain('1 further finding');
+    expect(review.body).toContain('untouched since the last review');
+  });
+
+  it('approves when everything left in scope is clean', () => {
+    // The convergence case: the author fixed what was raised and pushed. The
+    // only findings left are about code this push did not touch, so there is
+    // nothing new to say and the review should say so.
+    const review = buildReview(
+      listed(finding({ file: 'untouched.ts' })),
+      diff({ 'b.ts': [3] }),
+      new Set(['b.ts']),
+    );
+    expect(review.event).toBe('APPROVE');
+    expect(review.comments).toHaveLength(0);
+    expect(review.body).toContain('1 further finding');
+  });
+
+  it('still approves a genuinely clean review with nothing carried', () => {
+    const review = buildReview(
+      listed(),
+      diff({ 'b.ts': [3] }),
+      new Set(['b.ts']),
+    );
+    expect(review.event).toBe('APPROVE');
+    expect(review.body).toBe(
+      'Reviewed the diff and found nothing worth changing.',
+    );
+  });
+
+  it('keeps a finding with no file, which cannot be attributed to one', () => {
+    const review = buildReview(
+      listed(finding({ file: undefined, line: undefined })),
+      diff({ 'b.ts': [3] }),
+      new Set(['b.ts']),
+    );
+    expect(review.event).toBe('COMMENT');
+    expect(review.body).toContain('Actionable comment');
+  });
+});

--- a/scripts/post-review.ts
+++ b/scripts/post-review.ts
@@ -54,6 +54,26 @@ export type Commentable = ReadonlyMap<string, ReadonlySet<number>>;
  */
 export type Scope = ReadonlySet<string> | null;
 
+/**
+ * GitHub's compare endpoint returns at most this many files and does not page
+ * past them, so a longer list has been silently truncated.
+ */
+export const COMPARE_FILE_CAP = 300;
+
+/**
+ * The scope a compare result supports, or `null` when it cannot be trusted to be
+ * complete.
+ *
+ * Suppressing a finding because its file fell off the end of a truncated list is
+ * the exact failure this scoping exists to prevent: a genuinely new problem,
+ * filed under "not repeated here", on a review that could then approve.
+ *
+ * Being wrong about the cap is safe in the direction that matters - too low
+ * reviews more than it needs to, and only too high could suppress.
+ */
+export const scopeFromCompare = (touched: readonly string[]): Scope =>
+  touched.length >= COMPARE_FILE_CAP ? null : new Set(touched);
+
 const VERDICT = /^VERDICT: (APPROVE|COMMENT)$/gm;
 
 /**
@@ -311,10 +331,11 @@ const lastReviewedSha = async (
 /**
  * The files touched since this reviewer last looked, or `null` when it has not.
  *
- * A `compare` that fails - the old commit garbage-collected after a force-push,
- * most likely - widens the scope back to everything rather than narrowing it to
- * nothing. Reviewing too much is the behaviour being fixed; reviewing nothing
- * silently would be worse than the bug.
+ * Both failure modes here widen rather than narrow. A `compare` that throws -
+ * the old commit garbage-collected after a force-push, most likely - and a
+ * response at the file cap both fall back to the whole diff. Reviewing too much
+ * is the behaviour being fixed; reviewing nothing silently would be worse than
+ * the bug.
  */
 const scopeSince = async (
   repo: string,
@@ -328,10 +349,13 @@ const scopeSince = async (
       await gh(['api', `repos/${repo}/compare/${since}...${head}`]),
     ) as { files?: { filename: string }[] };
     const touched = compared.files?.map((file) => file.filename) ?? [];
+    const scope = scopeFromCompare(touched);
     console.log(
-      `Reviewing ${touched.length} file(s) changed since ${since.slice(0, 7)}.`,
+      scope === null
+        ? `Compare returned ${touched.length} files, at or past the ${COMPARE_FILE_CAP} the API caps at, so the list may be short. Reviewing the whole diff.`
+        : `Reviewing ${touched.length} file(s) changed since ${since.slice(0, 7)}.`,
     );
-    return new Set(touched);
+    return scope;
   } catch (error) {
     console.log(
       `Could not compare ${since.slice(0, 7)}...${head.slice(0, 7)}, reviewing the whole diff: ${String(error)}`,

--- a/scripts/post-review.ts
+++ b/scripts/post-review.ts
@@ -32,6 +32,28 @@ export interface Review {
 /** Line numbers on the right-hand side of the diff, which are the commentable ones. */
 export type Commentable = ReadonlyMap<string, ReadonlySet<number>>;
 
+/**
+ * The files this review is allowed to report on, or `null` for all of them.
+ *
+ * `null` is the first review of a pull request, which sees the whole diff. Every
+ * review after it sees only the files touched since the previous one.
+ *
+ * **This is what lets a pull request converge.** The reviewer runs against the
+ * full diff on every push and is not deterministic over it, so unchanged code
+ * gets a fresh chance to yield a finding on each run. Measured on #70: round 3
+ * reported `rssMeanMiB` in `src/resources.ts` and a duplicated `Row` in
+ * `servers/drivers/pair.ts`, and `git log` shows neither file was touched between
+ * the first push and the commit that round reviewed. Both findings were equally
+ * true and equally reportable in round 1. Five rounds, 24 findings, and never an
+ * approval, because there was always something new to say about code nobody had
+ * changed.
+ *
+ * Findings outside the scope are counted in the body rather than dropped in
+ * silence: they were reportable earlier and are still true, and hiding them would
+ * be this script deciding what the author may see.
+ */
+export type Scope = ReadonlySet<string> | null;
+
 const VERDICT = /^VERDICT: (APPROVE|COMMENT)$/gm;
 
 /**
@@ -125,8 +147,16 @@ const at = (finding: Finding): string =>
 export const buildReview = (
   result: string,
   commentable: Commentable,
+  scope: Scope = null,
 ): Review => {
-  const findings = findingsIn(result);
+  const all = findingsIn(result);
+  const findings =
+    all === undefined || scope === null
+      ? all
+      : all.filter(
+          (finding) => finding.file === undefined || scope.has(finding.file),
+        );
+  const carried = (all?.length ?? 0) - (findings?.length ?? 0);
   const sentinel = verdictIn(result);
   const clean =
     findings !== undefined &&
@@ -156,7 +186,10 @@ export const buildReview = (
   if (findings.length === 0) {
     return {
       event,
-      body: 'Reviewed the diff and found nothing worth changing.',
+      body:
+        carried === 0
+          ? 'Reviewed the diff and found nothing worth changing.'
+          : `Reviewed what changed since the last review and found nothing worth changing.\n\n${carriedNote(carried)}`,
       comments: [],
     };
   }
@@ -185,6 +218,8 @@ export const buildReview = (
 
   const plural = findings.length === 1 ? 'comment' : 'comments';
   const body = [`**Actionable ${plural} posted: ${comments.length}**`];
+
+  if (carried > 0) body.push('', carriedNote(carried));
 
   if (elsewhere.length > 0) {
     // Collapsed, so the conversation stays a summary rather than the review.
@@ -233,6 +268,16 @@ export const commentableLines = (
   return map;
 };
 
+/**
+ * Said plainly rather than hidden: these findings are real, they are just not
+ * about anything this push touched, so repeating them as new inline comments on
+ * every round is what turns a review into a treadmill.
+ */
+const carriedNote = (carried: number): string =>
+  `${carried} further finding${carried === 1 ? '' : 's'} ` +
+  `${carried === 1 ? 'is' : 'are'} in code untouched since the last review, ` +
+  'and so were reportable then. Not repeated here.';
+
 const gh = async (args: readonly string[]): Promise<string> => {
   const proc = Bun.spawn(['gh', ...args], { stdout: 'pipe', stderr: 'pipe' });
   const [out, err, code] = await Promise.all([
@@ -242,6 +287,57 @@ const gh = async (args: readonly string[]): Promise<string> => {
   ]);
   if (code !== 0) throw new Error(`gh ${args.join(' ')} failed: ${err.trim()}`);
   return out;
+};
+
+/**
+ * The commit this reviewer last posted a review against on this pull request, or
+ * `undefined` if this is the first.
+ *
+ * By the authenticated account rather than a hardcoded login: the workflow runs
+ * as whatever `DUNXONU_TOKEN` belongs to, and a review left by a human or by
+ * another bot must not narrow what this one looks at.
+ */
+const lastReviewedSha = async (
+  repo: string,
+  number: string,
+): Promise<string | undefined> => {
+  const me = (await gh(['api', 'user', '--jq', '.login'])).trim();
+  const reviews = JSON.parse(
+    await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/reviews`]),
+  ) as { user?: { login?: string }; commit_id?: string }[];
+  return reviews.findLast((review) => review.user?.login === me)?.commit_id;
+};
+
+/**
+ * The files touched since this reviewer last looked, or `null` when it has not.
+ *
+ * A `compare` that fails - the old commit garbage-collected after a force-push,
+ * most likely - widens the scope back to everything rather than narrowing it to
+ * nothing. Reviewing too much is the behaviour being fixed; reviewing nothing
+ * silently would be worse than the bug.
+ */
+const scopeSince = async (
+  repo: string,
+  number: string,
+  head: string,
+): Promise<Scope> => {
+  const since = await lastReviewedSha(repo, number);
+  if (since === undefined || since === head) return null;
+  try {
+    const compared = JSON.parse(
+      await gh(['api', `repos/${repo}/compare/${since}...${head}`]),
+    ) as { files?: { filename: string }[] };
+    const touched = compared.files?.map((file) => file.filename) ?? [];
+    console.log(
+      `Reviewing ${touched.length} file(s) changed since ${since.slice(0, 7)}.`,
+    );
+    return new Set(touched);
+  } catch (error) {
+    console.log(
+      `Could not compare ${since.slice(0, 7)}...${head.slice(0, 7)}, reviewing the whole diff: ${String(error)}`,
+    );
+    return null;
+  }
 };
 
 if (import.meta.main) {
@@ -284,7 +380,11 @@ if (import.meta.main) {
     await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/files`]),
   ) as { filename: string; patch?: string }[];
 
-  const review = buildReview(result, commentableLines(files));
+  const review = buildReview(
+    result,
+    commentableLines(files),
+    await scopeSince(repo, number, head),
+  );
   if (review.body === '' && review.comments.length === 0) {
     console.error('The reviewer produced no review. Not posting an empty one.');
     process.exit(1);


### PR DESCRIPTION
Closes #73.

dunxonu re-reviewed the whole diff on every push, and it is not deterministic over
the same input, so unchanged code got a fresh chance to yield a finding on each
run.

#70 ran **five rounds, 24 findings, and never approved**. Round 3 reported
`rssMeanMiB` in `src/resources.ts` and a duplicated `Row` in
`servers/drivers/pair.ts` - and `git log` shows neither file was touched between
the first push and the commit that round reviewed:

```
$ git log --oneline c1d9f3d..204f05a -- internal/bench/src/resources.ts
(nothing)
```

Both findings were good, and both were equally reportable in round 1. The problem
is when they arrive, not whether they are right.

## The change

A review after the first reports only on files touched since **this account's**
previous review of the pull request. The first review still sees everything.

Out-of-scope findings are counted in the body, not dropped in silence - they were
reportable earlier and are still true, and hiding them would be this script
deciding what the author may see.

That also makes the approval reachable, which is the other half of #73. Approving
used to require the reviewer to find literally nothing, which on a real diff never
happened. Now: fix what was raised, push, and a review whose scope comes back
clean approves.

## Where it lives, and why not in the prompt

`post-review.ts`, deterministically. `/code-review` takes a pull request, not a
range, and an appended instruction to narrow it would lose to the command's own -
which this workflow already records twice as the reason two other appended
instructions were dropped.

## Edge cases

- **Last review found by authenticated account**, not a hardcoded login, so a
  human's review on the pull request cannot narrow the bot's scope.
- **A failed `compare`** - the old commit collected after a force-push - widens
  back to the whole diff rather than narrowing to nothing. Reviewing too much is
  the bug being fixed; reviewing nothing silently would be worse than it.
- **A finding with no file** cannot be attributed to one and is always kept.

Six new tests, including the convergence case: everything left in scope clean,
findings carried, `APPROVE`.

## Not done

#73 also suggested letting severity pick the event so a review could approve *with*
non-blocking notes. `ReportFindings` gives `post-review.ts` a category and a
verdict but no severity, so there is nothing to threshold on, and scoping makes
the approval reachable without it. Worth revisiting only if approvals still turn
out to be rare.

## Reviewing this

This pull request changes the reviewer that reviews it. The first review here runs
under the old behaviour, since the workflow on `main` is what runs; the effect is
visible from the second push onward, and on the next pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reviews now focus inline findings on files changed since the reviewer’s previous review.
  - Findings from unchanged files are summarized in the review body instead of being posted again.
  - Reviews still post actionable findings that are not associated with a file.
  - Reviews fall back to the full diff when file comparisons are incomplete.

- **Documentation**
  - Added workflow guidance explaining how review findings are scoped and summarized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->