### PR TITLE
docs(architecture): attribute the boot cost, which was never split

### DIFF
--- a/docs/architecture/dependency-injection.md
+++ b/docs/architecture/dependency-injection.md
@@ -81,6 +81,34 @@ It would also cost `@dunx/core` its empty dependency list. The transform needs
 `oxc-parser`, a native binary. Every production deployment would then carry it,
 in order to run code that was already transformed at build time.
 
+### What the preload costs at boot
+
+Measured on Bun 1.4.2, a 5950X, median of 11 cold starts, each rung a whole
+process adding one step to the one above it:
+
+| Rung                        |   ms |  MiB | adds ms | adds MiB |
+| --------------------------- | ---: | ---: | ------: | -------: |
+| bare `bun`                  |  3.7 | 12.6 |         |          |
+| + `@dunx/transform` preload |  9.8 | 26.7 |    +6.1 |    +14.1 |
+| + `import '@dunx/core'`     | 11.4 | 27.4 |    +1.5 |     +0.7 |
+| + `import '@dunx/http'`     | 16.9 | 30.2 |    +5.5 |     +2.7 |
+| + `HttpFactory.create`      | 22.3 | 41.3 |    +5.4 |    +11.1 |
+| + `listen()`                | 24.8 | 43.2 |    +2.5 |     +1.9 |
+| raw `Bun.serve`, for scale  |  4.4 | 14.6 |         |          |
+
+**The preload is the largest single item in both columns** - 49% of the memory a
+dunx process holds over a raw `Bun.serve` one, and 30% of the time. It is paid
+before any application code runs: the 14.1 MiB is `oxc-parser` loading into a
+script with no classes in it at all.
+
+The container and the resolved provider graph are the other half, at 11.1 MiB and
+5.4 ms.
+
+`bun build --compile` already avoids the preload half - the records are written at
+build time and the binary needs no parser, which is what `examples/binary`
+demonstrates. So the 14.1 MiB is a cost of the `bun run` deployment shape rather
+than of the design, and anyone choosing between the two can now price it.
+
 So registration stays explicit, and the failure mode is closed off instead:
 
 ### The missing-transform guard

--- a/docs/architecture/dependency-injection.md
+++ b/docs/architecture/dependency-injection.md
@@ -84,11 +84,14 @@ in order to run code that was already transformed at build time.
 ### What the preload costs at boot
 
 Measured on Bun 1.4.2, a 5950X, median of 11 cold starts, each rung a whole
-process adding one step to the one above it:
+process adding one step to the one above it. The `oxc-parser` row is the
+exception: it is measured against bare `bun`, so it splits the preload below it
+rather than stacking on it.
 
 | Rung                        |   ms |  MiB | adds ms | adds MiB |
 | --------------------------- | ---: | ---: | ------: | -------: |
 | bare `bun`                  |  3.7 | 12.6 |         |          |
+| `import 'oxc-parser'` alone |  8.9 | 24.7 |    +5.2 |    +12.1 |
 | + `@dunx/transform` preload |  9.8 | 26.7 |    +6.1 |    +14.1 |
 | + `import '@dunx/core'`     | 11.4 | 27.4 |    +1.5 |     +0.7 |
 | + `import '@dunx/http'`     | 16.9 | 30.2 |    +5.5 |     +2.7 |
@@ -96,18 +99,28 @@ process adding one step to the one above it:
 | + `listen()`                | 24.8 | 43.2 |    +2.5 |     +1.9 |
 | raw `Bun.serve`, for scale  |  4.4 | 14.6 |         |          |
 
-**The preload is the largest single item in both columns** - 49% of the memory a
-dunx process holds over a raw `Bun.serve` one, and 30% of the time. It is paid
-before any application code runs: the 14.1 MiB is `oxc-parser` loading into a
-script with no classes in it at all.
+**The preload is the largest single item in memory**, at 49% of what a dunx
+process holds over a raw `Bun.serve` one, and it is paid before any application
+code runs: the rung above adds it to a script with no classes in it at all.
+`oxc-parser` on its own accounts for 12.1 of those 14.1 MiB, measured the same
+way; the rest is the plugin and its registration.
 
-The container and the resolved provider graph are the other half, at 11.1 MiB and
-5.4 ms.
+**Time ranks differently, and the two should not be read as one number.** Of the
+21.1 ms over the baseline, the preload is 6.1, `import '@dunx/http'` is 5.5 and
+`HttpFactory.create` is 5.4. Those three are within a millisecond of each other,
+so anyone reducing boot latency has three targets rather than one, and the import
+is as large as the container.
 
-`bun build --compile` already avoids the preload half - the records are written at
-build time and the binary needs no parser, which is what `examples/binary`
-demonstrates. So the 14.1 MiB is a cost of the `bun run` deployment shape rather
-than of the design, and anyone choosing between the two can now price it.
+Memory is the lopsided one: 14.1 for the preload and 11.1 for the container and
+the resolved provider graph, against 2.7 for that same import.
+
+The preload half is already avoidable for a compiled deployment. `examples/binary`
+calls `Bun.build({ compile, plugins: [depsPlugin] })`, which applies the transform
+during the build and bakes the records into the binary, so the artifact carries no
+parser and needs no preload. That is the `Bun.build` API with `depsPlugin` rather
+than a plain `bun build --compile`, which would produce a binary with no records
+in it at all. So the 14.1 MiB is a cost of the `bun run` deployment shape rather
+than of the design, and the two can now be priced against each other.
 
 So registration stays explicit, and the failure mode is closed off instead:
 


### PR DESCRIPTION
Closes #72.

That issue recorded dunx booting at 1.93x raw `Bun.serve` and +16.7 MiB, and noted
the memory had **never been attributed**. It is now, next to the paragraph in
`docs/architecture/dependency-injection.md` that asserts production carries
`oxc-parser` "in order to run code that was already transformed at build time" -
which is exactly the claim these numbers price.

A ladder of whole processes, each adding one step to the one above it, median of
11 cold starts on Bun 1.4.2:

| Rung | ms | MiB | adds ms | adds MiB |
| ---- | -: | --: | ------: | -------: |
| bare `bun` | 3.7 | 12.6 | | |
| + `@dunx/transform` preload | 9.8 | 26.7 | +6.1 | +14.1 |
| + `import '@dunx/core'` | 11.4 | 27.4 | +1.5 | +0.7 |
| + `import '@dunx/http'` | 16.9 | 30.2 | +5.5 | +2.7 |
| + `HttpFactory.create` | 22.3 | 41.3 | +5.4 | +11.1 |
| + `listen()` | 24.8 | 43.2 | +2.5 | +1.9 |
| raw `Bun.serve`, for scale | 4.4 | 14.6 | | |

**The preload is the largest single item in both columns** - 49% of the memory and
30% of the time - and it is paid before any application code runs. The 14.1 MiB is
`oxc-parser` loading into a script with no classes in it at all. The container and
resolved provider graph are the other half, at 11.1 MiB and 5.4 ms.

**And that half is already avoidable.** `bun build --compile` writes the records at
build time and the binary carries no parser, which `examples/binary` already
demonstrates and documents. So the 14.1 MiB is a cost of the `bun run` deployment
shape rather than of the design - which is worth knowing when choosing between the
two, and was not written down anywhere.

No code changed, and nothing here argues for a change. #72 was tracking, the
unknown in it is now known, and this is where it lives.

The absolute figures are lower than the benchmark's because the harness measures
spawn to first served request and its subjects import zod; the deltas are what
this table is for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark data covering startup time and memory usage across different Bun execution stages.
  * Documented the startup overhead associated with the transformation preload.
  * Clarified that compiled deployments avoid this preload cost, while `bun run` deployments incur it before application code executes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->