### PR TITLE
fix: two security defects found in a framework review

### DIFF
--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -764,6 +764,39 @@ locally, `NetworkSink` for S3), preceded by an empty `Bun.write` to create paren
 and truncate. On 1.4.1 the local half is `Bun.write(path, stream)`; the S3 half is
 still a `NetworkSink`, because `S3Client`'s write takes no `ReadableStream`.
 
+### `Bun.Glob.scan` - `cwd` is where a pattern starts, not a boundary
+
+`scan({ cwd })` resolves the pattern against `cwd` and follows it wherever it
+leads. An absolute pattern ignores `cwd` entirely. Measured on 1.4.2 rev
+`744846f84`, one run, against a root holding `ok/a.txt` and `sub/s.txt` with a
+`secret/creds.env` beside it:
+
+| Pattern              | Yields                                           |
+| -------------------- | ------------------------------------------------ |
+| `**/*`               | `sub/s.txt`, `ok/a.txt`                          |
+| `../secret/*`        | `../secret/creds.env`                            |
+| `sub/../../secret/*` | `sub/../../secret/creds.env`                     |
+| `/etc/hostn*`        | `/etc/hostname`                                  |
+| `{ok,../secret}/*`   | nothing, and that includes the `ok/a.txt` branch |
+| `{.,..}/secret/*`    | nothing                                          |
+| `[.][.]/secret/*`    | nothing                                          |
+| `..?/secret/*`       | nothing                                          |
+
+A `..` segment and a leading `/` escape. The forms that spell a parent segment
+without writing one as a segment do not, and a brace group holding a `..` branch
+matches nothing at all rather than expanding to the branch that would have
+resolved. `dot: true` and `onlyFiles: true` change none of it.
+
+An escape stays visible in the result: a relative match keeps its `../` prefix
+and an absolute pattern yields absolute paths, so nothing is normalised away
+before the caller sees it.
+
+`LocalStorage.list` takes its `glob` from a caller, which in an app is usually a
+query parameter, so it checks the pattern through the same `checkWithin` every
+key goes through and checks each path the scan produced. The second check is
+what keeps containment off the last four rows of that table: they are today's
+expansion, not a promise.
+
 ### `Bun.S3Client` - the undocumented surface
 
 `prototype`: `delete`, `exists`, `file`, `list`, `presign`, `size`, `stat`,

--- a/examples/full/src/negative.test.ts
+++ b/examples/full/src/negative.test.ts
@@ -185,6 +185,18 @@ it('refuses to walk out of the storage root', async () => {
   expect(status).toBe(400);
 });
 
+it('refuses a listing glob that walks out too, not just a key', async () => {
+  // The prefix was checked and the glob beside it was not, so `?glob=/etc/*`
+  // listed the host filesystem through a route that refuses `?key=../..`.
+  for (const glob of ['/etc/*', '../../**/*']) {
+    const { status } = await json<ErrorBody>(
+      `files?glob=${encodeURIComponent(glob)}`,
+    );
+
+    expect(status).toBe(400);
+  }
+});
+
 it('answers 404 for a storage key that was never written', async () => {
   const { status } = await json<ErrorBody>(
     'files/object?key=never-written.txt',

--- a/examples/full/src/storage/files.controller.ts
+++ b/examples/full/src/storage/files.controller.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 /**
  * The key is a query parameter because keys contain slashes: `reports/q1.csv` is
  * one key, not two segments. `Storage` itself rejects traversal - try
- * `?key=../../etc/passwd`.
+ * `?key=../../etc/passwd`, or `?glob=/etc/*` on the listing.
  */
 const FileKey = z.object({ key: z.string().min(1).max(200) }).meta({
   id: 'FileKey',
@@ -26,8 +26,8 @@ const WriteFile = z
 
 const listFiles = {
   query: z.object({
-    prefix: z.string().default(''),
-    glob: z.string().default('**/*'),
+    prefix: z.string().max(200).default(''),
+    glob: z.string().max(200).default('**/*'),
   }),
 } as const;
 const objectKey = { query: FileKey } as const;
@@ -45,11 +45,16 @@ export class FilesController {
     keys: readonly string[];
   }> {
     const keys: string[] = [];
-    for await (const entry of this.storage.list({
-      prefix: query.prefix,
-      glob: query.glob,
-    })) {
-      keys.push(entry.key);
+    try {
+      for await (const entry of this.storage.list({
+        prefix: query.prefix,
+        glob: query.glob,
+      })) {
+        keys.push(entry.key);
+      }
+    } catch (error) {
+      if (!(error instanceof PathTraversalError)) throw error;
+      throw new HttpError(HttpStatusCode.BAD_REQUEST, error.message);
     }
     // The contract cannot promise a root, so narrowing reaches it.
     const root =

--- a/packages/dashboard/src/board.ts
+++ b/packages/dashboard/src/board.ts
@@ -30,7 +30,10 @@ interface BullBoardModules {
     serverAdapter: unknown;
     options?: { uiConfig: BoardUiConfig };
   }) => unknown;
-  readonly BullMQAdapter: new (queue: unknown) => QueueAdapter;
+  readonly BullMQAdapter: new (
+    queue: unknown,
+    options?: { readOnlyMode: boolean },
+  ) => QueueAdapter;
   readonly BunAdapter: new () => {
     setBasePath(path: string): unknown;
     setQueues(queues: unknown): unknown;
@@ -131,7 +134,6 @@ export const boardNames = (
  * setting only one leaves the page half-branded.
  */
 interface BoardUiConfig {
-  readonly readOnlyMode: boolean;
   readonly boardTitle: string;
   /** The mark **in the board's own header**, beside the title. */
   readonly boardLogo: { path: string; width?: number; height?: number };
@@ -145,7 +147,6 @@ const uiConfigFor = (
   options: DashboardOptions,
   favicon: string,
 ): BoardUiConfig => ({
-  readOnlyMode: !options.commands,
   boardTitle: `${options.title} queues`,
   // Both, not just the tab: `boardLogo` is the mark in bull-board's own header,
   // which is what actually makes the page look like part of this app rather than
@@ -187,12 +188,17 @@ export const buildBoard = async (
   serverAdapter.setBasePath(basePath);
 
   createBullBoard({
-    queues: names.map((name) => new BullMQAdapter(source.queue(name))),
+    // `commands: false` maps onto bull-board's own `readOnlyMode` rather than dunx
+    // refusing the POSTs itself, and that switch is **per adapter**: `BaseAdapter`
+    // reads it in its constructor and `queueProvider` answers 405 from it. As a
+    // `uiConfig` key it set a field nothing reads and every mutation stayed open.
+    queues: names.map(
+      (name) =>
+        new BullMQAdapter(source.queue(name), {
+          readOnlyMode: !options.commands,
+        }),
+    ),
     serverAdapter,
-    // `commands: false` maps straight onto bull-board's own `readOnlyMode` rather
-    // than dunx refusing the POSTs itself. Enforcing it here would be a second
-    // implementation of a switch the library already has, and one that disagreed
-    // the moment bull-board grew an operation dunx had not heard of.
     options: { uiConfig: uiConfigFor(options, favicon) },
   });
 

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -316,7 +316,10 @@ describe('the queues handoff', () => {
 });
 
 describe('a read-only mount', () => {
-  it('hands bull-board its own readOnlyMode rather than refusing posts', async () => {
+  let readOnly: Awaited<ReturnType<typeof HttpFactory.create>>;
+  let url = '';
+
+  beforeAll(async () => {
     // dunx does not police bull-board's operations - it has the switch, and a
     // second implementation would disagree the moment it grew an operation.
     @Module({
@@ -327,20 +330,51 @@ describe('a read-only mount', () => {
     })
     class ReadOnly {}
 
-    const readOnly = await HttpFactory.create(ReadOnly, {
+    readOnly = await HttpFactory.create(ReadOnly, {
       requestLogging: false,
       bootLogging: false,
     });
     readOnly.use(DashboardMiddleware);
-    const url = (await readOnly.listen(0)).replace(/\/$/, '');
+    url = (await readOnly.listen(0)).replace(/\/$/, '');
+  });
 
-    const page = await fetch(`${url}/_dunx/queues`);
-    expect(page.status).toBe(200);
-    // bull-board's own UI config, which is where the switch actually lives.
-    expect(await page.text()).toContain('"readOnlyMode":true');
-
+  afterAll(async () => {
     await readOnly.shutdown();
   });
+
+  it('serves the board', async () => {
+    const page = await fetch(`${url}/_dunx/queues`);
+
+    expect(page.status).toBe(200);
+    // bull-board's own shell, so read-only is a refusal of the writes rather
+    // than of the page.
+    expect(await page.text()).toContain('__UI_CONFIG__');
+  });
+
+  // The switch is per **adapter**: `BaseAdapter` reads `readOnlyMode` in its
+  // constructor and `queueProvider` answers 405 from it. Passing it to `uiConfig`
+  // instead set a key bull-board does not have, so every mutation was allowed and
+  // the UI rendered the buttons - asserting the string appeared in the page is
+  // what let that pass. This asserts the refusal instead.
+  const mutations = [
+    ['PUT', 'emails/pause'],
+    ['PUT', 'emails/obliterate'],
+    ['PUT', 'emails/clean/completed'],
+    ['POST', 'emails/add'],
+  ] as const;
+
+  for (const [method, path] of mutations) {
+    it(`refuses ${method} ${path} with 405`, async () => {
+      const response = await fetch(`${url}/_dunx/queues/api/queues/${path}`, {
+        method,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'x', data: {}, options: {} }),
+      });
+
+      expect(response.status).toBe(405);
+      expect(await response.text()).toContain('QUEUE_READ_ONLY');
+    });
+  }
 });
 
 describe('without a config handle', () => {

--- a/packages/infra/src/files/local.test.ts
+++ b/packages/infra/src/files/local.test.ts
@@ -307,6 +307,34 @@ describe('LocalStorage', () => {
       }
     });
 
+    // The prefix was checked and the glob beside it was not, so `prefix: '../..'`
+    // threw while `glob: '/etc/*'` listed the host. Measured on Bun 1.4.2:
+    // `scan` walks a `..` segment and ignores `cwd` entirely for an absolute
+    // pattern.
+    it('rejects a glob that escapes, not just a prefix', async () => {
+      const patterns = [
+        '../*',
+        '../../**/*',
+        'reports/../../*',
+        '/etc/*',
+        '..\\*',
+      ];
+
+      for (const glob of patterns) {
+        expect(await rejection(collect(storage.list({ glob })))).toBeInstanceOf(
+          PathTraversalError,
+        );
+      }
+    });
+
+    it('still lists a glob that merely mentions dots', async () => {
+      await storage.write('a..b/c.txt', 'fine');
+
+      expect(await collect(storage.list({ glob: 'a..b/*' }))).toEqual([
+        'a..b/c.txt',
+      ]);
+    });
+
     it('names the key and the root it refused to leave', async () => {
       const error = await rejection(storage.read('../../etc/passwd'));
 

--- a/packages/infra/src/files/local.test.ts
+++ b/packages/infra/src/files/local.test.ts
@@ -308,9 +308,8 @@ describe('LocalStorage', () => {
     });
 
     // The prefix was checked and the glob beside it was not, so `prefix: '../..'`
-    // threw while `glob: '/etc/*'` listed the host. Measured on Bun 1.4.2:
-    // `scan` walks a `..` segment and ignores `cwd` entirely for an absolute
-    // pattern.
+    // threw while `glob: '/etc/*'` listed the host. What `scan` does with each
+    // of these is in docs/bun-apis.md.
     it('rejects a glob that escapes, not just a prefix', async () => {
       const patterns = [
         '../*',
@@ -328,10 +327,10 @@ describe('LocalStorage', () => {
     });
 
     it('contains what a brace pattern expands to as well', async () => {
-      // Bun 1.4.2 matches nothing for a brace group holding a `..` branch rather
-      // than expanding it into a traversal, and `list` checks the paths a scan
-      // produced - so either way this is a refusal or an empty listing, never a
-      // key from outside the root.
+      // A brace group holding a `..` branch matches nothing on Bun 1.4.2 rather
+      // than expanding into a traversal (docs/bun-apis.md), and `list` checks
+      // the paths a scan produced - so either way this is an empty listing or a
+      // refusal, never a key from outside the root.
       expect(
         await collect(storage.list({ glob: '{reports,../..}/*' })),
       ).toEqual([]);

--- a/packages/infra/src/files/local.test.ts
+++ b/packages/infra/src/files/local.test.ts
@@ -327,6 +327,26 @@ describe('LocalStorage', () => {
       }
     });
 
+    it('contains what a brace pattern expands to as well', async () => {
+      // Bun 1.4.2 matches nothing for a brace group holding a `..` branch rather
+      // than expanding it into a traversal, and `list` checks the paths a scan
+      // produced - so either way this is a refusal or an empty listing, never a
+      // key from outside the root.
+      expect(
+        await collect(storage.list({ glob: '{reports,../..}/*' })),
+      ).toEqual([]);
+    });
+
+    it('lists a key whose colon only looks drive-qualified', async () => {
+      // `resolve` settles this rather than a second regex: on POSIX the key is
+      // an ordinary filename, on Windows it is drive-relative and resolves out.
+      await storage.write('c:notes.txt', 'fine');
+
+      expect(await collect(storage.list({ glob: 'c:*' }))).toEqual([
+        'c:notes.txt',
+      ]);
+    });
+
     it('still lists a glob that merely mentions dots', async () => {
       await storage.write('a..b/c.txt', 'fine');
 

--- a/packages/infra/src/files/local.ts
+++ b/packages/infra/src/files/local.ts
@@ -114,7 +114,7 @@ export class LocalStorage extends Storage {
     // Checked like the prefix above it, or the glob walks out of the root the
     // prefix was just held inside. S3 needs no equivalent: there the glob only
     // filters keys the bucket already returned.
-    const glob = new Bun.Glob(assertGlobWithin(options?.glob ?? '**/*'));
+    const glob = new Bun.Glob(assertGlobWithin(cwd, options?.glob ?? '**/*'));
 
     let yielded = 0;
     try {
@@ -124,9 +124,14 @@ export class LocalStorage extends Storage {
         dot: true,
         onlyFiles: true,
       })) {
+        const key = `${base}${toPosix(relative)}`;
+        // The pattern was checked, and so is every path it produced - so
+        // containment holds however `Bun.Glob` expands a brace or a bracket,
+        // rather than because a measurement said today's expansion is contained.
+        resolveWithin(this.#root, key);
         if (yielded >= limit) return;
         yielded += 1;
-        yield { key: `${base}${toPosix(relative)}` };
+        yield { key };
       }
     } catch (error) {
       // An absent directory lists as empty, matching what S3 does for a prefix

--- a/packages/infra/src/files/local.ts
+++ b/packages/infra/src/files/local.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path';
 import type { BunFile } from 'bun';
 import { FileNotFoundError, UnsupportedOperationError } from './errors.js';
 import {
+  assertGlobWithin,
   guardMissing,
   isMissing,
   resolveDirWithin,
@@ -110,7 +111,10 @@ export class LocalStorage extends Storage {
     const cwd = resolveDirWithin(this.#root, prefix);
     const limit = options?.limit ?? Infinity;
     const base = prefix === '' ? '' : `${toPosix(prefix).replace(/\/+$/, '')}/`;
-    const glob = new Bun.Glob(options?.glob ?? '**/*');
+    // Checked like the prefix above it, or the glob walks out of the root the
+    // prefix was just held inside. S3 needs no equivalent: there the glob only
+    // filters keys the bucket already returned.
+    const glob = new Bun.Glob(assertGlobWithin(options?.glob ?? '**/*'));
 
     let yielded = 0;
     try {

--- a/packages/infra/src/files/local.ts
+++ b/packages/infra/src/files/local.ts
@@ -112,8 +112,8 @@ export class LocalStorage extends Storage {
     const limit = options?.limit ?? Infinity;
     const base = prefix === '' ? '' : `${toPosix(prefix).replace(/\/+$/, '')}/`;
     // Checked like the prefix above it, or the glob walks out of the root the
-    // prefix was just held inside. S3 needs no equivalent: there the glob only
-    // filters keys the bucket already returned.
+    // prefix was just held inside (docs/bun-apis.md). S3 needs no equivalent:
+    // there the glob only filters keys the bucket already returned.
     const glob = new Bun.Glob(assertGlobWithin(cwd, options?.glob ?? '**/*'));
 
     let yielded = 0;

--- a/packages/infra/src/files/path.ts
+++ b/packages/infra/src/files/path.ts
@@ -48,12 +48,16 @@ export const resolveDirWithin = (root: string, prefix: string): string =>
  * A `list` pattern, checked before `Bun.Glob` is constructed from it. `scan`
  * walks a `..` segment and ignores `cwd` outright for an absolute pattern, so a
  * checked `prefix` buys nothing while the glob beside it can name the whole
- * filesystem. Segments, not a substring: an inner `a..b` still lists.
+ * filesystem.
+ *
+ * The same `checkWithin` every key goes through, so there is one definition of
+ * "outside the root" rather than a second one that drifts. A wildcard is an
+ * ordinary path character to `resolve`, and the root itself is the pattern's
+ * own directory. What this cannot see is how `Bun.Glob` expands a brace or a
+ * bracket, so `LocalStorage.list` checks the paths it produced as well.
  */
-export const assertGlobWithin = (glob: string): string => {
-  if (hasParentSegment(glob) || /^([/\\]|[A-Za-z]:)/.test(glob)) {
-    throw new PathTraversalError(glob);
-  }
+export const assertGlobWithin = (root: string, glob: string): string => {
+  checkWithin(root, glob, true);
   return glob;
 };
 

--- a/packages/infra/src/files/path.ts
+++ b/packages/infra/src/files/path.ts
@@ -45,6 +45,19 @@ export const resolveDirWithin = (root: string, prefix: string): string =>
   checkWithin(root, prefix, true);
 
 /**
+ * A `list` pattern, checked before `Bun.Glob` is constructed from it. `scan`
+ * walks a `..` segment and ignores `cwd` outright for an absolute pattern, so a
+ * checked `prefix` buys nothing while the glob beside it can name the whole
+ * filesystem. Segments, not a substring: an inner `a..b` still lists.
+ */
+export const assertGlobWithin = (glob: string): string => {
+  if (hasParentSegment(glob) || /^([/\\]|[A-Za-z]:)/.test(glob)) {
+    throw new PathTraversalError(glob);
+  }
+  return glob;
+};
+
+/**
  * An object key with leading slashes and duplicate separators removed. `..` is
  * rejected outright rather than collapsed: an S3 key is opaque, so a caller who
  * wrote `..` meant a path, and under a configured prefix that would escape it.

--- a/tools/create-app/templates/features/storage/files.controller.ts
+++ b/tools/create-app/templates/features/storage/files.controller.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 /**
  * The key is a query parameter because keys contain slashes: `reports/q1.csv` is
  * one key, not two segments. `Storage` itself rejects traversal - try
- * `?key=../../etc/passwd`.
+ * `?key=../../etc/passwd`, or `?glob=/etc/*` on the listing.
  */
 const FileKey = z.object({ key: z.string().min(1).max(200) }).meta({
   id: 'FileKey',
@@ -26,8 +26,8 @@ const WriteFile = z
 
 const listFiles = {
   query: z.object({
-    prefix: z.string().default(''),
-    glob: z.string().default('**/*'),
+    prefix: z.string().max(200).default(''),
+    glob: z.string().max(200).default('**/*'),
   }),
 } as const;
 const objectKey = { query: FileKey } as const;
@@ -45,11 +45,16 @@ export class FilesController {
     keys: readonly string[];
   }> {
     const keys: string[] = [];
-    for await (const entry of this.storage.list({
-      prefix: query.prefix,
-      glob: query.glob,
-    })) {
-      keys.push(entry.key);
+    try {
+      for await (const entry of this.storage.list({
+        prefix: query.prefix,
+        glob: query.glob,
+      })) {
+        keys.push(entry.key);
+      }
+    } catch (error) {
+      if (!(error instanceof PathTraversalError)) throw error;
+      throw new HttpError(HttpStatusCode.BAD_REQUEST, error.message);
     }
     // The contract cannot promise a root, so narrowing reaches it.
     const root =


### PR DESCRIPTION
Two findings from a security pass over `packages/*` and `tools/*`. Each commit
carries a test that fails without its fix.

**`commands: false` did nothing.** `readOnlyMode` is a per-queue bull-board
adapter option, not a `UIConfig` key, so a read-only dashboard mount served every
mutating queue route: obliterate, clean, retry, and `POST .../add`, which injects
an arbitrary job name and payload into the app's workers. The hand-written
restatement of `BullMQAdapter` had erased the constructor's options parameter,
and the old test asserted the string appeared in the page.

**A `list` glob escaped the storage root.** `LocalStorage.list` checked `prefix`
and not `glob`; `Bun.Glob.scan` walks `..` and ignores `cwd` for an absolute
pattern, so `?glob=/etc/*` enumerated the host through a route that refuses
`?key=../..`. `examples/full` passed the query string in unchecked and
`@dunx/create-app` vendors that folder. Filenames only - `read` and `stat` go
through `resolveWithin`.

`bun run ci` green, 13/13.

Not done here: the example's dashboard still runs with `commands: true`, so the
Rule 4 coverage for the first fix is the package suite, which exercises real
bull-board against a real `Bun.serve`. Adding a board probe to `examples/full`
would make its dashboard demo open a broker socket, which that panel avoids on
purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented file-listing glob patterns from accessing paths outside the configured storage directory, including absolute, parent-directory, and Windows-style traversal patterns.
  - Invalid traversal patterns now return a clear 400 Bad Request response.
  - Limited file-listing prefix and glob parameters to 200 characters.
  - Preserved support for valid filenames containing consecutive dots and colons.
  - Enforced read-only mode by rejecting queue-modifying requests with a 405 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->