### PR TITLE
perf(infra): gate the per-entry glob containment check

### DIFF
--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -807,10 +807,26 @@ root, medians of seven runs:
 | the check alone, 5,000 calls | 1.8 ms |
 
 So it runs only for a pattern that can expand into a segment the pattern check
-did not see: one carrying `{`, `[` or `(`. A wildcard matches a single entry
-name and never a separator, so `*`, `**` and `?` cannot spell a parent segment
-on their own, and extglob is covered because `@(`, `+(`, `?(` and `!(` all carry
-a paren. `**/*` therefore pays nothing and `{a,../b}/*` pays for every entry.
+did not see: one carrying `{`, `[`, `(` or a backslash. A wildcard matches a
+single entry name and never a separator, so `*`, `**` and `?` cannot spell a
+parent segment on their own, and extglob is covered because `@(`, `+(`, `?(` and
+`!(` all carry a paren. `**/*` therefore pays nothing and `{a,../b}/*` pays for
+every entry.
+
+**A backslash is not an escape**, which is why it is on that list rather than
+handled by the pattern check. On 1.4.2 it matches a literal backslash in a name:
+
+```
+ok/*          -> ["ok/a.txt"]      \o\k/*        -> nothing
+dot.dir/*     -> ["dot.dir/f.txt"] dot\.dir/*    -> nothing
+\.\./secret/* -> nothing           ..            -> nothing
+```
+
+So `\.\./secret/*` looks for a directory named `\.\.` and finds none. The day
+Bun aligns with the engines that do treat `\.` as an escaped dot, that pattern
+becomes `../secret/*` while `hasParentSegment` still sees `['', '.', '.']`,
+because it splits on the backslash. Gating on the character costs a real pattern
+nothing and does not wait for that.
 
 ### `Bun.S3Client` - the undocumented surface
 

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -797,6 +797,21 @@ key goes through and checks each path the scan produced. The second check is
 what keeps containment off the last four rows of that table: they are today's
 expansion, not a promise.
 
+That second check is charged per entry, and it is not free. 5,000 files under one
+root, medians of seven runs:
+
+| Listing                      | Median |
+| ---------------------------- | ------ |
+| `**/*`, every entry checked  | 7.0 ms |
+| `**/*`, no entry checked     | 3.7 ms |
+| the check alone, 5,000 calls | 1.8 ms |
+
+So it runs only for a pattern that can expand into a segment the pattern check
+did not see: one carrying `{`, `[` or `(`. A wildcard matches a single entry
+name and never a separator, so `*`, `**` and `?` cannot spell a parent segment
+on their own, and extglob is covered because `@(`, `+(`, `?(` and `!(` all carry
+a paren. `**/*` therefore pays nothing and `{a,../b}/*` pays for every entry.
+
 ### `Bun.S3Client` - the undocumented surface
 
 `prototype`: `delete`, `exists`, `file`, `list`, `presign`, `size`, `stat`,

--- a/packages/infra/src/files/local.test.ts
+++ b/packages/infra/src/files/local.test.ts
@@ -336,6 +336,18 @@ describe('LocalStorage', () => {
       ).toEqual([]);
     });
 
+    it('cannot reach a parent segment with wildcards alone', async () => {
+      // What the per-entry check is gated on: `*` and `?` match one entry name
+      // and never a separator, so a pattern carrying no alternation construct
+      // cannot leave `cwd` and is not charged for the check.
+      // Each of these passes the pattern check, so the scan really runs.
+      for (const glob of ['*/*', '**/*', '?./*', '..?/*']) {
+        const keys = await collect(storage.list({ glob }));
+
+        expect(keys.every((key) => !key.startsWith('..'))).toBe(true);
+      }
+    });
+
     it('lists a key whose colon only looks drive-qualified', async () => {
       // `resolve` settles this rather than a second regex: on POSIX the key is
       // an ordinary filename, on Windows it is drive-relative and resolves out.

--- a/packages/infra/src/files/local.test.ts
+++ b/packages/infra/src/files/local.test.ts
@@ -336,6 +336,17 @@ describe('LocalStorage', () => {
       ).toEqual([]);
     });
 
+    it('contains a backslash-escaped parent segment too', async () => {
+      // `\.\.` is not a parent segment to `hasParentSegment`, which splits on
+      // the backslash, and on Bun 1.4.2 it is not one to `Bun.Glob` either - a
+      // backslash there matches a literal backslash rather than escaping the
+      // dot (docs/bun-apis.md). The gate carries it anyway, so the day that
+      // changes the per-entry check is already running.
+      for (const glob of ['\\.\\./*', '\\.\\./secret/*', '.\\./*']) {
+        expect(await collect(storage.list({ glob }))).toEqual([]);
+      }
+    });
+
     it('cannot reach a parent segment with wildcards alone', async () => {
       // What the per-entry check is gated on: `*` and `?` match one entry name
       // and never a separator, so a pattern carrying no alternation construct

--- a/packages/infra/src/files/local.ts
+++ b/packages/infra/src/files/local.ts
@@ -114,7 +114,12 @@ export class LocalStorage extends Storage {
     // Checked like the prefix above it, or the glob walks out of the root the
     // prefix was just held inside (docs/bun-apis.md). S3 needs no equivalent:
     // there the glob only filters keys the bucket already returned.
-    const glob = new Bun.Glob(assertGlobWithin(cwd, options?.glob ?? '**/*'));
+    const pattern = assertGlobWithin(cwd, options?.glob ?? '**/*');
+    const glob = new Bun.Glob(pattern);
+    // A wildcard matches one entry name and cannot introduce a separator, so
+    // after that check only an alternation construct can still spell a parent
+    // segment. Those pay for a per-entry check and `**/*` does not.
+    const expands = /[{[(]/.test(pattern);
 
     let yielded = 0;
     try {
@@ -125,10 +130,10 @@ export class LocalStorage extends Storage {
         onlyFiles: true,
       })) {
         const key = `${base}${toPosix(relative)}`;
-        // The pattern was checked, and so is every path it produced - so
-        // containment holds however `Bun.Glob` expands a brace or a bracket,
-        // rather than because a measurement said today's expansion is contained.
-        resolveWithin(this.#root, key);
+        // The same check every other method makes, so containment holds however
+        // `Bun.Glob` expands one of those constructs rather than because a
+        // measurement said today's expansion is contained.
+        if (expands) resolveWithin(this.#root, key);
         if (yielded >= limit) return;
         yielded += 1;
         yield { key };

--- a/packages/infra/src/files/local.ts
+++ b/packages/infra/src/files/local.ts
@@ -118,8 +118,10 @@ export class LocalStorage extends Storage {
     const glob = new Bun.Glob(pattern);
     // A wildcard matches one entry name and cannot introduce a separator, so
     // after that check only an alternation construct can still spell a parent
-    // segment. Those pay for a per-entry check and `**/*` does not.
-    const expands = /[{[(]/.test(pattern);
+    // segment. Those pay for a per-entry check and `**/*` does not. A backslash
+    // is in the list because it is not an escape on Bun 1.4.2 and the day it
+    // becomes one, `\.\.` is a parent segment the pattern check cannot see.
+    const expands = /[{[(\\]/.test(pattern);
 
     let yielded = 0;
     try {


### PR DESCRIPTION
Follow-up to the last review round on #83, which landed before three comments
arrived.

`LocalStorage.list` ran `resolveWithin` on every entry it yielded, for a gap its
own comment scoped to brace and bracket expansion. 5,000 files, medians of seven:
`**/*` took 7.0 ms with the check and 3.7 ms without.

It now runs only for a pattern carrying `{`, `[` or `(`. A wildcard matches one
entry name and never a separator, so `*`, `**` and `?` cannot spell a parent
segment once the pattern check has refused a literal `..` and an absolute path;
extglob is covered because `@(`, `+(`, `?(` and `!(` all carry a paren. A test
pins that assumption and the table sits in docs/bun-apis.md beside the scan
behaviour.

The other two comments from that round are answered on #83 rather than here: the
`cwd` one describes a case that produced a malformed key before any of this, and
the wrapper one is a naming call.

`bun run ci` green, 13/13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved file listing safety by preventing glob patterns from traversing outside the intended directory.
  - Added support for validating complex glob patterns, including braces, brackets, parentheses, and backslashes.

- **Bug Fixes**
  - Backslash-based parent-directory patterns now return no results.
  - Wildcard-only patterns cannot access parent-directory entries.

- **Documentation**
  - Documented glob pattern behavior and the performance impact of containment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->