### PR TITLE
docs: correct the swagger-ui-dist peer claim, record Bun.YAML

### DIFF
--- a/docs/architecture/tooling.md
+++ b/docs/architecture/tooling.md
@@ -277,8 +277,11 @@ decision rather than a footnote to it. Two things follow, and both are in the co
 - **It is not inlined.** 1.7 MiB in every page response would resend it on every
   load. The two files are served as routes with `cache-control: immutable` and the
   installed version in the query, so a browser fetches them once.
-- **It is an optional peer, resolved on the first request for the page.** An app
-  serving only `/openapi.json` neither installs nor loads it.
+- **It is a dependency, resolved on the first request for the page.** An app
+  serving only `/openapi.json` installs the 12 MB and never looks it up:
+  `SwaggerAssets.resolve()` runs when a page is first built, not at boot, so a
+  broken install surfaces as that route failing instead of as everyone's boot
+  error. CLAUDE.md carries the carve-out for why it is a dependency and not a peer.
 
 Two measurements from the explorer era still shape things as they are:
 **per-component Mantine CSS** beat the `styles.css` barrel 381 KiB to 517 KiB, and

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -409,12 +409,49 @@ an upload buffer with `await new Bun.Image(buffer).metadata()`, which replaces a
 `Bun.zstdCompressSync`, `Bun.CookieMap`, `Bun.udpSocket`, `Bun.listen`,
 `Bun.connect`, `Bun.FileSystemRouter`, `Bun.ArrayBufferSink`, `Bun.randomUUIDv7`,
 `Bun.inflateSync`, `Bun.Transpiler`, `Bun.color`, `Bun.semver`, `Bun.markdown`,
-`Bun.TOML`, `Bun.which`, `Bun.hash`, `Bun.CSRF`, `Bun.dns`, `Bun.stringWidth`,
+`Bun.TOML`, `Bun.YAML`, `Bun.which`, `Bun.hash`, `Bun.CSRF`, `Bun.dns`,
+`Bun.stringWidth`,
 `Bun.escapeHTML`, `Bun.deepEquals`, `Bun.peek`, `Bun.readableStreamToBytes`,
 `Bun.build`.
 
 Modules: `bun:sqlite` (exports `Database`, `Statement`, `SQLiteError`, `constants`),
-`bun:ffi`, `bun:jsc`, `bun:test`.
+`bun:yaml`, `bun:ffi`, `bun:jsc`, `bun:test`.
+
+### `Bun.YAML` parses config, and a duplicate key takes the last silently
+
+`Bun.YAML` is absent from the API table above and from Bun's docs. On 1.4.2 it is
+`{ parse, stringify }`, and `bun:yaml` resolves as a builtin carrying the `yaml`
+package's surface: `Document`, `Composer`, `parseDocument`, `parseAllDocuments`,
+`visit`. `Bun.TOML` is the same pair, and its `stringify` is undocumented too.
+
+Scalars come back typed, so a config file needs no coercion pass:
+
+```
+server:   { port: 3000, host: "0.0.0.0" }   port     -> number
+database: { poolSize: 10, ssl: false }      ssl      -> boolean
+empty:                                       empty   -> null
+```
+
+Three behaviours to know before pointing it at a config file:
+
+- **A duplicate key does not throw.** `a: 1\na: 2` parses to `{"a": 2}`. The `yaml`
+  package rejects that under its default schema; `Bun.YAML` keeps the last one.
+- **A multi-document stream returns an array.** `a: 1\n---\nb: 2` parses to
+  `[{"a":1},{"b":2}]`, so a stray `---` turns an object into a list and parses
+  clean.
+- **A parse error is a `SyntaxError`** reading `YAML Parse error: Unexpected token`.
+
+The loading half decides the shape of anything file-backed:
+
+| Reading `application.yml`                        | Result                                                                                                   |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `await import('./application.yml')` in a package | resolves against **that module**, so a published `dist/` looks beside itself instead of in the app's cwd |
+| `await import(absolutePath)`                     | works, and parses                                                                                        |
+| `await import(missingPath)`                      | throws `ResolveMessage`                                                                                  |
+| `Bun.file(missingPath).exists()`                 | `false`                                                                                                  |
+
+An optional per-environment overlay needs the last row, so `Bun.file(abs).text()`
+plus `Bun.YAML.parse` is the pairing for a config loader, not a dynamic import.
 
 ### Note on `Bun.SQL` and `Bun.RedisClient`
 


### PR DESCRIPTION
Two stale/missing entries in the maintainer docs, found while costing issues #85 and #79.

- `tooling.md` called `swagger-ui-dist` an optional peer. It is a hard `dependency`; only the lazy `SwaggerAssets.resolve()` half was true.
- `bun-apis.md` had no YAML entry. Probed on 1.4.2 and recorded, including the three behaviours that decide the shape of a file-backed config loader (issue #79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how Swagger UI is delivered, including behavior for applications that expose only the OpenAPI specification and when configuration issues become visible.
  - Added documentation for Bun’s YAML APIs, including parsing, stringifying, typed values, duplicate keys, multi-document handling, syntax errors, and file-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->