### PR TITLE
fix(ci): pull MinIO from quay.io, pinned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,11 +165,17 @@ jobs:
       # command and a service block has no way to pass one. `files/s3.ts` was 35.1%
       # lines with nothing exercising `Bun.S3Client` at all; the round-trip against
       # a real bucket takes it to 87.8%.
+      #
+      # Both images come from quay.io and carry an explicit tag. `minio/minio` and
+      # `minio/mc` were pulled from Docker Hub, which turned an untagged pull into
+      # `pull access denied ... repository does not exist` and failed this job on a
+      # commit that changed nothing here. quay.io is MinIO's own registry; the tag
+      # is pinned so the image cannot move under CI the way `latest` just did.
       - name: Start MinIO and create the bucket
         run: |
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=dunxtest -e MINIO_ROOT_PASSWORD=dunxtestsecret \
-            minio/minio server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           for _ in $(seq 1 40); do
             if curl -sf http://localhost:9000/minio/health/live >/dev/null; then
               break
@@ -179,7 +185,7 @@ jobs:
           curl -sf http://localhost:9000/minio/health/live >/dev/null
           docker run --rm --network host \
             -e MC_HOST_local=http://dunxtest:dunxtestsecret@localhost:9000 \
-            minio/mc mb --ignore-existing local/dunx-test
+            quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z mb --ignore-existing local/dunx-test
 
       - name: Build
         run: bun run ci build


### PR DESCRIPTION
Docker Hub stopped serving `minio/minio` and `minio/mc` between the last green run and the PR #90 merge; both repositories answer `object not found`, so the untagged pull failed the coverage job's MinIO step with `pull access denied`. Nothing in the merged PRs caused it.

Both images move to quay.io, MinIO's own registry, with an explicit release tag instead of an implicit `latest`.

Verified from a cold image cache: the step runs to exit 0, and every phase passes run separately the way CI runs them (`static`, `examples`, `docs`, `browser`, `coverage` - 2295 tests, 0 fail, every package above the 90% floor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated coverage validation to use pinned MinIO images from Quay.io, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->