### PR TITLE
docs: land the OpenTelemetry record, re-probe it on 1.4.2, fix a stale transform comment

### DIFF
--- a/docs/architecture/metrics.md
+++ b/docs/architecture/metrics.md
@@ -64,6 +64,51 @@ both behaviours are in [bun-apis.md](../bun-apis.md).
 per query, so instrumenting after `open()` works. That keeps this out of both
 connection constructors and both option classes.
 
+## Re-measured: the cost case against OpenTelemetry has collapsed, and the answer held anyway
+
+The note rejected `@opentelemetry/api` partly on cost, at noop 14.4-18.0 ns and
+904-932 ns with an SDK registered. Those are Bun 1.3.14 figures and they are
+stale. Re-measured on 1.4.0, 200k iterations warmed, against the attributes dunx
+would actually pass:
+
+| Call                                       |    ns |
+| ------------------------------------------ | ----: |
+| `perf_hooks` `record()`, what dunx uses    |  10.1 |
+| OTel noop `histogram.record`               |   3.8 |
+| OTel noop, with a route attributes object  |   5.9 |
+| OTel + SDK `histogram.record`              |  78.3 |
+| OTel + SDK, with a route attributes object | 359.0 |
+| `prom-client` `observe` with labels        | 430.8 |
+
+So an app registering no SDK would pay **less** than the native histogram, and one
+registering an SDK pays 359 ns, which is 6.6% of the 5.4 us request logging
+already spends. Cost is no longer an argument in either direction.
+
+**The answer is still no dependency**, on three reasons that never were about
+speed:
+
+- **OTel's metrics API is write-only.** A `Histogram` cannot be asked for its
+  p99. The dashboard's Stats panel reads `snapshot()`, so recording into OTel
+  instead of aggregating here would mean attaching a `MetricReader` and reading
+  the collected batch back - more machinery than `Durations` is.
+- **The instrumentation is dunx's either way.** No SDK sees `Bun.serve`,
+  `Bun.SQL`, `Bun.RedisClient` or `fetch` (measured, in bun-apis.md), and the
+  route _pattern_ comes from dunx's own `RouteContext`. Only the aggregation was
+  ever in question.
+- **`RuntimeStats` and `EventLoopLag` have no working equivalent.**
+  `prom-client`'s `collectDefaultMetrics` is partly dead on Bun: event-loop lag
+  always 0, no active-resource counts, zero GC samples.
+
+Plus `@dunx/core` has zero dependencies, and the guide's `prom-client` recipe is
+about fifteen lines.
+
+**What would change it:** an adopter wanting OTLP export without writing that
+pump. The shape is settled if it ever comes - `@opentelemetry/api` as an optional
+peer, `RequestMetrics` and `QueryMetrics` recording into instruments named by the
+semantic conventions they already follow, alongside the native aggregation rather
+than instead of it. Do not reopen this on the cost figures alone; the numbers
+above are the current ones and they did not decide it.
+
 ## What is still not built
 
 The ambient `stats.time('db.query')` handle, which the note gates on nothing now

--- a/docs/bun-apis.md
+++ b/docs/bun-apis.md
@@ -643,6 +643,13 @@ not go through it, so a preloaded SDK patches nothing unless the file that impor
 `node:http` is CJS. The same process instruments a CJS `require` and misses the ESM
 import beside it.
 
+Re-probed on **1.4.2**, and with `getNodeAutoInstrumentations()` in place of the
+single http instrumentation. Nothing moved: a CJS `require('node:http')` still
+records **2** spans with `http.get.__wrapped` true, an ESM `import` still records
+**0**, and `Bun.serve`, `fetch` and `bun:sqlite` in one process still record **0**
+between them. The CJS row is the one that gets misread as having broken since;
+it has not.
+
 The API half works. `startActiveSpan` holds context across an `await`, and a child
 started after it carries the parent's trace id and span id -
 `@opentelemetry/context-async-hooks` over `AsyncLocalStorage`.

--- a/packages/transform/src/deps.ts
+++ b/packages/transform/src/deps.ts
@@ -101,14 +101,13 @@ const entryFor = (
 };
 
 /**
- * Records each class's constructor dependencies, and each decorated field's
- * declared type, as thunks on the class itself.
+ * Records each class's constructor dependencies as a thunk on the class itself.
  *
  * A thunk, not a literal: the body is evaluated when the record is read rather
  * than when the module is defined, so a dependency declared later in the file -
  * or in a circular import - is not a temporal-dead-zone crash. That is what
  * removes the need for a `forwardRef` escape hatch, and it is also why a class decorator
- * cannot read the field record while it runs: the statement is appended after the
+ * cannot read the record while it runs: the statement is appended after the
  * class, which is after decoration.
  */
 export const transform = (


### PR DESCRIPTION
Three loose ends found while triaging the open issues.

- `docs/architecture/metrics.md`: the re-measured OpenTelemetry note, which had been stashed since 2026-09-02 on a branch that was merged and is now deleted. It is what #82 was closed on.
- `docs/bun-apis.md`: re-probed the auto-instrumentation table on 1.4.2. It still reproduces, including under `getNodeAutoInstrumentations()`. A review had claimed the CJS row had broken; it has not, and now the file says so.
- `packages/transform/src/deps.ts`: the doc comment described a decorated-field record the transform has never written.

Docs only plus one comment. `no-em-dash`, `no-slop` and the transform suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metrics documentation with fresh performance measurements and clarified criteria for future telemetry integrations.
  * Documented the latest Bun OpenTelemetry behavior, including current instrumentation coverage across module and runtime APIs.
  * Clarified that dependency metadata documentation covers constructor dependencies only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->