### PR TITLE
ci: take v1.3.0, which reviews the code rather than the patch

### DIFF
--- a/.github/workflows/fast-code-review.yml
+++ b/.github/workflows/fast-code-review.yml
@@ -79,7 +79,7 @@ jobs:
       # Pinned to the tag's commit rather than to `v1`, which is a moving tag:
       # this job hands the action four secrets, and retargeting `v1` would run
       # unreviewed code with them.
-      - uses: petarzarkov/fast-code-review@5a755ef9536df3c98368ed1bc0794c2f9eb3f743 # v1.2.3
+      - uses: petarzarkov/fast-code-review@c2bc36fab217519ec368f700683a7c633d6f69ea # v1.3.0
         with:
           github_token: ${{ secrets.DUNXONU_TOKEN }}
 


### PR DESCRIPTION
The reviewer now gets each changed file whole with the change marked inside it, plus that file's test and its local imports as background, instead of GitHub's three-line patch.

Worth noting this pull request cannot demonstrate the difference: it is a one-line version bump, and there is no surrounding code for the extra context to matter to. The signal will come from the next substantive change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->