### PR TITLE
fix(http): preflight and rate limit a claimed path per path, and escape swagger options

### DIFF
--- a/packages/http/src/connect/connect.test.ts
+++ b/packages/http/src/connect/connect.test.ts
@@ -368,6 +368,41 @@ describe('ConnectModule', () => {
     return app.listen(0);
   };
 
+  it('answers a CORS preflight on an RPC path', async () => {
+    @Module({
+      imports: [
+        ConnectModule.forRoot({
+          services: [connectService(GreetService, GreetRpc)],
+        }),
+      ],
+    })
+    class CorsModule {}
+
+    app = await HttpFactory.create(CorsModule as never, {
+      bootLogging: false,
+      requestLogging: false,
+    });
+    app.use(ConnectMiddleware);
+    app.enableCors({ origin: 'https://app.example' });
+    const url = await app.listen(0);
+
+    const res = await fetch(`${url}${SAY}`, {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://app.example',
+        'access-control-request-method': 'POST',
+      },
+    });
+
+    // `preflight` is mounted over the route table, which an RPC path is not in,
+    // so without one built here a browser gRPC-Web call never gets past this.
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-methods')).toContain('POST');
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'https://app.example',
+    );
+  });
+
   it('refuses a controller route that would shadow an RPC path', async () => {
     @Controller('/')
     class Shadow {

--- a/packages/http/src/connect/middleware.ts
+++ b/packages/http/src/connect/middleware.ts
@@ -53,6 +53,11 @@ export class ConnectMiddleware implements Middleware, ClaimsPaths {
     return this.#registry.paths;
   }
 
+  /** Connect and gRPC-Web both POST. Connect's GET form is not served here. */
+  claimedMethods(): readonly string[] {
+    return ['POST'];
+  }
+
   handle(req: BunRequest, ctx: RouteContext, next: Next): Promise<Response> {
     if (ctx.get(UNMATCHED) !== true) return next();
 

--- a/packages/http/src/server/middleware.ts
+++ b/packages/http/src/server/middleware.ts
@@ -44,6 +44,11 @@ export const compose = (
  */
 export interface ClaimsPaths {
   claimedPaths(): readonly string[];
+  /**
+   * The methods those paths answer. `preflight` is mounted over the route table,
+   * which a claimed path is not in, so an `OPTIONS` would reach the 404.
+   */
+  claimedMethods(): readonly string[];
 }
 
 export const hasClaimedPaths = (value: object): value is ClaimsPaths =>

--- a/packages/http/src/server/routes.ts
+++ b/packages/http/src/server/routes.ts
@@ -222,7 +222,23 @@ export const buildFallback = (
     throw new HttpError(HttpStatusCode.NOT_FOUND, 'NOT_FOUND');
   };
 
+  // A claimed path is served here rather than from the route table, so its
+  // preflight is built here too. `buildRoutes` does the same for a real route.
+  const claimedPreflight = new Map<string, RouteHandler>();
+  if (cors) {
+    for (const entry of middleware) {
+      if (!hasClaimedPaths(entry)) continue;
+      const answer = preflight(cors, entry.claimedMethods());
+      for (const path of entry.claimedPaths())
+        claimedPreflight.set(path, answer);
+    }
+  }
+
   const run: ServedHandler = async (req, server) => {
+    if (req.method === 'OPTIONS') {
+      const answer = claimedPreflight.get(new URL(req.url).pathname);
+      if (answer !== undefined) return answer(req);
+    }
     try {
       return await compose(
         middleware,

--- a/packages/http/src/throttle/guard.ts
+++ b/packages/http/src/throttle/guard.ts
@@ -86,6 +86,9 @@ export class ThrottleGuard implements Middleware {
   /**
    * Per **handler**, not per path: two verbs on one path get their own budgets,
    * and a parameterised path does not fragment into a key per id.
+   *
+   * A claimed path reports `(unmatched)`/`(none)` for every one of them, so it
+   * keys on the path: otherwise every RPC on a mount shares one budget.
    */
   #key(req: BunRequest, ctx: RouteContext): string {
     const subject =
@@ -93,7 +96,11 @@ export class ThrottleGuard implements Middleware {
         req,
         ctx,
       ) ?? 'anonymous';
-    return `${this.options.prefix}:throttle:${ctx.controller}:${ctx.handler}:${subject}`;
+    const scope =
+      ctx.get(UNMATCHED) === true
+        ? ctx.path
+        : `${ctx.controller}:${ctx.handler}`;
+    return `${this.options.prefix}:throttle:${scope}:${subject}`;
   }
 
   async #hit(key: string, windowSeconds: number): Promise<number | undefined> {

--- a/packages/http/src/throttle/throttle.test.ts
+++ b/packages/http/src/throttle/throttle.test.ts
@@ -372,6 +372,35 @@ describe('ThrottleGuard, against a counter that is down', () => {
     await expect(call()).rejects.toThrow(/Rate limit exceeded/);
   });
 
+  it('gives each claimed path its own budget, not one for the mount', async () => {
+    const claimed = new ClaimedRoutes();
+    claimed.attach(['/svc/A', '/svc/B']);
+    const guard = new ThrottleGuard(
+      new ThrottleOptions({
+        limit: 1,
+        windowSeconds: 60,
+        prefix: 'app',
+        subject: () => 'unit',
+      }),
+      new MemoryThrottleStore(),
+      new ClientAddress(),
+      new Counting(),
+      claimed,
+    );
+    const call = (path: string) =>
+      guard.handle(
+        new Request(`http://x${path}`) as never,
+        { ...contextOf({ unmatched: true }), path } as never,
+        () => Promise.resolve(new Response('rpc')),
+      );
+
+    expect((await call('/svc/A')).status).toBe(200);
+    // A second method on the same mount, which shared A's budget when the key
+    // was built from the handler name every unmatched path reports.
+    expect((await call('/svc/B')).status).toBe(200);
+    await expect(call('/svc/A')).rejects.toThrow(/Rate limit exceeded/);
+  });
+
   it('skips an unmatched path before it ever reaches the store', async () => {
     const logger = new Counting();
     const guard = new ThrottleGuard(

--- a/packages/openapi/src/swagger/options.test.ts
+++ b/packages/openapi/src/swagger/options.test.ts
@@ -23,6 +23,19 @@ const page = (ui?: SwaggerUiOptions): string =>
   );
 
 describe('renderUiOptions', () => {
+  it('escapes a value that would close the inline script block', () => {
+    const rendered = renderUiOptions(
+      { configUrl: '</script><script>alert(1)</script>' },
+      'swagger-ui',
+    );
+
+    // This lands inside an inline `<script>`, so a raw `</script>` in a value
+    // ends the block and everything after it is markup. The Scalar renderer
+    // embeds its options through the same escape.
+    expect(rendered).not.toContain('</script>');
+    expect(rendered).toContain('\\u003c/script');
+  });
+
   it('always names the mount point, and never from the caller', () => {
     expect(renderUiOptions({}, 'swagger-ui')).toContain('dom_id:"#swagger-ui"');
   });

--- a/packages/openapi/src/swagger/options.ts
+++ b/packages/openapi/src/swagger/options.ts
@@ -1,3 +1,4 @@
+import { embedJson } from '@dunx/http/internal';
 import { SHELL_KEYS } from '../shell.js';
 
 /**
@@ -194,7 +195,9 @@ export const renderUiOptions = (
       parts.push(`${JSON.stringify(key)}:${value}`);
       continue;
     }
-    parts.push(`${JSON.stringify(key)}:${JSON.stringify(value)}`);
+    // `embedJson`, not `JSON.stringify`: this lands in an inline `<script>`,
+    // which a value carrying `</script>` would close. Scalar embeds the same way.
+    parts.push(`${embedJson(key)}:${embedJson(value)}`);
   }
 
   // `presets` is the one default that has to be source: it names a property of the


### PR DESCRIPTION
Three defects from a post-release audit of everything merged in the last two days. Two are consequences of `696779e`, which brought RPC under `ThrottleGuard`.

- **A browser cannot call an RPC.** `preflight` is mounted over the route table; a claimed path is not in it, so `OPTIONS` fell through to the 404 with no allow-methods. `buildFallback` builds one per claimed path now.
- **Every RPC on a mount shared one rate-limit budget**, because the throttle key is built from the controller and handler names and an unmatched path reports `(unmatched)`/`(none)` for both.
- **`renderUiOptions` did not escape** Swagger UI option values going into an inline `<script>`. The Scalar renderer already used `embedJson`.

Each has a test, each verified against the old code. `bun run ci` 13/13.