### PR TITLE
fix(http): three server-sent-events frames the spec dispatches and dunx did not

### DIFF
--- a/packages/http/src/client/sse.test.ts
+++ b/packages/http/src/client/sse.test.ts
@@ -50,6 +50,28 @@ const messages = async (
 };
 
 describe('sseMessages', () => {
+  it('joins a CRLF split across two chunks into one event', async () => {
+    const messages = [];
+    for await (const m of sseMessages(
+      streamOf('data: a\r', '\ndata: b\r\n\r\n'),
+    )) {
+      messages.push(m);
+    }
+
+    // A trailing `\r` is half of a `\r\n` until the next byte says otherwise;
+    // taking it as a line ending split this into two events.
+    expect(messages).toEqual([{ data: 'a\nb' }]);
+  });
+
+  it('dispatches a data field carrying an empty value', async () => {
+    const messages = [];
+    for await (const m of sseMessages(streamOf('data:\n\n'))) messages.push(m);
+
+    // Only a frame with no `data:` field at all is skipped, which is what a
+    // comment heartbeat relies on.
+    expect(messages).toEqual([{ data: '' }]);
+  });
+
   it('carries the envelope, not just the payload', async () => {
     expect(
       await messages(

--- a/packages/http/src/client/sse.ts
+++ b/packages/http/src/client/sse.ts
@@ -25,9 +25,10 @@ const split = (line: string): readonly [string, string] => {
  * Every event of a server-sent-events body, in order, ending with the stream or
  * with `[DONE]`. One still being read when the body ends is dropped, per spec.
  *
- * Async iteration rather than `getReader()`, which releases the reader on
- * completion, on a consumer `break` and on the `[DONE]` return. Hand-rolled:
- * Bun exposes no `EventSource` global and no SSE parser, measured not assumed.
+ * `getReader()` rather than async iteration, so the last read is told apart from
+ * a chunk boundary: a trailing `\r` is half a `\r\n` in one and a line ending in
+ * the other. `releaseLock` in a `finally` covers a `break` and `[DONE]`.
+ * Hand-rolled: Bun exposes no `EventSource` and no SSE parser, measured.
  */
 export async function* sseMessages(
   body: ReadableStream<Uint8Array>,
@@ -39,45 +40,66 @@ export async function* sseMessages(
   let id: string | undefined;
   let retry: number | undefined;
 
-  for await (const chunk of body) {
-    buffer += decoder.decode(chunk, { stream: true });
+  const reader = body.getReader();
+  let done = false;
 
-    let end = LINE.exec(buffer);
-    while (end !== null) {
-      const line = buffer.slice(0, end.index);
-      buffer = buffer.slice(end.index + end[0].length);
-      end = LINE.exec(buffer);
+  try {
+    for (;;) {
+      let end = LINE.exec(buffer);
+      while (end !== null) {
+        // A trailing `\r` may be half of a `\r\n` in the next chunk, and taking
+        // it as a line ending splits one event in two. Once the body has ended
+        // nothing more is coming, so it is one.
+        if (!done && end[0] === '\r' && end.index + 1 === buffer.length) break;
+        const line = buffer.slice(0, end.index);
+        buffer = buffer.slice(end.index + end[0].length);
+        end = LINE.exec(buffer);
 
-      // The blank line dispatches. An event with no data is not one: the spec
-      // resets the buffers and moves on, which is what a heartbeat relies on.
-      if (line === '') {
-        const payload = data.join('\n');
-        data = [];
-        if (payload === '') {
+        // The blank line dispatches.
+        if (line === '') {
+          const seen = data.length > 0;
+          const payload = data.join('\n');
+          data = [];
+          // No `data:` field at all does not dispatch, which a heartbeat relies
+          // on. One carrying an empty value does.
+          if (!seen) {
+            event = undefined;
+            continue;
+          }
+          if (payload === '[DONE]') return;
+          yield {
+            data: payload,
+            ...(event === undefined ? {} : { event }),
+            ...(id === undefined ? {} : { id }),
+            ...(retry === undefined ? {} : { retry }),
+          };
           event = undefined;
           continue;
         }
-        if (payload === '[DONE]') return;
-        yield {
-          data: payload,
-          ...(event === undefined ? {} : { event }),
-          ...(id === undefined ? {} : { id }),
-          ...(retry === undefined ? {} : { retry }),
-        };
-        event = undefined;
-        continue;
+
+        // A comment, which is what a heartbeat is.
+        if (line.startsWith(':')) continue;
+
+        const [field, value] = split(line);
+        if (field === 'data') data.push(value);
+        else if (field === 'event') event = value;
+        // The spec ignores an id containing NUL, and a non-integer retry.
+        else if (field === 'id' && !value.includes('\0')) id = value;
+        else if (field === 'retry' && /^\d+$/.test(value))
+          retry = Number(value);
       }
 
-      // A comment, which is what a heartbeat is.
-      if (line.startsWith(':')) continue;
-
-      const [field, value] = split(line);
-      if (field === 'data') data.push(value);
-      else if (field === 'event') event = value;
-      // The spec ignores an id containing NUL, and a non-integer retry.
-      else if (field === 'id' && !value.includes('\0')) id = value;
-      else if (field === 'retry' && /^\d+$/.test(value)) retry = Number(value);
+      if (done) return;
+      const next = await reader.read();
+      if (next.done) {
+        buffer += decoder.decode();
+        done = true;
+        continue;
+      }
+      buffer += decoder.decode(next.value, { stream: true });
     }
+  } finally {
+    reader.releaseLock();
   }
 }
 

--- a/packages/http/src/sse/event.ts
+++ b/packages/http/src/sse/event.ts
@@ -1,6 +1,7 @@
 /**
  * One server-sent event. Every field is optional: `retry` alone changes the
- * reconnection delay, `event` alone fires a named event with no payload.
+ * reconnection delay, and `event` or `id` alone carries an empty `data:` so it
+ * dispatches, which a frame with no data field at all does not.
  */
 export interface SseEvent {
   /** A string as it is, anything else through `JSON.stringify`. Each line of it
@@ -32,6 +33,11 @@ export const frameEvent = (event: SseEvent): string => {
     const data =
       typeof event.data === 'string' ? event.data : JSON.stringify(event.data);
     for (const line of lines(data ?? '')) fields.push(`data: ${line}`);
+  } else if (event.event !== undefined || event.id !== undefined) {
+    // No `data` field does not dispatch: the spec leaves the buffer empty and
+    // returns, so a named event would be silence. A `retry`-only frame carries
+    // none, being a setting rather than an event.
+    fields.push('data: ');
   }
   return `${fields.join('\n')}\n\n`;
 };

--- a/packages/http/src/sse/sse.test.ts
+++ b/packages/http/src/sse/sse.test.ts
@@ -14,6 +14,19 @@ const events = async function* (
   for (let i = 0; i < count; i += 1) yield { data: `event-${i}` };
 };
 
+describe('a frame with no data', () => {
+  it('carries an empty data line so a named event dispatches', () => {
+    // Without it the spec leaves the data buffer empty and returns, so an
+    // `event`-only frame is silence on the wire.
+    expect(frameEvent({ event: 'ready' })).toBe('event: ready\ndata: \n\n');
+    expect(frameEvent({ id: '7' })).toBe('id: 7\ndata: \n\n');
+  });
+
+  it('leaves a retry-only frame undispatched, which is what retry is', () => {
+    expect(frameEvent({ retry: 5000 })).toBe('retry: 5000\n\n');
+  });
+});
+
 describe('frameEvent', () => {
   it('frames a string payload and terminates it with a blank line', () => {
     expect(frameEvent({ data: 'hello' })).toBe('data: hello\n\n');


### PR DESCRIPTION
Triaged out of the post-release review. Each was probed against the parser and framer before and after.

- **A `\r\n` split across a chunk boundary read as two events.** `data: a\r` + `\ndata: b\r\n\r\n` yielded two where the bytes are one carrying `a\nb`. The parser holds a trailing `\r` back now, which means telling the last read from a chunk boundary: it takes a reader rather than iterating.
- **`data:` with an empty value dispatched nothing.** The spec skips a frame whose data buffer was never written, which is what a comment heartbeat relies on, not one written with an empty string.
- **`frameEvent({ event: 'ready' })` was silence on the wire**, while the doc above it promised a named event with no payload. dunx's own parser read it back as `[]`, which is how it surfaced.

`bun run ci` 13/13.