### PR TITLE
fix(infra): stop a tiered promote putting a deleted value back

### DIFF
--- a/examples/full/bunfig.toml
+++ b/examples/full/bunfig.toml
@@ -1,7 +1,7 @@
 # The compiler plugin records each class's constructor parameter types so the
 # container can resolve them. Without this preload, constructor injection is
 # invisible to the runtime and providers are built with no arguments.
-preload = ["@dunx/transform/preload"]
+preload = ["@dunx/transform/preload", "./src/cache-prefix.preload.ts"]
 
 [test]
-preload = ["@dunx/transform/preload"]
+preload = ["@dunx/transform/preload", "./src/cache-prefix.preload.ts"]

--- a/examples/full/src/cache-prefix.preload.ts
+++ b/examples/full/src/cache-prefix.preload.ts
@@ -1,0 +1,4 @@
+// One L2 namespace per process, so two suites against the one valkey this repo
+// runs do not read each other's entries. `cache.module.ts` reads the variable;
+// an app that sets none gets a stable prefix, which is what a shared L2 needs.
+process.env['DUNX_CACHE_PREFIX'] ??= `dunx-full:${process.pid}`;

--- a/examples/full/src/cache/cache.module.ts
+++ b/examples/full/src/cache/cache.module.ts
@@ -86,7 +86,11 @@ const appRedis = RedisModule.forRootAsync(
         const l1 = new MemoryCacheStore({ max: 500 });
         const shared = {
           ttl: 30_000,
-          prefix: `dunx-full:${process.pid}:cache`,
+          // One prefix per deployment, not per process: a shared L2 that no
+          // replica or restart can read is not shared. The example's own suites
+          // set DUNX_CACHE_PREFIX so concurrent runs do not collide on one
+          // valkey; an app that sets nothing gets a stable prefix.
+          prefix: `${process.env['DUNX_CACHE_PREFIX'] ?? 'app'}:cache`,
         };
         try {
           await redis.ping();

--- a/examples/full/src/tour.test.ts
+++ b/examples/full/src/tour.test.ts
@@ -5,13 +5,10 @@ const APP_DIR = new URL('..', import.meta.url).pathname;
 
 /**
  * The tour is the end-to-end check: it boots the same app `bun start` serves,
- * narrates every package and exits 0. Assertions read the structured entries
- * rather than raw stdout - `NODE_ENV=production` selects the plain JSON
- * formatter, so there is no ANSI to strip and a message containing a comma is
- * not broken up by the colouriser.
- *
- * Both streams are collected: `ConsoleTransport` sends warn and above to stderr
- * so a log shipper can separate them, and the degraded-cache line is a warning.
+ * narrates every package and exits 0. Assertions read the structured entries,
+ * `NODE_ENV=production` selecting the plain JSON formatter so there is no ANSI
+ * to strip. Both streams are collected: `ConsoleTransport` sends warn and above
+ * to stderr, and the degraded-cache line is a warning.
  */
 const runTour = async (env: Record<string, string> = {}) => {
   const proc = Bun.spawn(['bun', 'src/tour.ts'], {

--- a/packages/infra/src/cache/tiered.test.ts
+++ b/packages/infra/src/cache/tiered.test.ts
@@ -129,6 +129,33 @@ describe('a write landing during a promote', () => {
     expect(await l1.get('k')).toBeUndefined();
   });
 
+  it('protects every concurrent read, not just the first to finish', async () => {
+    let nth = 0;
+    class Staggered extends MemoryCacheStore {
+      override async get<V>(key: string): Promise<V | undefined> {
+        const value = await super.get<V>(key);
+        await Bun.sleep(++nth === 1 ? 10 : 40);
+        return value;
+      }
+    }
+    const l1 = new MemoryCacheStore();
+    const tiered = new TieredCacheStore(l1, new Staggered(), {
+      promoteTtl: 60_000,
+    });
+    await tiered.set('k', 'old', 60_000);
+    await l1.del('k');
+
+    const first = tiered.get('k');
+    const second = tiered.get('k');
+    await Bun.sleep(2);
+    await tiered.del('k');
+    await Promise.all([first, second]);
+
+    // Marking the key rather than counting the readers let whichever finished
+    // first clear it, and the one behind wrote the deleted value back.
+    expect(await l1.get('k')).toBeUndefined();
+  });
+
   it('does not overwrite a value written while it was reading', async () => {
     const { tiered } = await racing((t) => t.set('k', 'new', 60_000));
 

--- a/packages/infra/src/cache/tiered.test.ts
+++ b/packages/infra/src/cache/tiered.test.ts
@@ -92,3 +92,46 @@ describe('TieredCacheStore', () => {
     expect(await store.del('k')).toBe(true);
   });
 });
+
+/** An L2 whose read is slow enough for a write to land while it is in flight. */
+class SlowL2 extends MemoryCacheStore {
+  override async get<V>(key: string): Promise<V | undefined> {
+    const value = await super.get<V>(key);
+    await Bun.sleep(20);
+    return value;
+  }
+}
+
+describe('a write landing during a promote', () => {
+  const racing = async (
+    invalidate: (t: TieredCacheStore) => Promise<unknown>,
+  ) => {
+    const l1 = new MemoryCacheStore();
+    const tiered = new TieredCacheStore(l1, new SlowL2(), {
+      promoteTtl: 60_000,
+    });
+    await tiered.set('k', 'old', 60_000);
+    await l1.del('k'); // the next read has to go to L2
+
+    const reading = tiered.get('k');
+    await Bun.sleep(5);
+    await invalidate(tiered);
+    await reading;
+    return { l1, tiered };
+  };
+
+  it('does not put a deleted value back into L1', async () => {
+    const { l1, tiered } = await racing((t) => t.del('k'));
+
+    // The promote wrote `old` back for the whole promoteTtl, so a delete was
+    // undone for thirty seconds by default.
+    expect(await tiered.get('k')).toBeUndefined();
+    expect(await l1.get('k')).toBeUndefined();
+  });
+
+  it('does not overwrite a value written while it was reading', async () => {
+    const { tiered } = await racing((t) => t.set('k', 'new', 60_000));
+
+    expect(await tiered.get<string>('k')).toBe('new');
+  });
+});

--- a/packages/infra/src/cache/tiered.ts
+++ b/packages/infra/src/cache/tiered.ts
@@ -24,6 +24,9 @@ export interface TieredCacheInit {
  */
 export class TieredCacheStore extends CacheStore {
   readonly #promoteTtl: number;
+  /** Keys with an L2 read in flight, and those invalidated while one was. */
+  readonly #promoting = new Set<string>();
+  readonly #superseded = new Set<string>();
 
   constructor(
     private readonly l1: CacheStore,
@@ -47,18 +50,36 @@ export class TieredCacheStore extends CacheStore {
   async get<V = unknown>(key: string): Promise<V | undefined> {
     const near = await this.l1.get<V>(key);
     if (near !== undefined) return near;
-    const far = await this.l2.get<V>(key);
-    if (far === undefined) return undefined;
-    await this.l1.set(key, far, this.#promoteTtl);
-    return far;
+
+    this.#promoting.add(key);
+    try {
+      const far = await this.l2.get<V>(key);
+      if (far === undefined) return undefined;
+      // A `del` or `set` landing while the L2 read was in flight has already
+      // run. Promoting now would put the old value back into L1 and answer
+      // from it until `promoteTtl` expired, so the write is dropped instead.
+      if (this.#superseded.has(key)) return undefined;
+      await this.l1.set(key, far, this.#promoteTtl);
+      return far;
+    } finally {
+      this.#promoting.delete(key);
+      this.#superseded.delete(key);
+    }
+  }
+
+  /** Bounded by the reads in flight, so it holds nothing between `get` calls. */
+  #supersede(key: string): void {
+    if (this.#promoting.has(key)) this.#superseded.add(key);
   }
 
   async set<V>(key: string, value: V, ttl: number): Promise<void> {
+    this.#supersede(key);
     await this.l2.set(key, value, ttl);
     await this.l1.set(key, value, Math.min(ttl, this.#promoteTtl));
   }
 
   async del(key: string): Promise<boolean> {
+    this.#supersede(key);
     const [near, far] = await Promise.all([this.l1.del(key), this.l2.del(key)]);
     return near || far;
   }

--- a/packages/infra/src/cache/tiered.ts
+++ b/packages/infra/src/cache/tiered.ts
@@ -24,8 +24,8 @@ export interface TieredCacheInit {
  */
 export class TieredCacheStore extends CacheStore {
   readonly #promoteTtl: number;
-  /** Keys with an L2 read in flight, and those invalidated while one was. */
-  readonly #promoting = new Set<string>();
+  /** How many L2 reads are in flight per key, and which were invalidated. */
+  readonly #promoting = new Map<string, number>();
   readonly #superseded = new Set<string>();
 
   constructor(
@@ -51,7 +51,7 @@ export class TieredCacheStore extends CacheStore {
     const near = await this.l1.get<V>(key);
     if (near !== undefined) return near;
 
-    this.#promoting.add(key);
+    this.#promoting.set(key, (this.#promoting.get(key) ?? 0) + 1);
     try {
       const far = await this.l2.get<V>(key);
       if (far === undefined) return undefined;
@@ -62,8 +62,15 @@ export class TieredCacheStore extends CacheStore {
       await this.l1.set(key, far, this.#promoteTtl);
       return far;
     } finally {
-      this.#promoting.delete(key);
-      this.#superseded.delete(key);
+      // Counted, not a flag: the first of several concurrent reads to finish
+      // would otherwise clear the mark and let the ones behind it write the
+      // value a `del` had already removed.
+      const left = (this.#promoting.get(key) ?? 1) - 1;
+      if (left > 0) this.#promoting.set(key, left);
+      else {
+        this.#promoting.delete(key);
+        this.#superseded.delete(key);
+      }
     }
   }
 

--- a/tools/create-app/templates/features/cache/cache.module.ts
+++ b/tools/create-app/templates/features/cache/cache.module.ts
@@ -86,7 +86,11 @@ const appRedis = RedisModule.forRootAsync(
         const l1 = new MemoryCacheStore({ max: 500 });
         const shared = {
           ttl: 30_000,
-          prefix: `dunx-full:${process.pid}:cache`,
+          // One prefix per deployment, not per process: a shared L2 that no
+          // replica or restart can read is not shared. The example's own suites
+          // set DUNX_CACHE_PREFIX so concurrent runs do not collide on one
+          // valkey; an app that sets nothing gets a stable prefix.
+          prefix: `${process.env['DUNX_CACHE_PREFIX'] ?? 'app'}:cache`,
         };
         try {
           await redis.ping();


### PR DESCRIPTION
`TieredCacheStore.get` reads L1, misses, reads L2, and writes what it found into L1. A `del` or `set` landing between the L2 read and that write had **already run**, so the promote put the old value back and answered from it until `promoteTtl` expired — thirty seconds by default.

Probed before the fix:

```
after del, tiered.get : value
after del, l1 holds   : value
```

Invalidate a session or a permission and it comes back. `Cache` already had this guard for its own loader (`#superseded`); the tiered store did not, and its suite had no concurrency case. Both directions now tested, both verified against the old code.

Separately: the cache feature's L2 prefix carried `process.pid`. Right for this repo's suites, which share one valkey; wrong for the app it is **vendored into** by `create-app`, where a prefix no other process can compute means a replica or restart reads nothing. It reads `DUNX_CACHE_PREFIX` with a stable default now, and `examples/full` sets it from a preload.

`bun run ci` 13/13.