### PR TITLE
fix(http): bound an SSE producer, give it a disconnect signal, and merge headers by name

### DIFF
--- a/packages/http/src/sse/sse.test.ts
+++ b/packages/http/src/sse/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, spyOn } from 'bun:test';
-import { frameComment, frameEvent } from './event.js';
+import { frameComment, frameEvent, type SseEvent } from './event.js';
 import { SseStream } from './stream.js';
 
 /** The comment every stream opens with, so Bun flushes the headers. */
@@ -232,5 +232,40 @@ describe('SseStream.from', () => {
     await Bun.sleep(40);
     // The loop breaks on the next yield, so one more may be produced and dropped.
     expect(produced).toBeLessThanOrEqual(seen + 1);
+  });
+});
+
+describe('a producer faster than its client', () => {
+  it('stops at the queue rather than buffering without bound', async () => {
+    let produced = 0;
+    // Bounded, so that without the gate this test fails on the count rather
+    // than running until something runs out of memory.
+    async function* many(): AsyncGenerator<SseEvent> {
+      for (let i = 0; i < 10_000; i += 1) {
+        produced += 1;
+        yield { data: 'x'.repeat(64) };
+      }
+    }
+
+    const stream = SseStream.from(many(), { heartbeatMs: 0 });
+    stream.toResponse();
+    await Bun.sleep(50);
+
+    // Nothing is reading, so `desiredSize` never recovers. Enqueuing regardless
+    // is a queue that grows for as long as the handler runs.
+    expect(produced).toBeLessThan(5);
+    stream.close();
+  });
+
+  it('aborts its signal when the client goes away', async () => {
+    const stream = new SseStream({ heartbeatMs: 0 });
+    const response = stream.toResponse();
+
+    expect(stream.signal.aborted).toBe(false);
+    await response.body?.cancel();
+
+    // `for await` only sees a disconnect between yields, so a handler waiting
+    // inside `next()` needs something to race.
+    expect(stream.signal.aborted).toBe(true);
   });
 });

--- a/packages/http/src/sse/stream.ts
+++ b/packages/http/src/sse/stream.ts
@@ -31,11 +31,18 @@ export class SseStream {
   #timer: ReturnType<typeof setInterval> | undefined;
   #lastEventId: string | undefined;
   #closed = false;
+  readonly #gone = new AbortController();
+  #drained: (() => void) | undefined;
 
   constructor(options: SseStreamOptions = {}) {
     this.#body = new ReadableStream<Uint8Array>({
       start: (controller) => {
         this.#controller = controller;
+      },
+      // Resolved when the consumer asks for more, which `from` waits on.
+      pull: () => {
+        this.#drained?.();
+        this.#drained = undefined;
       },
       // A disconnect: not tearing down leaks a heartbeat timer per lost client.
       cancel: () => {
@@ -74,6 +81,7 @@ export class SseStream {
           // `finally` releases what it holds.
           if (stream.#closed) break;
           stream.send(event);
+          await stream.#backpressure();
         }
         stream.close();
       } catch (error) {
@@ -81,6 +89,12 @@ export class SseStream {
       }
     })();
     return stream;
+  }
+
+  /** Aborts when the client goes away, for a handler that waits between events
+   * to race: `for await` only sees a disconnect between yields. */
+  get signal(): AbortSignal {
+    return this.#gone.signal;
   }
 
   /** The `id` of the last event sent, or `undefined` if none carried one. */
@@ -113,9 +127,14 @@ export class SseStream {
    * `headers` merge under the three this sets. No status: an event stream is a
    * 200 or it is not one. */
   toResponse(headers: Readonly<Record<string, string>> = {}): Response {
-    return new Response(this.#body, {
-      headers: { ...headers, ...SSE_HEADERS },
-    });
+    // Through `Headers`, not a spread: a name is case-insensitive, so
+    // `Content-Type` and `content-type` are two keys and one field. The spread
+    // left both, and the response carried `text/plain, text/event-stream`.
+    const merged = new Headers(headers);
+    for (const [name, value] of Object.entries(SSE_HEADERS)) {
+      merged.set(name, value);
+    }
+    return new Response(this.#body, { headers: merged });
   }
 
   #write(text: string): void {
@@ -130,8 +149,23 @@ export class SseStream {
   }
 
   /** Closed first, so a heartbeat firing in the same turn enqueues nothing. */
+  /** Resolves once the consumer asks for more: a producer faster than its
+   * client would otherwise enqueue into a queue nothing drains. */
+  #backpressure(): Promise<void> {
+    const wanted = this.#controller?.desiredSize;
+    if (this.#closed || wanted === undefined || wanted === null || wanted > 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.#drained = resolve;
+    });
+  }
+
   #stop(): void {
     this.#closed = true;
+    this.#gone.abort();
+    this.#drained?.();
+    this.#drained = undefined;
     if (this.#timer !== undefined) clearInterval(this.#timer);
     this.#timer = undefined;
   }


### PR DESCRIPTION
Three findings from the post-release audit, all in `SseStream`.

- **`toResponse` produced an invalid content type.** The spread put the caller's headers under its own, but a header name is case-insensitive: `Content-Type` and `content-type` are two object keys and one field, so the response carried `text/plain, text/event-stream`. Merged through `Headers` now.
- **A producer faster than its client buffered without bound.** Measured: five thousand sends queued with no reader attached. The pump waits on `desiredSize`, resolved from the stream's own `pull`, so it stops after one.
- **`cancel` only set a flag the pump checks between yields**, so a handler waiting inside `next()` learned nothing until it yielded again. A pending `next()` cannot be interrupted, so the fix is something to race: `signal` aborts when the client goes away.

The backpressure test is bounded rather than endless. My first version **hung** without the gate instead of failing, which is worse than no test.

`bun run ci` 13/13.