### PR TITLE
fix: close the tail of the post-release audit

### DIFF
--- a/examples/full/src/jobs/jobs.demo.ts
+++ b/examples/full/src/jobs/jobs.demo.ts
@@ -64,7 +64,17 @@ export class JobsDemo {
 
     // Foreground, so this handler runs here: the stats section reads both.
     const audit = await this.publisher.publish(AUDIT_QUEUE, 'record', result);
-    await audit.waitUntilFinished(this.events.events(AUDIT_QUEUE), SETTLE_MS);
+    // Wrapped for the reason the render above is: the ttl rejects, and a slow
+    // audit took the whole tour down rather than narrating that it was slow.
+    try {
+      await audit.waitUntilFinished(this.events.events(AUDIT_QUEUE), SETTLE_MS);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.info(
+        `audit ${audit.id ?? '(unassigned)'} did not finish: ${reason}`,
+      );
+      return;
+    }
     this.logger.info(
       `audit ${audit.id ?? '(unassigned)'} ran in this process, so its handler ` +
         'duration is one this container can report',

--- a/examples/full/src/landing/public/landing.js
+++ b/examples/full/src/landing/public/landing.js
@@ -434,6 +434,9 @@ $('explorers-go').addEventListener('click', async (event) => {
       `both render ${Object.keys(spec.paths).length} paths from one document`,
     );
     out.textContent = lines.join('\n');
+  } catch (error) {
+    // Without this the pane reads "fetching..." for as long as the tab is open.
+    out.textContent = `could not read the explorers: ${String(error)}`;
   } finally {
     button.disabled = false;
   }

--- a/examples/full/src/sse/events.controller.ts
+++ b/examples/full/src/sse/events.controller.ts
@@ -29,7 +29,10 @@ export class EventsController {
    */
   @Sse('/ticks', ticks)
   async *ticks(input: SseInput<typeof ticks>): AsyncGenerator<SseEvent> {
-    const from = Number(input.lastEventId ?? '0');
+    // Nothing guarantees the id a client sends back is one of ours, and
+    // `Number('abc')` is NaN, which answers a reconnect with no events.
+    const seen = Number(input.lastEventId ?? '0');
+    const from = Number.isFinite(seen) && seen >= 0 ? seen : 0;
     for (let tick = from + 1; tick <= from + input.query.count; tick += 1) {
       yield { data: { tick }, event: 'tick', id: String(tick) };
       await Bun.sleep(5);

--- a/packages/http/src/connect/middleware.ts
+++ b/packages/http/src/connect/middleware.ts
@@ -37,9 +37,8 @@ const grpcUnsupported = (): Response =>
  * first is what leaves a matched route paying nothing. Anything outside the
  * registered paths falls through untouched.
  *
- * `ThrottleGuard` covers an RPC. Its early return is for an unmatched path
- * nobody claims, so a burst of 404s cannot spend a caller's budget; a claimed
- * path is served and is limited like a route. See docs/guide/27-rpc.md.
+ * `ThrottleGuard` covers an RPC: its early return is for an unmatched path
+ * nobody claims, and a claimed path is served. See docs/guide/27-rpc.md.
  */
 export class ConnectMiddleware implements Middleware, ClaimsPaths {
   readonly #registry: ConnectRegistry;

--- a/packages/http/src/connect/options.ts
+++ b/packages/http/src/connect/options.ts
@@ -1,6 +1,6 @@
 import type { DescService } from '@bufbuild/protobuf';
 import type { ConnectRouterOptions, ServiceImpl } from '@connectrpc/connect';
-import type { Ctor, ModuleRef } from '@dunx/core';
+import { AppError, type Ctor, type ModuleRef } from '@dunx/core';
 import { normalizePrefix } from '../route/prefix.js';
 
 /**
@@ -92,21 +92,21 @@ export class ConnectOptions {
     this.grpcWeb = grpcWeb ?? true;
     this.streamTimeout = streamTimeout ?? 0;
     if (!Number.isFinite(this.streamTimeout) || this.streamTimeout < 0) {
-      throw new Error(
+      throw new AppError(
         `ConnectModule streamTimeout must be a non-negative number of seconds, got ${String(streamTimeout)}.`,
       );
     }
     this.router = router;
 
     if (!this.connect && !this.grpcWeb) {
-      throw new Error(
+      throw new AppError(
         'ConnectModule needs at least one protocol, and both connect and ' +
           'grpcWeb are false. Native gRPC is not a third option here: it ' +
           'carries grpc-status in an HTTP trailer and Bun.serve sends none.',
       );
     }
     if (services.length === 0) {
-      throw new Error(
+      throw new AppError(
         'ConnectModule.forRoot was given no services. Pass at least one ' +
           'connectService(Desc, Impl), or drop the module.',
       );

--- a/packages/http/src/connect/registry.ts
+++ b/packages/http/src/connect/registry.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@dunx/core';
 import {
   createConnectRouter,
   type ConnectRouter,
@@ -65,7 +66,7 @@ export class ConnectRegistry {
     options.services.forEach((registration, index) => {
       const implementation = implementations[index];
       if (implementation === undefined) {
-        throw new Error(
+        throw new AppError(
           `No instance was resolved for ${registration.useClass.name}, which ` +
             `serves ${registration.service.typeName}.`,
         );

--- a/packages/infra/src/cache/cache.test.ts
+++ b/packages/infra/src/cache/cache.test.ts
@@ -144,7 +144,18 @@ describe('Cache', () => {
 
   it('stores again once the superseded load has finished', async () => {
     const cache = cacheWith();
+    // The mark has to be set for this to test anything: a `del` with nothing in
+    // flight records none, and the old version passed without the cleanup.
+    const loading = cache.wrap('k', async () => {
+      await Bun.sleep(30);
+      return 'stale';
+    });
+    await Bun.sleep(5);
     await cache.del('k');
+    await loading;
+    expect(await cache.get('k')).toBeUndefined();
+
+    // The next load is not superseded, so it stores.
     expect(await cache.wrap('k', () => 'after')).toBe('after');
     expect(await cache.get<string>('k')).toBe('after');
   });

--- a/packages/infra/src/queue/processor.ts
+++ b/packages/infra/src/queue/processor.ts
@@ -116,6 +116,7 @@ export class JobProcessor {
       app,
       this.#options.queues,
     );
+    // No metrics: a counter this forked child keeps, nothing reads.
     const dispatcher = new JobDispatcher(
       jobs,
       app.get(QueueOptions).jobTimeoutMs,

--- a/tools/create-app/templates/features/jobs/jobs.demo.ts
+++ b/tools/create-app/templates/features/jobs/jobs.demo.ts
@@ -64,7 +64,17 @@ export class JobsDemo {
 
     // Foreground, so this handler runs here: the stats section reads both.
     const audit = await this.publisher.publish(AUDIT_QUEUE, 'record', result);
-    await audit.waitUntilFinished(this.events.events(AUDIT_QUEUE), SETTLE_MS);
+    // Wrapped for the reason the render above is: the ttl rejects, and a slow
+    // audit took the whole tour down rather than narrating that it was slow.
+    try {
+      await audit.waitUntilFinished(this.events.events(AUDIT_QUEUE), SETTLE_MS);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.info(
+        `audit ${audit.id ?? '(unassigned)'} did not finish: ${reason}`,
+      );
+      return;
+    }
     this.logger.info(
       `audit ${audit.id ?? '(unassigned)'} ran in this process, so its handler ` +
         'duration is one this container can report',


### PR DESCRIPTION
The last six findings. Nothing here is large; one is worth calling out.

**A test that passed with the code it covered deleted.** `cache.test.ts`'s "stores again once the superseded load has finished" built a fresh cache and deleted a key with nothing in flight, so `#supersede` recorded nothing and the set was empty either way. Removing the cleanup it names left it green. It supersedes a real in-flight load now, and fails without that cleanup.

The rest:

- The explorers panel had `try`/`finally` and no `catch`, so a failed fetch left the pane reading "fetching..." indefinitely. Its siblings all catch.
- `jobs.demo.ts` awaited the audit job bare where the render above it is wrapped, so a slow audit took the whole tour down.
- The SSE example read `Last-Event-ID` straight through `Number`; a client returning a foreign id got `NaN`, every comparison false, and an empty stream instead of starting over.
- Connect's boot validation threw plain `Error` where the package throws `AppError`.
- `processor.ts` omits metrics deliberately (a forked child's counters reach nobody) and now says so rather than reading as an oversight.

`bun run ci` 13/13.