### PR TITLE
ci: bring back the Claude review, on request only

### DIFF
--- a/.github/workflows/dunxonu-deep-review.yml
+++ b/.github/workflows/dunxonu-deep-review.yml
@@ -50,16 +50,46 @@ jobs:
       id-token: write
       actions: read
     steps:
-      # Tell whoever asked that it started. A deep review takes minutes, and the
-      # alternative is a person typing the trigger twice because nothing
-      # happened.
-      - name: Acknowledge
+      # Resolved before the checkout, not after it.
+      #
+      # `actions/checkout` with `refs/pull/N/head` resolves that ref at the
+      # instant it runs, and asking the API for the head afterwards can return a
+      # commit pushed in between. The workspace would then hold one tree while
+      # the review was posted against another, and post-review.ts would not
+      # catch it: its freshness check compares the head to the sha it was given,
+      # and the newer sha is what it was given. So the sha is pinned first and
+      # the checkout is told exactly which commit to take.
+      - name: Resolve the head commit
+        id: head
         env:
           GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+          sha=$(gh api "repos/${{ github.repository }}/pulls/$NUMBER" --jq .head.sha)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "reviewing $sha"
+
+      # Tell whoever asked that it started, on the comment they typed it in.
+      #
+      # A deep review takes minutes and the alternative is somebody typing the
+      # trigger again because nothing happened, which is also why the reaction
+      # goes on their comment rather than on the pull request: a reaction on the
+      # top post is not where they are looking. The two comment kinds live under
+      # different paths, and only the event name says which one this is.
+      - name: Acknowledge
+        env:
+          GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          if [ "${{ github.event_name }}" = 'pull_request_review_comment' ]; then
+            path="pulls/comments/$COMMENT_ID"
+          else
+            path="issues/comments/$COMMENT_ID"
+          fi
           gh api --method POST \
-            "repos/${{ github.repository }}/issues/$NUMBER/reactions" \
+            "repos/${{ github.repository }}/$path/reactions" \
             -f content=eyes >/dev/null || true
 
       # Full history, not depth 1. Three of the tools below are `git log`,
@@ -77,17 +107,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: refs/pull/${{ github.event.issue.number || github.event.pull_request.number }}/head
-
-      - name: Resolve the head commit
-        id: head
-        env:
-          GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
-          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-        run: |
-          sha=$(gh api "repos/${{ github.repository }}/pulls/$NUMBER" --jq .head.sha)
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          ref: ${{ steps.head.outputs.sha }}
 
       # Pinned to a commit. A tag is mutable and this step is handed two secrets,
       # so retargeting `v1` would run unreviewed code with them.

--- a/.github/workflows/dunxonu-deep-review.yml
+++ b/.github/workflows/dunxonu-deep-review.yml
@@ -1,0 +1,156 @@
+name: dunxonu deep review
+
+# The second reviewer, and the one you have to ask for.
+#
+# `fast-code-review` reviews every push on free tiers: seconds, no subscription,
+# and good enough that it has caught real bugs on this repository. This one runs
+# Claude over a checkout with git and gh in its hands, at `/code-review high`,
+# and costs a subscription call every time. So it runs when somebody types
+# `@dunxonudeepreview` and never otherwise.
+#
+# The trigger is deliberately not `@dunxonu`: that is the automatic reviewer's
+# own mention phrase, and it answers questions. `fast-code-review` requires a
+# non-word character after its phrase, so `@dunxonudeepreview` does not wake it,
+# and the two cannot both fire on one comment. Verified in both directions
+# before this file was written.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# By comment rather than by pull request: two people asking for a deep review of
+# different things should get two, and a second request is never a supersede of
+# the first the way a second push is.
+concurrency:
+  group: dunxonu-deep-review-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  review:
+    name: Deep review on request
+    runs-on: ubuntu-latest
+    # Three conditions, and all three matter. The phrase is the point of the
+    # workflow. `issue.pull_request` turns away the same comment on an actual
+    # issue, where there is no diff to review and the API call would 404. And
+    # the sender check keeps dunxonu from triggering itself, since it posts with
+    # a real user's token and its own comments raise this event.
+    if: >-
+      contains(github.event.comment.body, '@dunxonudeepreview') &&
+      (github.event.issue.pull_request != null || github.event.pull_request != null) &&
+      github.event.sender.login != 'dunxonu'
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      # Tell whoever asked that it started. A deep review takes minutes, and the
+      # alternative is a person typing the trigger twice because nothing
+      # happened.
+      - name: Acknowledge
+        env:
+          GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/$NUMBER/reactions" \
+            -f content=eyes >/dev/null || true
+
+      # Full history, not depth 1. Three of the tools below are `git log`,
+      # `git blame` and `git show`, and a single-commit checkout gives them
+      # nothing: a review at depth 1 reported reading `main...HEAD`, a range that
+      # does not exist locally.
+      #
+      # `persist-credentials: false` because the reviewer reads files and the
+      # pull request it reads is attacker-controlled text. checkout@v4 leaves the
+      # workflow token in `.git/config` inside the workspace, so a prompt
+      # injection that got the agent to print that file would disclose a token
+      # holding `pull-requests: write`. Nothing here needs credentials after the
+      # fetch.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: refs/pull/${{ github.event.issue.number || github.event.pull_request.number }}/head
+
+      - name: Resolve the head commit
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          sha=$(gh api "repos/${{ github.repository }}/pulls/$NUMBER" --jq .head.sha)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+      # Pinned to a commit. A tag is mutable and this step is handed two secrets,
+      # so retargeting `v1` would run unreviewed code with them.
+      - id: review
+        uses: anthropics/claude-code-action@b7912aeeb535234e3e9385ff49e8237f689b5f14 # v1
+        env:
+          # A background task in a headless run never reports back, because the
+          # run ends when the main agent stops. `-p` already runs this in the
+          # foreground; this turns the rest of it off.
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.DUNXONU_TOKEN }}
+          # `high` rather than `medium`. Somebody asked for this one by name, and
+          # broader coverage at the cost of a longer run is the whole reason to
+          # ask. `medium` is what the automatic reviewer already approximates.
+          #
+          # `track_progress` stays absent: it delivers the run through the
+          # action's own tracking comment, whose body always opens with a
+          # hardcoded "Claude finished @<user>'s task in <duration>" and a job
+          # link, and nothing configures that away.
+          #
+          # `--comment` stays absent too: it posts each finding through the
+          # inline-comment tool, which put six separate top-level comments on
+          # one pull request seconds apart.
+          prompt: /code-review high ${{ github.repository }}/pull/${{ steps.head.outputs.number }}
+          # --allowedTools REPLACES the skill's own list rather than adding to
+          # it, so everything it reaches for has to be named. Read, Grep and Glob
+          # need no entry. The text commands are here because a measured run
+          # without them reached for `cat -n`, `grep -nE` and `awk` eight times
+          # and was refused each time, which left it verifying findings by
+          # inference.
+          #
+          # `bun test` is deliberately still absent: it executes the code under
+          # review and this job carries an OAuth token. Add `Bash(bun test:*)` to
+          # trade that for a reviewer that can run the suite it reasons about.
+          claude_args: |
+            --append-system-prompt "Do not post anything yourself: no gh pr review, no gh pr comment, no inline comments. Something else reads your final message and posts it as a pull request review, so open with no preamble naming the job, the run, the duration or yourself. Report your findings as the typed list you normally would. If you write prose instead, end the message with a line reading exactly VERDICT: APPROVE when you found nothing worth changing, or exactly VERDICT: COMMENT when you did. Never use an em dash or an en dash anywhere in your output."
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh api:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Bash(git diff:*),Bash(git status:*),Bash(git rev-parse:*),Bash(git merge-base:*),Bash(git ls-files:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(wc:*),Bash(grep:*),Bash(rg:*),Bash(sed:*),Bash(awk:*),Bash(ls:*),Bash(find:*)"
+
+      # One review per request, findings on the lines they are about and the body
+      # a count, because the whole review in the body put a screen of prose in
+      # the conversation.
+      #
+      # `--whole-diff` is what makes this different from the automatic reviewer.
+      # The narrowing in post-review.ts asks what this account last reviewed, and
+      # dunxonu now reviews every push, so without the flag a deep review would
+      # scope itself to whatever changed since that automatic run: usually
+      # nothing. The one review somebody asked for would look at the least.
+      #
+      # An empty review is a hard failure rather than a green check. A review
+      # gate that can pass without reviewing is worse than no gate, and this one
+      # was explicitly requested, so silence is the wrong answer.
+      - name: Submit the review
+        env:
+          GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
+          EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+          # Bun is on PATH because the action put it there.
+          bun scripts/post-review.ts \
+            "$EXECUTION_FILE" \
+            "${{ github.repository }}" \
+            "${{ steps.head.outputs.number }}" \
+            "${{ steps.head.outputs.sha }}" \
+            --whole-diff

--- a/.github/workflows/dunxonu-deep-review.yml
+++ b/.github/workflows/dunxonu-deep-review.yml
@@ -38,10 +38,21 @@ jobs:
     # issue, where there is no diff to review and the API call would 404. And
     # the sender check keeps dunxonu from triggering itself, since it posts with
     # a real user's token and its own comments raise this event.
+    # `contains` is a cheap pre-filter only; the exact match happens in the first
+    # step, because workflow expressions have no word boundary and
+    # `@dunxonudeepreviewer` contains this string.
+    #
+    # The author check is the one that matters. This job hands an agent a
+    # `gh api` wildcard and a token holding `pull-requests: write`, and the pull
+    # request it reads is attacker-controlled text, so a prompt injection in a
+    # diff plus a trigger word from any passer-by is enough to act with that
+    # token. It also bills a subscription call per run. Both reasons say the
+    # same thing: only people who already have write access may ask.
     if: >-
       contains(github.event.comment.body, '@dunxonudeepreview') &&
       (github.event.issue.pull_request != null || github.event.pull_request != null) &&
-      github.event.sender.login != 'dunxonu'
+      github.event.sender.login != 'dunxonu' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     timeout-minutes: 30
     permissions:
       contents: read
@@ -59,8 +70,24 @@ jobs:
       # catch it: its freshness check compares the head to the sha it was given,
       # and the newer sha is what it was given. So the sha is pinned first and
       # the checkout is told exactly which commit to take.
+      # The word boundary the `if:` above cannot express. `@dunxonudeepreviewer`
+      # and `@dunxonudeepreview-old` both contain the trigger and neither is a
+      # request for a thirty minute, subscription billed run.
+      - name: Check the trigger is exactly ours
+        id: gate
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          if printf '%s' "$BODY" | grep -qiE '@dunxonudeepreview([^A-Za-z0-9_-]|$)'; then
+            echo 'ok=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'ok=false' >> "$GITHUB_OUTPUT"
+            echo 'The trigger appears only inside a longer word. Nothing to do.'
+          fi
+
       - name: Resolve the head commit
         id: head
+        if: steps.gate.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
@@ -79,6 +106,7 @@ jobs:
       # top post is not where they are looking. The two comment kinds live under
       # different paths, and only the event name says which one this is.
       - name: Acknowledge
+        if: steps.gate.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
           COMMENT_ID: ${{ github.event.comment.id }}
@@ -104,6 +132,7 @@ jobs:
       # holding `pull-requests: write`. Nothing here needs credentials after the
       # fetch.
       - uses: actions/checkout@v4
+        if: steps.gate.outputs.ok == 'true'
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -112,6 +141,7 @@ jobs:
       # Pinned to a commit. A tag is mutable and this step is handed two secrets,
       # so retargeting `v1` would run unreviewed code with them.
       - id: review
+        if: steps.gate.outputs.ok == 'true'
         uses: anthropics/claude-code-action@b7912aeeb535234e3e9385ff49e8237f689b5f14 # v1
         env:
           # A background task in a headless run never reports back, because the
@@ -152,16 +182,17 @@ jobs:
       # a count, because the whole review in the body put a screen of prose in
       # the conversation.
       #
-      # `--whole-diff` is what makes this different from the automatic reviewer.
-      # The narrowing in post-review.ts asks what this account last reviewed, and
-      # dunxonu now reviews every push, so without the flag a deep review would
-      # scope itself to whatever changed since that automatic run: usually
-      # nothing. The one review somebody asked for would look at the least.
+      # Always the whole diff. post-review.ts used to narrow to what changed
+      # since this account's last review, which is now meaningless: dunxonu
+      # reviews every push automatically, so a requested deep review would have
+      # scoped itself to nothing. That narrowing is gone rather than flagged
+      # off, since nothing could reach it.
       #
       # An empty review is a hard failure rather than a green check. A review
       # gate that can pass without reviewing is worse than no gate, and this one
       # was explicitly requested, so silence is the wrong answer.
       - name: Submit the review
+        if: steps.gate.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.DUNXONU_TOKEN }}
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
@@ -172,5 +203,4 @@ jobs:
             "$EXECUTION_FILE" \
             "${{ github.repository }}" \
             "${{ steps.head.outputs.number }}" \
-            "${{ steps.head.outputs.sha }}" \
-            --whole-diff
+            "${{ steps.head.outputs.sha }}"

--- a/.github/workflows/dunxonu-deep-review.yml
+++ b/.github/workflows/dunxonu-deep-review.yml
@@ -231,6 +231,14 @@ jobs:
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
         run: |
           set -euo pipefail
+          # A missing trusted copy is a bootstrap, not a mystery. The script is
+          # taken from the default branch on purpose, so a pull request that
+          # adds or moves it cannot post a review until it merges. Saying that
+          # plainly beats "Module not found" from Bun.
+          if [ ! -f .trusted/scripts/post-review.ts ]; then
+            echo "::error::The default branch has no scripts/post-review.ts. This job runs the copy from there deliberately, never the one in the pull request, so it cannot post until that file is on the default branch."
+            exit 1
+          fi
           # Bun is on PATH because the action put it there.
           bun .trusted/scripts/post-review.ts \
             "$EXECUTION_FILE" \

--- a/.github/workflows/dunxonu-deep-review.yml
+++ b/.github/workflows/dunxonu-deep-review.yml
@@ -54,12 +54,15 @@ jobs:
       github.event.sender.login != 'dunxonu' &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     timeout-minutes: 30
+    # Read only. `permissions:` governs the automatic GITHUB_TOKEN, which is what
+    # the agent below is handed; DUNXONU_TOKEN is a personal access token with
+    # its own scopes, so the submit step can still post while the agent cannot.
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
+      pull-requests: read
+      # The action reads its own run to produce `execution_file`.
       actions: read
+      id-token: write
     steps:
       # Resolved before the checkout, not after it.
       #
@@ -131,7 +134,12 @@ jobs:
       # injection that got the agent to print that file would disclose a token
       # holding `pull-requests: write`. Nothing here needs credentials after the
       # fetch.
-      - uses: actions/checkout@v4
+      # Pinned to a commit: `v4` is mutable, and a retargeted tag would run
+      # unreviewed code in a job that goes on to touch a token.
+      #
+      # Everything this brings into the workspace is attacker-controlled. It is
+      # here for the agent to read and for nothing else to execute.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         if: steps.gate.outputs.ok == 'true'
         with:
           fetch-depth: 0
@@ -150,7 +158,16 @@ jobs:
           CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: '1'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.DUNXONU_TOKEN }}
+          # The workflow's own token, which this job has granted read only,
+          # rather than DUNXONU_TOKEN.
+          #
+          # The agent is allowed `Bash(gh api:*)`, which is any method against
+          # any endpoint, and it reads a pull request whose text anybody can
+          # write. An appended instruction saying "do not post anything" is a
+          # request, not an authorization boundary, so the boundary is the token:
+          # with this one it can read the things it needs and write nothing at
+          # all. Posting happens in the trusted step at the bottom.
+          github_token: ${{ github.token }}
           # `high` rather than `medium`. Somebody asked for this one by name, and
           # broader coverage at the cost of a longer run is the whole reason to
           # ask. `medium` is what the automatic reviewer already approximates.
@@ -182,11 +199,27 @@ jobs:
       # a count, because the whole review in the body put a screen of prose in
       # the conversation.
       #
-      # Always the whole diff. post-review.ts used to narrow to what changed
-      # since this account's last review, which is now meaningless: dunxonu
-      # reviews every push automatically, so a requested deep review would have
-      # scoped itself to nothing. That narrowing is gone rather than flagged
-      # off, since nothing could reach it.
+      # The script is taken from the default branch, not from the pull request,
+      # and only now that the agent has stopped.
+      #
+      # Both halves matter. The workspace holds pull request content, so a
+      # contributor could simply edit `scripts/post-review.ts` and have it run
+      # with DUNXONU_TOKEN in `GH_TOKEN`: no prompt injection required, just a
+      # commit. And fetching the trusted copy earlier would not help, because
+      # the agent's tool list includes `sed` and `awk`, either of which writes a
+      # file in place. So the trusted copy does not exist while the agent runs.
+      - name: Fetch the submission script from the default branch
+        if: steps.gate.outputs.ok == 'true'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .trusted
+          sparse-checkout: scripts
+          persist-credentials: false
+
+      # One review per request, findings on the lines they are about and the
+      # body a count, because the whole review in the body put a screen of prose
+      # in the conversation.
       #
       # An empty review is a hard failure rather than a green check. A review
       # gate that can pass without reviewing is worse than no gate, and this one
@@ -199,7 +232,7 @@ jobs:
         run: |
           set -euo pipefail
           # Bun is on PATH because the action put it there.
-          bun scripts/post-review.ts \
+          bun .trusted/scripts/post-review.ts \
             "$EXECUTION_FILE" \
             "${{ github.repository }}" \
             "${{ steps.head.outputs.number }}" \

--- a/scripts/post-review.test.ts
+++ b/scripts/post-review.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   buildReview,
   commentableLines,
-  COMPARE_FILE_CAP,
   type Commentable,
-  scopeFromCompare,
 } from './post-review.js';
 
 const finding = (over: Record<string, unknown> = {}) => ({
@@ -195,59 +193,20 @@ describe('reading the diff', () => {
  * Scoping later reviews to what actually changed is what lets a pull request
  * converge.
  */
-describe('scoping a review to what changed since the last one', () => {
+describe('a review of the whole diff', () => {
   const both = diff({ 'a.ts': [10], 'b.ts': [3] });
 
-  it('reports everything when there is no previous review', () => {
+  it('reports every finding it was given', () => {
     const review = buildReview(
       listed(finding(), finding({ file: 'b.ts', line: 3 })),
       both,
-      null,
     );
     expect(review.comments).toHaveLength(2);
     expect(review.event).toBe('COMMENT');
   });
 
-  it('drops findings in files untouched since the last review', () => {
-    const review = buildReview(
-      listed(finding(), finding({ file: 'b.ts', line: 3 })),
-      both,
-      new Set(['b.ts']),
-    );
-    expect(review.comments).toHaveLength(1);
-    expect(review.comments[0]?.path).toBe('b.ts');
-  });
-
-  it('says how many it carried rather than hiding them', () => {
-    const review = buildReview(
-      listed(finding(), finding({ file: 'b.ts', line: 3 })),
-      both,
-      new Set(['b.ts']),
-    );
-    expect(review.body).toContain('1 further finding');
-    expect(review.body).toContain('untouched since the last review');
-  });
-
-  it('approves when everything left in scope is clean', () => {
-    // The convergence case: the author fixed what was raised and pushed. The
-    // only findings left are about code this push did not touch, so there is
-    // nothing new to say and the review should say so.
-    const review = buildReview(
-      listed(finding({ file: 'untouched.ts' })),
-      diff({ 'b.ts': [3] }),
-      new Set(['b.ts']),
-    );
-    expect(review.event).toBe('APPROVE');
-    expect(review.comments).toHaveLength(0);
-    expect(review.body).toContain('1 further finding');
-  });
-
-  it('still approves a genuinely clean review with nothing carried', () => {
-    const review = buildReview(
-      listed(),
-      diff({ 'b.ts': [3] }),
-      new Set(['b.ts']),
-    );
+  it('approves a genuinely clean review', () => {
+    const review = buildReview(listed(), diff({ 'b.ts': [3] }));
     expect(review.event).toBe('APPROVE');
     expect(review.body).toBe(
       'Reviewed the diff and found nothing worth changing.',
@@ -258,35 +217,40 @@ describe('scoping a review to what changed since the last one', () => {
     const review = buildReview(
       listed(finding({ file: undefined, line: undefined })),
       diff({ 'b.ts': [3] }),
-      new Set(['b.ts']),
     );
     expect(review.event).toBe('COMMENT');
     expect(review.body).toContain('Actionable comment');
   });
 });
 
-/*
- * The compare endpoint caps its file list at 300 and does not page past it, so a
- * bigger change comes back silently short. Narrowing the scope to a truncated
- * list would suppress genuinely new findings and could then approve - the exact
- * failure the scoping exists to prevent, which is why this widens instead.
- */
-describe('scope from a compare result', () => {
-  it('scopes to the files it was given', () => {
-    expect(scopeFromCompare(['a.ts', 'b.ts'])).toEqual(
-      new Set(['a.ts', 'b.ts']),
-    );
+describe('a block with one malformed entry', () => {
+  const commentable: Commentable = new Map([['a.ts', new Set([1, 2])]]);
+
+  it('keeps the entries that parsed instead of discarding the block', () => {
+    // One truncated entry used to throw away every finding beside it, and the
+    // raw JSON went into the review body as prose.
+    const result = [
+      '```json',
+      JSON.stringify([
+        { file: 'a.ts', line: 1, summary: 'real one' },
+        { file: 'a.ts', line: 2 },
+      ]),
+      '```',
+    ].join('\n');
+
+    const review = buildReview(result, commentable);
+    expect(review.comments).toHaveLength(1);
+    expect(review.comments[0]?.body).toContain('real one');
   });
 
-  it('scopes to nothing changed, which is still a scope', () => {
-    expect(scopeFromCompare([])).toEqual(new Set());
+  it('still refuses an array that is not findings at all', () => {
+    const review = buildReview('```json\n[1, 2, 3]\n```', commentable);
+    // No findings array recognised, so it is prose and cannot approve.
+    expect(review.event).toBe('COMMENT');
+    expect(review.comments).toHaveLength(0);
   });
 
-  it('widens to the whole diff when the list may be truncated', () => {
-    const many = Array.from({ length: COMPARE_FILE_CAP }, (_, i) => `f${i}.ts`);
-    expect(scopeFromCompare(many)).toBeNull();
-    expect(
-      scopeFromCompare(many.slice(0, COMPARE_FILE_CAP - 1)),
-    ).not.toBeNull();
+  it('still reads an empty array as a clean review', () => {
+    expect(buildReview('[]', commentable).event).toBe('APPROVE');
   });
 });

--- a/scripts/post-review.test.ts
+++ b/scripts/post-review.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildReview,
+  commentableLines,
+  COMPARE_FILE_CAP,
+  type Commentable,
+  scopeFromCompare,
+} from './post-review.js';
+
+const finding = (over: Record<string, unknown> = {}) => ({
+  file: 'a.ts',
+  line: 10,
+  summary: 'It does the wrong thing.',
+  failure_scenario: 'A caller passes x and gets y.',
+  ...over,
+});
+
+const listed = (...findings: unknown[]) => JSON.stringify(findings);
+
+const diff = (spec: Record<string, number[]>): Commentable =>
+  new Map(Object.entries(spec).map(([file, lines]) => [file, new Set(lines)]));
+
+/**
+ * The whole review used to go in the body, which put a screen of prose in the
+ * conversation on every push. The findings belong on the lines they are about.
+ */
+describe('building a review', () => {
+  it('anchors each finding to its line and keeps the body a summary', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      diff({ 'a.ts': [10], 'b.ts': [3] }),
+    );
+
+    expect(review.event).toBe('COMMENT');
+    expect(review.body).toBe('**Actionable comments posted: 2**');
+    expect(review.comments).toEqual([
+      {
+        path: 'a.ts',
+        line: 10,
+        side: 'RIGHT',
+        body: 'It does the wrong thing.\n\n**How it fails:** A caller passes x and gets y.',
+      },
+      {
+        path: 'b.ts',
+        line: 3,
+        side: 'RIGHT',
+        body: 'It does the wrong thing.\n\n**How it fails:** A caller passes x and gets y.',
+      },
+    ]);
+  });
+
+  /**
+   * GitHub rejects the entire review if one comment names a line outside the
+   * diff, so those are summarised rather than dropped or posted.
+   */
+  it('summarises a finding the diff cannot carry, collapsed', () => {
+    const review = buildReview(
+      listed(
+        finding(),
+        finding({ file: 'CLAUDE.md', line: 0, short_summary: 'Rule 4' }),
+        finding({ file: 'untouched.ts', line: 900 }),
+      ),
+      diff({ 'a.ts': [10] }),
+    );
+
+    expect(review.comments).toHaveLength(1);
+    expect(review.body).toContain('**Actionable comments posted: 1**');
+    expect(review.body).toContain(
+      '<details><summary>Outside the diff (2)</summary>',
+    );
+    expect(review.body).toContain('`CLAUDE.md:0` Rule 4');
+    expect(review.body).toContain('`untouched.ts:900`');
+  });
+
+  it('approves an empty list and says so in one line', () => {
+    const review = buildReview('[]', diff({}));
+    expect(review.event).toBe('APPROVE');
+    expect(review.comments).toEqual([]);
+    expect(review.body).toBe(
+      'Reviewed the diff and found nothing worth changing.',
+    );
+  });
+
+  it('does not let a stray empty fence approve a flagged review', () => {
+    const review = buildReview(
+      'Found a problem.\n\n```json\n[]\n```\n\nVERDICT: COMMENT\n',
+      diff({}),
+    );
+    expect(review.event).toBe('COMMENT');
+    expect(review.body).toContain('Found a problem.');
+  });
+
+  /**
+   * The sentinel alone would approve a review that listed findings and then said
+   * APPROVE; the list alone was already shown to approve on a stray empty fence.
+   * Approving needs both to agree.
+   */
+  it('refuses to approve while findings exist, whatever the sentinel says', () => {
+    const review = buildReview(
+      `\`\`\`json\n${listed(finding())}\n\`\`\`\n\nVERDICT: APPROVE\n`,
+      diff({ 'a.ts': [10] }),
+    );
+    expect(review.event).toBe('COMMENT');
+    expect(review.comments).toHaveLength(1);
+  });
+
+  it('takes prose as the body, with the verdict from the sentinel', () => {
+    const review = buildReview('Looks fine.\n\nVERDICT: APPROVE\n', diff({}));
+    expect(review.event).toBe('APPROVE');
+    expect(review.body).toBe('Looks fine.');
+    expect(review.comments).toEqual([]);
+  });
+
+  /**
+   * `exec` returns the first match. A review that quotes the instruction before
+   * ending on `VERDICT: COMMENT` would have been read from the quote.
+   */
+  it('reads the last sentinel, not the first', () => {
+    const review = buildReview(
+      'VERDICT: APPROVE\n\nOn reflection, it is not clean.\n\nVERDICT: COMMENT\n',
+      diff({}),
+    );
+    expect(review.event).toBe('COMMENT');
+    // Both whole-line sentinels are gone, wherever they sat.
+    expect(review.body).toBe('On reflection, it is not clean.');
+  });
+
+  it('leaves a sentinel mentioned inside a sentence alone', () => {
+    const review = buildReview(
+      'The runner writes VERDICT: APPROVE when clean.\n\nVERDICT: COMMENT\n',
+      diff({}),
+    );
+    expect(review.event).toBe('COMMENT');
+    expect(review.body).toBe('The runner writes VERDICT: APPROVE when clean.');
+  });
+
+  it('comments when prose carries no sentinel', () => {
+    expect(buildReview('Notes, no verdict.', diff({})).event).toBe('COMMENT');
+  });
+
+  it('collects findings from every fenced block', () => {
+    const review = buildReview(
+      `\`\`\`json\n${listed(finding())}\n\`\`\`\n\n## More\n\n` +
+        `\`\`\`json\n${listed(finding({ file: 'b.ts', line: 3 }))}\n\`\`\``,
+      diff({ 'a.ts': [10], 'b.ts': [3] }),
+    );
+    expect(review.comments).toHaveLength(2);
+  });
+});
+
+describe('reading the diff', () => {
+  it('counts right-hand lines and skips deletions', () => {
+    const lines = commentableLines([
+      {
+        filename: 'a.ts',
+        patch: [
+          '@@ -1,3 +1,4 @@',
+          ' keep',
+          '-gone',
+          '+added',
+          '+more',
+          ' tail',
+        ].join('\n'),
+      },
+    ]);
+    // 1 keep, 2 added, 3 more, 4 tail. The deletion consumes no right-hand line.
+    expect([...(lines.get('a.ts') ?? [])]).toEqual([1, 2, 3, 4]);
+  });
+
+  it('handles several hunks, and a file with no patch at all', () => {
+    const lines = commentableLines([
+      {
+        filename: 'a.ts',
+        patch: [
+          '@@ -1,1 +1,1 @@',
+          '+one',
+          '@@ -50,1 +60,2 @@',
+          '+sixty',
+          '+sixtyone',
+        ].join('\n'),
+      },
+      { filename: 'binary.png' },
+    ]);
+    expect([...(lines.get('a.ts') ?? [])]).toEqual([1, 60, 61]);
+    expect(lines.has('binary.png')).toBe(false);
+  });
+});
+
+/*
+ * The reviewer runs against the full diff on every push and is not deterministic
+ * over it, so unchanged code gets a fresh chance to yield a finding on each run.
+ * Measured on #70: five rounds, 24 findings, never an approval, with round 3
+ * reporting two files `git log` shows were untouched since the first push.
+ *
+ * Scoping later reviews to what actually changed is what lets a pull request
+ * converge.
+ */
+describe('scoping a review to what changed since the last one', () => {
+  const both = diff({ 'a.ts': [10], 'b.ts': [3] });
+
+  it('reports everything when there is no previous review', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      both,
+      null,
+    );
+    expect(review.comments).toHaveLength(2);
+    expect(review.event).toBe('COMMENT');
+  });
+
+  it('drops findings in files untouched since the last review', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      both,
+      new Set(['b.ts']),
+    );
+    expect(review.comments).toHaveLength(1);
+    expect(review.comments[0]?.path).toBe('b.ts');
+  });
+
+  it('says how many it carried rather than hiding them', () => {
+    const review = buildReview(
+      listed(finding(), finding({ file: 'b.ts', line: 3 })),
+      both,
+      new Set(['b.ts']),
+    );
+    expect(review.body).toContain('1 further finding');
+    expect(review.body).toContain('untouched since the last review');
+  });
+
+  it('approves when everything left in scope is clean', () => {
+    // The convergence case: the author fixed what was raised and pushed. The
+    // only findings left are about code this push did not touch, so there is
+    // nothing new to say and the review should say so.
+    const review = buildReview(
+      listed(finding({ file: 'untouched.ts' })),
+      diff({ 'b.ts': [3] }),
+      new Set(['b.ts']),
+    );
+    expect(review.event).toBe('APPROVE');
+    expect(review.comments).toHaveLength(0);
+    expect(review.body).toContain('1 further finding');
+  });
+
+  it('still approves a genuinely clean review with nothing carried', () => {
+    const review = buildReview(
+      listed(),
+      diff({ 'b.ts': [3] }),
+      new Set(['b.ts']),
+    );
+    expect(review.event).toBe('APPROVE');
+    expect(review.body).toBe(
+      'Reviewed the diff and found nothing worth changing.',
+    );
+  });
+
+  it('keeps a finding with no file, which cannot be attributed to one', () => {
+    const review = buildReview(
+      listed(finding({ file: undefined, line: undefined })),
+      diff({ 'b.ts': [3] }),
+      new Set(['b.ts']),
+    );
+    expect(review.event).toBe('COMMENT');
+    expect(review.body).toContain('Actionable comment');
+  });
+});
+
+/*
+ * The compare endpoint caps its file list at 300 and does not page past it, so a
+ * bigger change comes back silently short. Narrowing the scope to a truncated
+ * list would suppress genuinely new findings and could then approve - the exact
+ * failure the scoping exists to prevent, which is why this widens instead.
+ */
+describe('scope from a compare result', () => {
+  it('scopes to the files it was given', () => {
+    expect(scopeFromCompare(['a.ts', 'b.ts'])).toEqual(
+      new Set(['a.ts', 'b.ts']),
+    );
+  });
+
+  it('scopes to nothing changed, which is still a scope', () => {
+    expect(scopeFromCompare([])).toEqual(new Set());
+  });
+
+  it('widens to the whole diff when the list may be truncated', () => {
+    const many = Array.from({ length: COMPARE_FILE_CAP }, (_, i) => `f${i}.ts`);
+    expect(scopeFromCompare(many)).toBeNull();
+    expect(
+      scopeFromCompare(many.slice(0, COMPARE_FILE_CAP - 1)),
+    ).not.toBeNull();
+  });
+});

--- a/scripts/post-review.ts
+++ b/scripts/post-review.ts
@@ -1,0 +1,464 @@
+/**
+ * Posts a `/code-review` run as one pull request review: a short summary, and each
+ * finding as an inline comment on the line it is about.
+ *
+ * `bun scripts/post-review.ts <execution-file> <owner/repo> <number> <sha> [--whole-diff]`
+ *
+ * The whole review used to go in the body, which put a screen of prose in the
+ * conversation for every push. GitHub takes the comments with the review in one
+ * `POST`, so this is still one review per run rather than a comment per finding.
+ */
+interface Finding {
+  readonly file?: string;
+  readonly line?: number;
+  readonly summary?: string;
+  readonly short_summary?: string;
+  readonly failure_scenario?: string;
+}
+
+export interface ReviewComment {
+  readonly path: string;
+  readonly line: number;
+  readonly side: 'RIGHT';
+  readonly body: string;
+}
+
+export interface Review {
+  readonly event: 'APPROVE' | 'COMMENT';
+  readonly body: string;
+  readonly comments: readonly ReviewComment[];
+}
+
+/** Line numbers on the right-hand side of the diff, which are the commentable ones. */
+export type Commentable = ReadonlyMap<string, ReadonlySet<number>>;
+
+/**
+ * The files this review is allowed to report on, or `null` for all of them.
+ *
+ * `null` is the first review of a pull request, which sees the whole diff. Every
+ * review after it sees only the files touched since the previous one.
+ *
+ * **This is what lets a pull request converge.** The reviewer runs against the
+ * full diff on every push and is not deterministic over it, so unchanged code
+ * gets a fresh chance to yield a finding on each run. Measured on #70: round 3
+ * reported `rssMeanMiB` in `src/resources.ts` and a duplicated `Row` in
+ * `servers/drivers/pair.ts`, and `git log` shows neither file was touched between
+ * the first push and the commit that round reviewed. Both findings were equally
+ * true and equally reportable in round 1. Five rounds, 24 findings, and never an
+ * approval, because there was always something new to say about code nobody had
+ * changed.
+ *
+ * Findings outside the scope are counted in the body rather than dropped in
+ * silence: they were reportable earlier and are still true, and hiding them would
+ * be this script deciding what the author may see.
+ */
+export type Scope = ReadonlySet<string> | null;
+
+/**
+ * GitHub's compare endpoint returns at most this many files and does not page
+ * past them, so a longer list has been silently truncated.
+ */
+export const COMPARE_FILE_CAP = 300;
+
+/**
+ * The scope a compare result supports, or `null` when it cannot be trusted to be
+ * complete.
+ *
+ * Suppressing a finding because its file fell off the end of a truncated list is
+ * the exact failure this scoping exists to prevent: a genuinely new problem,
+ * filed under "not repeated here", on a review that could then approve.
+ *
+ * Being wrong about the cap is safe in the direction that matters - too low
+ * reviews more than it needs to, and only too high could suppress.
+ */
+export const scopeFromCompare = (touched: readonly string[]): Scope =>
+  touched.length >= COMPARE_FILE_CAP ? null : new Set(touched);
+
+const VERDICT = /^VERDICT: (APPROVE|COMMENT)$/gm;
+
+/**
+ * The last sentinel, not the first. The instruction says to end the message with
+ * one, and a review that quotes the instruction before ending on
+ * `VERDICT: COMMENT` would otherwise be read from the quote and approved.
+ */
+const verdictIn = (text: string): string | undefined =>
+  [...text.matchAll(VERDICT)].at(-1)?.[1];
+
+/** Only the sentinel lines, wherever they are, so none is left in the body. */
+const withoutVerdict = (text: string): string =>
+  text.replace(VERDICT, '').trim();
+const FENCE = /^```(?:json)?[ \t]*\n([\s\S]*?)\n```[ \t]*$/gm;
+
+const resultOf = (raw: string): string => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return '';
+  }
+  if (Array.isArray(parsed)) {
+    return (
+      parsed
+        .filter(
+          (event): event is { type: string; result?: string } =>
+            typeof event === 'object' && event !== null && 'type' in event,
+        )
+        .findLast((event) => event.type === 'result')?.result ?? ''
+    );
+  }
+  return (parsed as { result?: string }).result ?? '';
+};
+
+const parseFindings = (block: string): readonly Finding[] | undefined => {
+  const body = block.trim();
+  if (!body.startsWith('[')) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed.every(
+      (entry) =>
+        typeof entry === 'object' && entry !== null && 'summary' in entry,
+    )
+      ? (parsed as Finding[])
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const findingsIn = (text: string): readonly Finding[] | undefined => {
+  const fenced = [...text.matchAll(FENCE)].map((match) => match[1] ?? '');
+  const lists = (fenced.length > 0 ? fenced : [text])
+    .map(parseFindings)
+    .filter((list): list is readonly Finding[] => list !== undefined);
+  return lists.length === 0 ? undefined : lists.flat();
+};
+
+/**
+ * A message that is nothing but an empty list is a clean review. An illustrative
+ * empty fence inside a real write-up is not: `Array.prototype.every` is vacuously
+ * true on `[]`, which once approved a pull request the reviewer had written up.
+ */
+const proseOutside = (text: string): string => {
+  const withoutFences = text.replace(FENCE, '').trim();
+  return withoutFences === text.trim() && parseFindings(text) !== undefined
+    ? ''
+    : withoutFences;
+};
+
+const detail = (finding: Finding): string => {
+  const parts: string[] = [];
+  if (finding.summary !== undefined) parts.push(finding.summary);
+  if (finding.failure_scenario !== undefined) {
+    parts.push(`**How it fails:** ${finding.failure_scenario}`);
+  }
+  return parts.join('\n\n');
+};
+
+const at = (finding: Finding): string =>
+  finding.file === undefined
+    ? 'elsewhere'
+    : `\`${finding.file}${finding.line === undefined ? '' : `:${finding.line}`}\``;
+
+/**
+ * GitHub rejects the whole review if any comment names a line outside the diff, so
+ * a finding about an untouched line is summarised in the body instead of dropped.
+ */
+export const buildReview = (
+  result: string,
+  commentable: Commentable,
+  scope: Scope = null,
+): Review => {
+  const all = findingsIn(result);
+  const findings =
+    all === undefined || scope === null
+      ? all
+      : all.filter(
+          (finding) => finding.file === undefined || scope.has(finding.file),
+        );
+  const carried = (all?.length ?? 0) - (findings?.length ?? 0);
+  const sentinel = verdictIn(result);
+  const clean =
+    findings !== undefined &&
+    findings.length === 0 &&
+    proseOutside(result) === '';
+
+  /**
+   * Approving needs both signals to agree. The sentinel alone would approve a
+   * review that listed five findings and ended `VERDICT: APPROVE`, and the list
+   * alone was already shown to approve on a stray empty fence. Either one saying
+   * there is something to fix is enough to withhold the approval.
+   */
+  const nothingFound = findings === undefined ? false : findings.length === 0;
+  const event: Review['event'] =
+    sentinel === 'COMMENT' || (findings !== undefined && !nothingFound)
+      ? 'COMMENT'
+      : sentinel === 'APPROVE' || clean
+        ? 'APPROVE'
+        : 'COMMENT';
+
+  // Prose, so there is nothing to anchor: it goes in the body. An empty list that
+  // is not the whole message lands here too, or a write-up carrying an
+  // illustrative empty fence would be summarised away as a clean review.
+  if (findings === undefined || (findings.length === 0 && !clean)) {
+    return { event, body: withoutVerdict(result), comments: [] };
+  }
+  if (findings.length === 0) {
+    return {
+      event,
+      body:
+        carried === 0
+          ? 'Reviewed the diff and found nothing worth changing.'
+          : `Reviewed what changed since the last review and found nothing worth changing.\n\n${carriedNote(carried)}`,
+      comments: [],
+    };
+  }
+
+  const comments: ReviewComment[] = [];
+  const elsewhere: Finding[] = [];
+
+  for (const finding of findings) {
+    const lines =
+      finding.file === undefined ? undefined : commentable.get(finding.file);
+    if (
+      finding.file !== undefined &&
+      finding.line !== undefined &&
+      lines?.has(finding.line) === true
+    ) {
+      comments.push({
+        path: finding.file,
+        line: finding.line,
+        side: 'RIGHT',
+        body: detail(finding),
+      });
+    } else {
+      elsewhere.push(finding);
+    }
+  }
+
+  const plural = findings.length === 1 ? 'comment' : 'comments';
+  const body = [`**Actionable ${plural} posted: ${comments.length}**`];
+
+  if (carried > 0) body.push('', carriedNote(carried));
+
+  if (elsewhere.length > 0) {
+    // Collapsed, so the conversation stays a summary rather than the review.
+    body.push(
+      '',
+      `<details><summary>Outside the diff (${elsewhere.length})</summary>`,
+      '',
+      ...elsewhere.map(
+        (finding) =>
+          `- ${at(finding)} ${finding.short_summary ?? finding.summary ?? ''}`,
+      ),
+      '',
+      '</details>',
+    );
+  }
+
+  return { event, body: body.join('\n'), comments };
+};
+
+/** `@@ -a,b +c,d @@` then one line per row, counting only the right-hand side. */
+export const commentableLines = (
+  files: readonly { readonly filename: string; readonly patch?: string }[],
+): Commentable => {
+  const map = new Map<string, Set<number>>();
+
+  for (const file of files) {
+    if (file.patch === undefined) continue;
+    const lines = new Set<number>();
+    let cursor = 0;
+
+    for (const row of file.patch.split('\n')) {
+      const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(row);
+      if (hunk) {
+        cursor = Number(hunk[1]);
+        continue;
+      }
+      if (row.startsWith('-')) continue;
+      if (row.startsWith('+') || row.startsWith(' ')) {
+        lines.add(cursor);
+        cursor += 1;
+      }
+    }
+    map.set(file.filename, lines);
+  }
+
+  return map;
+};
+
+/**
+ * Said plainly rather than hidden: these findings are real, they are just not
+ * about anything this push touched, so repeating them as new inline comments on
+ * every round is what turns a review into a treadmill.
+ */
+const carriedNote = (carried: number): string =>
+  `${carried} further finding${carried === 1 ? '' : 's'} ` +
+  `${carried === 1 ? 'is' : 'are'} in code untouched since the last review, ` +
+  'and so were reportable then. Not repeated here.';
+
+const gh = async (args: readonly string[]): Promise<string> => {
+  const proc = Bun.spawn(['gh', ...args], { stdout: 'pipe', stderr: 'pipe' });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`gh ${args.join(' ')} failed: ${err.trim()}`);
+  return out;
+};
+
+/**
+ * The commit this reviewer last posted a review against on this pull request, or
+ * `undefined` if this is the first.
+ *
+ * By the authenticated account rather than a hardcoded login: the workflow runs
+ * as whatever `DUNXONU_TOKEN` belongs to, and a review left by a human or by
+ * another bot must not narrow what this one looks at.
+ */
+const lastReviewedSha = async (
+  repo: string,
+  number: string,
+): Promise<string | undefined> => {
+  const me = (await gh(['api', 'user', '--jq', '.login'])).trim();
+  const reviews = JSON.parse(
+    await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/reviews`]),
+  ) as { user?: { login?: string }; commit_id?: string }[];
+  return reviews.findLast((review) => review.user?.login === me)?.commit_id;
+};
+
+/**
+ * The files touched since this reviewer last looked, or `null` when it has not.
+ *
+ * Both failure modes here widen rather than narrow. A `compare` that throws -
+ * the old commit garbage-collected after a force-push, most likely - and a
+ * response at the file cap both fall back to the whole diff. Reviewing too much
+ * is the behaviour being fixed; reviewing nothing silently would be worse than
+ * the bug.
+ */
+const scopeSince = async (
+  repo: string,
+  number: string,
+  head: string,
+): Promise<Scope> => {
+  const since = await lastReviewedSha(repo, number);
+  if (since === undefined || since === head) return null;
+  try {
+    const compared = JSON.parse(
+      await gh(['api', `repos/${repo}/compare/${since}...${head}`]),
+    ) as { files?: { filename: string }[] };
+    const touched = compared.files?.map((file) => file.filename) ?? [];
+    const scope = scopeFromCompare(touched);
+    console.log(
+      scope === null
+        ? `Compare returned ${touched.length} files, at or past the ${COMPARE_FILE_CAP} the API caps at, so the list may be short. Reviewing the whole diff.`
+        : `Reviewing ${touched.length} file(s) changed since ${since.slice(0, 7)}.`,
+    );
+    return scope;
+  } catch (error) {
+    console.log(
+      `Could not compare ${since.slice(0, 7)}...${head.slice(0, 7)}, reviewing the whole diff: ${String(error)}`,
+    );
+    return null;
+  }
+};
+
+if (import.meta.main) {
+  /**
+   * `--whole-diff` turns the narrowing off, and an on-demand review always
+   * passes it.
+   *
+   * The narrowing asks what this **account** last reviewed, and dunxonu now
+   * reviews every push through `fast-code-review`. So a deep review asked for
+   * by name would scope itself to whatever changed since that automatic review
+   * ran, which is usually nothing, and report nothing: the one review somebody
+   * explicitly requested would be the one that looked at the least.
+   *
+   * Convergence is not the point here either. Nobody types the trigger twice by
+   * accident, so there is no treadmill to prevent.
+   */
+  const wholeDiff = Bun.argv.includes('--whole-diff');
+  const [executionFile, repo, number, reviewed] = Bun.argv
+    .slice(2)
+    .filter((argument) => !argument.startsWith('--'));
+  if (
+    executionFile === undefined ||
+    repo === undefined ||
+    number === undefined ||
+    reviewed === undefined
+  ) {
+    console.error(
+      'Usage: bun scripts/post-review.ts <execution-file> <owner/repo> <number> <reviewed-sha> [--whole-diff]',
+    );
+    process.exit(2);
+  }
+
+  const result = resultOf(await Bun.file(executionFile).text());
+  if (result.trim() === '') {
+    console.error('The reviewer produced no review. Not posting an empty one.');
+    process.exit(1);
+  }
+
+  /**
+   * A push during the run moves the head, and a review posted against the new one
+   * attaches findings to lines that were read from the old one. `concurrency`
+   * cancels a superseded run, but not reliably before it reaches this point.
+   * Being superseded is not a failure, so this exits 0.
+   */
+  const head = (
+    await gh(['api', `repos/${repo}/pulls/${number}`, '--jq', '.head.sha'])
+  ).trim();
+  if (head !== reviewed) {
+    console.log(
+      `Head moved from ${reviewed.slice(0, 7)} to ${head.slice(0, 7)} during the run. Not posting a review of the commit before it.`,
+    );
+    process.exit(0);
+  }
+
+  const files = JSON.parse(
+    await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/files`]),
+  ) as { filename: string; patch?: string }[];
+
+  const review = buildReview(
+    result,
+    commentableLines(files),
+    wholeDiff ? null : await scopeSince(repo, number, head),
+  );
+  if (review.body === '' && review.comments.length === 0) {
+    console.error('The reviewer produced no review. Not posting an empty one.');
+    process.exit(1);
+  }
+
+  const payload = JSON.stringify({ commit_id: reviewed, ...review });
+  const proc = Bun.spawn(
+    [
+      'gh',
+      'api',
+      '--method',
+      'POST',
+      `repos/${repo}/pulls/${number}/reviews`,
+      '--input',
+      '-',
+    ],
+    {
+      stdin: new TextEncoder().encode(payload),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  );
+  const [err, code] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) {
+    console.error(`Posting the review failed: ${err.trim()}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `${review.event.toLowerCase()}: ${review.comments.length} inline, ${
+      review.body.length
+    } bytes of body`,
+  );
+}

--- a/scripts/post-review.ts
+++ b/scripts/post-review.ts
@@ -293,9 +293,25 @@ if (import.meta.main) {
     process.exit(0);
   }
 
-  const files = JSON.parse(
-    await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/files`]),
-  ) as { filename: string; patch?: string }[];
+  /**
+   * `--slurp`, and then flattened.
+   *
+   * `gh api --paginate` alone prints one JSON document per page, so a pull
+   * request past the endpoint's 30-file default came back as `[...][...]` and
+   * `JSON.parse` threw: the run failed without posting a review, and only on
+   * the larger pull requests most worth reviewing. `--slurp` wraps the pages in
+   * an outer array, which is a different shape rather than the one wanted, so
+   * the pages are flattened back into the flat list the rest of this expects.
+   */
+  const pages = JSON.parse(
+    await gh([
+      'api',
+      '--paginate',
+      '--slurp',
+      `repos/${repo}/pulls/${number}/files`,
+    ]),
+  ) as unknown[];
+  const files = pages.flat() as { filename: string; patch?: string }[];
 
   const review = buildReview(result, commentableLines(files));
   if (review.body === '' && review.comments.length === 0) {

--- a/scripts/post-review.ts
+++ b/scripts/post-review.ts
@@ -2,7 +2,7 @@
  * Posts a `/code-review` run as one pull request review: a short summary, and each
  * finding as an inline comment on the line it is about.
  *
- * `bun scripts/post-review.ts <execution-file> <owner/repo> <number> <sha> [--whole-diff]`
+ * `bun scripts/post-review.ts <execution-file> <owner/repo> <number> <sha>`
  *
  * The whole review used to go in the body, which put a screen of prose in the
  * conversation for every push. GitHub takes the comments with the review in one
@@ -31,48 +31,6 @@ export interface Review {
 
 /** Line numbers on the right-hand side of the diff, which are the commentable ones. */
 export type Commentable = ReadonlyMap<string, ReadonlySet<number>>;
-
-/**
- * The files this review is allowed to report on, or `null` for all of them.
- *
- * `null` is the first review of a pull request, which sees the whole diff. Every
- * review after it sees only the files touched since the previous one.
- *
- * **This is what lets a pull request converge.** The reviewer runs against the
- * full diff on every push and is not deterministic over it, so unchanged code
- * gets a fresh chance to yield a finding on each run. Measured on #70: round 3
- * reported `rssMeanMiB` in `src/resources.ts` and a duplicated `Row` in
- * `servers/drivers/pair.ts`, and `git log` shows neither file was touched between
- * the first push and the commit that round reviewed. Both findings were equally
- * true and equally reportable in round 1. Five rounds, 24 findings, and never an
- * approval, because there was always something new to say about code nobody had
- * changed.
- *
- * Findings outside the scope are counted in the body rather than dropped in
- * silence: they were reportable earlier and are still true, and hiding them would
- * be this script deciding what the author may see.
- */
-export type Scope = ReadonlySet<string> | null;
-
-/**
- * GitHub's compare endpoint returns at most this many files and does not page
- * past them, so a longer list has been silently truncated.
- */
-export const COMPARE_FILE_CAP = 300;
-
-/**
- * The scope a compare result supports, or `null` when it cannot be trusted to be
- * complete.
- *
- * Suppressing a finding because its file fell off the end of a truncated list is
- * the exact failure this scoping exists to prevent: a genuinely new problem,
- * filed under "not repeated here", on a review that could then approve.
- *
- * Being wrong about the cap is safe in the direction that matters - too low
- * reviews more than it needs to, and only too high could suppress.
- */
-export const scopeFromCompare = (touched: readonly string[]): Scope =>
-  touched.length >= COMPARE_FILE_CAP ? null : new Set(touched);
 
 const VERDICT = /^VERDICT: (APPROVE|COMMENT)$/gm;
 
@@ -109,18 +67,31 @@ const resultOf = (raw: string): string => {
   return (parsed as { result?: string }).result ?? '';
 };
 
+const isFinding = (entry: unknown): entry is Finding =>
+  typeof entry === 'object' && entry !== null && 'summary' in entry;
+
+/**
+ * A fenced block into findings, keeping the entries that parsed.
+ *
+ * `every` rather than `some` used to decide this, which meant one malformed
+ * entry threw away the whole block: five findings where the last was truncated
+ * mid-object became no findings at all, and the raw JSON went into the review
+ * body as prose. Dropping the one bad entry loses strictly less.
+ *
+ * `some` rather than `every` is still doing the work `every` was there for,
+ * which is telling a findings array apart from any other JSON array the model
+ * might emit. An empty array is exempt because that is the clean review signal
+ * and has no entry to recognise; `buildReview` handles the difference between
+ * an empty array and no array at all.
+ */
 const parseFindings = (block: string): readonly Finding[] | undefined => {
   const body = block.trim();
   if (!body.startsWith('[')) return undefined;
   try {
     const parsed: unknown = JSON.parse(body);
     if (!Array.isArray(parsed)) return undefined;
-    return parsed.every(
-      (entry) =>
-        typeof entry === 'object' && entry !== null && 'summary' in entry,
-    )
-      ? (parsed as Finding[])
-      : undefined;
+    if (parsed.length > 0 && !parsed.some(isFinding)) return undefined;
+    return parsed.filter(isFinding);
   } catch {
     return undefined;
   }
@@ -167,16 +138,8 @@ const at = (finding: Finding): string =>
 export const buildReview = (
   result: string,
   commentable: Commentable,
-  scope: Scope = null,
 ): Review => {
-  const all = findingsIn(result);
-  const findings =
-    all === undefined || scope === null
-      ? all
-      : all.filter(
-          (finding) => finding.file === undefined || scope.has(finding.file),
-        );
-  const carried = (all?.length ?? 0) - (findings?.length ?? 0);
+  const findings = findingsIn(result);
   const sentinel = verdictIn(result);
   const clean =
     findings !== undefined &&
@@ -206,10 +169,7 @@ export const buildReview = (
   if (findings.length === 0) {
     return {
       event,
-      body:
-        carried === 0
-          ? 'Reviewed the diff and found nothing worth changing.'
-          : `Reviewed what changed since the last review and found nothing worth changing.\n\n${carriedNote(carried)}`,
+      body: 'Reviewed the diff and found nothing worth changing.',
       comments: [],
     };
   }
@@ -238,8 +198,6 @@ export const buildReview = (
 
   const plural = findings.length === 1 ? 'comment' : 'comments';
   const body = [`**Actionable ${plural} posted: ${comments.length}**`];
-
-  if (carried > 0) body.push('', carriedNote(carried));
 
   if (elsewhere.length > 0) {
     // Collapsed, so the conversation stays a summary rather than the review.
@@ -288,16 +246,6 @@ export const commentableLines = (
   return map;
 };
 
-/**
- * Said plainly rather than hidden: these findings are real, they are just not
- * about anything this push touched, so repeating them as new inline comments on
- * every round is what turns a review into a treadmill.
- */
-const carriedNote = (carried: number): string =>
-  `${carried} further finding${carried === 1 ? '' : 's'} ` +
-  `${carried === 1 ? 'is' : 'are'} in code untouched since the last review, ` +
-  'and so were reportable then. Not repeated here.';
-
 const gh = async (args: readonly string[]): Promise<string> => {
   const proc = Bun.spawn(['gh', ...args], { stdout: 'pipe', stderr: 'pipe' });
   const [out, err, code] = await Promise.all([
@@ -309,79 +257,8 @@ const gh = async (args: readonly string[]): Promise<string> => {
   return out;
 };
 
-/**
- * The commit this reviewer last posted a review against on this pull request, or
- * `undefined` if this is the first.
- *
- * By the authenticated account rather than a hardcoded login: the workflow runs
- * as whatever `DUNXONU_TOKEN` belongs to, and a review left by a human or by
- * another bot must not narrow what this one looks at.
- */
-const lastReviewedSha = async (
-  repo: string,
-  number: string,
-): Promise<string | undefined> => {
-  const me = (await gh(['api', 'user', '--jq', '.login'])).trim();
-  const reviews = JSON.parse(
-    await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/reviews`]),
-  ) as { user?: { login?: string }; commit_id?: string }[];
-  return reviews.findLast((review) => review.user?.login === me)?.commit_id;
-};
-
-/**
- * The files touched since this reviewer last looked, or `null` when it has not.
- *
- * Both failure modes here widen rather than narrow. A `compare` that throws -
- * the old commit garbage-collected after a force-push, most likely - and a
- * response at the file cap both fall back to the whole diff. Reviewing too much
- * is the behaviour being fixed; reviewing nothing silently would be worse than
- * the bug.
- */
-const scopeSince = async (
-  repo: string,
-  number: string,
-  head: string,
-): Promise<Scope> => {
-  const since = await lastReviewedSha(repo, number);
-  if (since === undefined || since === head) return null;
-  try {
-    const compared = JSON.parse(
-      await gh(['api', `repos/${repo}/compare/${since}...${head}`]),
-    ) as { files?: { filename: string }[] };
-    const touched = compared.files?.map((file) => file.filename) ?? [];
-    const scope = scopeFromCompare(touched);
-    console.log(
-      scope === null
-        ? `Compare returned ${touched.length} files, at or past the ${COMPARE_FILE_CAP} the API caps at, so the list may be short. Reviewing the whole diff.`
-        : `Reviewing ${touched.length} file(s) changed since ${since.slice(0, 7)}.`,
-    );
-    return scope;
-  } catch (error) {
-    console.log(
-      `Could not compare ${since.slice(0, 7)}...${head.slice(0, 7)}, reviewing the whole diff: ${String(error)}`,
-    );
-    return null;
-  }
-};
-
 if (import.meta.main) {
-  /**
-   * `--whole-diff` turns the narrowing off, and an on-demand review always
-   * passes it.
-   *
-   * The narrowing asks what this **account** last reviewed, and dunxonu now
-   * reviews every push through `fast-code-review`. So a deep review asked for
-   * by name would scope itself to whatever changed since that automatic review
-   * ran, which is usually nothing, and report nothing: the one review somebody
-   * explicitly requested would be the one that looked at the least.
-   *
-   * Convergence is not the point here either. Nobody types the trigger twice by
-   * accident, so there is no treadmill to prevent.
-   */
-  const wholeDiff = Bun.argv.includes('--whole-diff');
-  const [executionFile, repo, number, reviewed] = Bun.argv
-    .slice(2)
-    .filter((argument) => !argument.startsWith('--'));
+  const [executionFile, repo, number, reviewed] = Bun.argv.slice(2);
   if (
     executionFile === undefined ||
     repo === undefined ||
@@ -389,7 +266,7 @@ if (import.meta.main) {
     reviewed === undefined
   ) {
     console.error(
-      'Usage: bun scripts/post-review.ts <execution-file> <owner/repo> <number> <reviewed-sha> [--whole-diff]',
+      'Usage: bun scripts/post-review.ts <execution-file> <owner/repo> <number> <reviewed-sha>',
     );
     process.exit(2);
   }
@@ -420,11 +297,7 @@ if (import.meta.main) {
     await gh(['api', '--paginate', `repos/${repo}/pulls/${number}/files`]),
   ) as { filename: string; patch?: string }[];
 
-  const review = buildReview(
-    result,
-    commentableLines(files),
-    wholeDiff ? null : await scopeSince(repo, number, head),
-  );
+  const review = buildReview(result, commentableLines(files));
   if (review.body === '' && review.comments.length === 0) {
     console.error('The reviewer produced no review. Not posting an empty one.');
     process.exit(1);


### PR DESCRIPTION
Two reviewers, different jobs. `fast-code-review` keeps reviewing every push on free tiers. This one runs Claude at `/code-review high` over a checkout, and only when somebody types `@dunxonudeepreview`.

The trigger is not `@dunxonu` on purpose: that is the automatic reviewer's mention phrase, and its matcher requires a non-word character after it, so the two cannot both fire on one comment.

`post-review.ts` returns with a `--whole-diff` flag that this workflow always passes, because its narrowing would otherwise scope a requested deep review to whatever changed since the last automatic one: usually nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand deep pull-request reviews initiated from review comments.
  * Reviews now analyze the complete pull-request diff and post findings directly to relevant changed lines.
  * Findings outside applicable diff lines are included in the review summary.
  * Clean reviews can be approved automatically, while reviews with findings remain comment-only.
  * Review requests avoid duplicate processing and confirm when analysis begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->