### PR TITLE
test(example): narrate the rpc metrics series in the tour

### DIFF
--- a/examples/full/src/rpc/rpc.demo.ts
+++ b/examples/full/src/rpc/rpc.demo.ts
@@ -4,6 +4,8 @@ import {
   createGrpcWebTransport,
 } from '@connectrpc/connect-web';
 import { Logger } from '@dunx/core';
+import { RequestMetrics } from '@dunx/http';
+import { ConnectRegistry } from '@dunx/http/connect';
 import { GreetService } from './greet_pb.js';
 
 type GreetClient = Client<typeof GreetService>;
@@ -16,7 +18,11 @@ type GreetClient = Client<typeof GreetService>;
  * of them: the outbound half of Connect is the library's own one-liner.
  */
 export class RpcDemo {
-  constructor(private readonly logger: Logger) {}
+  constructor(
+    private readonly logger: Logger,
+    private readonly registry: ConnectRegistry,
+    private readonly metrics: RequestMetrics,
+  ) {}
 
   async demonstrate(url: string): Promise<void> {
     const connect: GreetClient = createClient(
@@ -52,6 +58,7 @@ export class RpcDemo {
     this.logger.info(`plain JSON POST -> ${curl.status} ${await curl.text()}`);
 
     await this.refusals(url, connect);
+    this.counted();
   }
 
   /** The two answers that are not a successful call. */
@@ -75,6 +82,18 @@ export class RpcDemo {
     this.logger.info(
       `native gRPC content-type -> ${grpc.status} ${body.code} ` +
         '(Connect and gRPC-Web only)',
+    );
+  }
+
+  /** An rpc matches no route, so it answers off the same fallback a 404 does. */
+  private counted(): void {
+    const mounted = new Set(this.registry.paths);
+    const series = this.metrics
+      .snapshot()
+      .routes.filter((route) => mounted.has(route.route));
+    this.logger.info(
+      `${series.length} rpc series over ${mounted.size} mounted methods - ` +
+        'each is counted under its own path, not in the (unmatched) one',
     );
   }
 }

--- a/examples/full/src/tour.test.ts
+++ b/examples/full/src/tour.test.ts
@@ -358,6 +358,12 @@ it('keeps one series per route pattern, and one for every miss', () => {
   );
 });
 
+it('gives each rpc a series of its own, not the miss bucket', () => {
+  const seen = /(\d+) rpc series over (\d+) mounted methods/.exec(tour.text);
+  expect(Number(seen?.[1])).toBeGreaterThan(0);
+  expect(seen?.[1]).toBe(seen?.[2]);
+});
+
 it('times queries at the driver, since drizzle cannot time one', () => {
   expect(tour.text).toMatch(
     /\d+ queries, timed at the bun:sqlite handle dunx constructs/,


### PR DESCRIPTION
Rule 4 follow-through on #125: the fix shipped with no example exercising it.

`RpcDemo` reads `RequestMetrics` after its calls and reports one series per mounted method; `tour.test.ts` asserts the count is non-zero and matches `ConnectRegistry.paths`. Verified it fails with the claimed-path branch forced off.

Two notes for the reviewer:

- The line is in `RpcDemo`, not `StatsDemo` where the other metrics narration lives. `stats` is a create-app feature and `rpc` is example-only, so wiring `StatsModule` to `RpcModule` makes a scaffolded app import a module it never gets. `bun run sync:templates` is what surfaced it.
- `examples/full/src/tour.test.ts` is now at exactly 800 lines, the `max-lines` cap for tests. The next tour assertion will not fit, so that file wants splitting before anyone adds one.