### PR TITLE
refactor(infra): one bounded close for the five that had written it

### DIFF
--- a/docs/architecture/message-brokers.md
+++ b/docs/architecture/message-brokers.md
@@ -94,6 +94,52 @@ exits. Compare `internal/notes/roadmap/queue-shutdown-sigterm.md`, where the
 equivalent Redis path does not exit at all: every AMQP shutdown path measured here
 released the event loop.
 
+## Bounding a close
+
+Five sites bound one: the three above, `JobEvents` closing a `QueueEvents`
+stream, and `QueueConsumer` draining a worker that reached readiness before a
+later queue failed to. All five call `closeWithin` in `packages/infra/src`, which
+answers whether the bound expired and leaves the warning to the caller.
+
+They were five hand-written copies of the same race until issue #127. Two fixes
+had reached one copy each and neither had been carried across: `unref` on the
+timer, and the `clearTimeout` that stops a resource which closed at once from
+holding the loop open for the rest of the window. That second one had cost a clean
+shutdown 2.37 s against 0.36 s where it was missing.
+
+`@dunx/dashboard`'s `bounded` is a sixth of the same shape and stays where it is.
+It bounds a read during a request and answers with a value a panel renders, where
+these bound a close during teardown and answer with a verdict. Sharing the four
+lines under them means either `@dunx/dashboard` depending on `@dunx/infra`, which
+it does not, or a timeout primitive on `@dunx/core`'s public surface.
+
+### Why a race and not a signal
+
+`ResiliencePolicy` bounds its own operation with `AbortSignal.timeout` combined
+with the caller's through `AbortSignal.any`, and says so. Every close here does
+the opposite, and the two hold together rather than contradicting.
+
+A signal bounds an operation that reads it. `ResiliencePolicy` awaits
+`op(signal)` rather than racing it, so an `op` that ignores its signal runs to
+completion and the bound does nothing - documented in
+[the resilience guide](../guide/25-resilience.md). That is a cost worth paying for
+work the caller wrote.
+
+None of the five closes takes a signal. bullmq's `Worker.close(force?)` and
+`QueueEvents.close()` take no argument that cancels, and neither do
+rabbitmq-client's `Consumer`, `Publisher` and `Connection` closes. So there is
+nothing to hand a signal to, and a bound that has to settle against a library that
+will not cooperate can only be a race. The rule both halves follow: **a signal
+where the operation takes one, a race where it does not.**
+
+What a signal would change is the handler timeout - `jobTimeoutMs` and
+`handlerTimeoutMs`, where the work is the consumer's own method and could read
+one. Today it is not cancelled, only stopped being waited for, so a handler that
+outran its bound can act twice on one unit of work. Both
+[guide 15](../guide/15-queues.md) and [guide 28](../guide/28-message-brokers.md)
+say so. Changing that is cooperative cancellation through the handler signature,
+not a change to how the bound is measured.
+
 **Traces cross the broker.** `AmqpPublisher.publish` stamps the scope's
 `traceparent` and `tracestate` into the message headers and `AmqpDispatcher`
 continues that trace with a span of its own. Nothing in `@dunx/infra/queue` does

--- a/docs/architecture/message-brokers.md
+++ b/docs/architecture/message-brokers.md
@@ -129,7 +129,14 @@ None of the five closes takes a signal. bullmq's `Worker.close(force?)` and
 `QueueEvents.close()` take no argument that cancels, and neither do
 rabbitmq-client's `Consumer`, `Publisher` and `Connection` closes. So there is
 nothing to hand a signal to, and a bound that has to settle against a library that
-will not cooperate can only be a race. The rule both halves follow: **a signal
+will not cooperate can only be a race.
+
+An unsignalled close still runs to its own end, and the two ends are both
+measured. `Consumer.close()` settles 19.7 s after the broker went away, in the
+probe above. `QueueEvents.close()` against an unreachable broker neither resolves
+nor rejects on bullmq 6.3.4: the blocking read reconnects on a growing backoff
+past `autoReconnect: false`, which is what `JobEvents` records. A bound that
+stops waiting is the only one that covers both. The rule both halves follow: **a signal
 where the operation takes one, a race where it does not.**
 
 What a signal would change is the handler timeout - `jobTimeoutMs` and

--- a/docs/architecture/queues.md
+++ b/docs/architecture/queues.md
@@ -316,6 +316,9 @@ injected into the handler records `container:shutdown` in its `onShutdown`, and 
 test requires the sequence `slow:started`, `slow:finished`, `container:shutdown`,
 plus zero open sockets afterwards.
 
+Two of those closes are bounded, and share one helper with `@dunx/infra/amqp`'s
+three: see [Message brokers](./message-brokers.md), "Bounding a close".
+
 ### A forked child's colour, which is the parent's question
 
 bullmq forks a sandboxed processor with `stdio: 'pipe'` and pipes the child's

--- a/packages/core/src/resilience/policy.ts
+++ b/packages/core/src/resilience/policy.ts
@@ -26,6 +26,12 @@ export class ResiliencePolicy {
    * the caller's through `AbortSignal.any`, rather than a `setTimeout` and a
    * `clearTimeout` in a `finally`. Both are Web standards Bun implements, and the
    * timer is the runtime's to cancel.
+   *
+   * That is the primitive where the operation takes the signal, and it is why
+   * this awaits `op(signal)` rather than racing it. A bound on an operation that
+   * takes none - a broker client's `close()`, which is what `@dunx/infra` bounds
+   * during teardown - can only be a race, since a signal would abort nothing and
+   * the call would never settle.
    */
   async run<T>(op: (signal: AbortSignal) => Promise<T>): Promise<T> {
     return this.#attempts(op);

--- a/packages/core/src/resilience/policy.ts
+++ b/packages/core/src/resilience/policy.ts
@@ -30,8 +30,8 @@ export class ResiliencePolicy {
    * That is the primitive where the operation takes the signal, and it is why
    * this awaits `op(signal)` rather than racing it. A bound on an operation that
    * takes none - a broker client's `close()`, which is what `@dunx/infra` bounds
-   * during teardown - can only be a race, since a signal would abort nothing and
-   * the call would never settle.
+   * during teardown - can only be a race: an unsignalled close runs to its own
+   * end, which is seconds past the bound for some and never for others.
    */
   async run<T>(op: (signal: AbortSignal) => Promise<T>): Promise<T> {
     return this.#attempts(op);

--- a/packages/dashboard/src/api/bounded.ts
+++ b/packages/dashboard/src/api/bounded.ts
@@ -6,6 +6,13 @@
  *
  * The fallback is a value rather than a rejection: an unreachable queue still gets
  * a row saying so.
+ *
+ * Not shared with `@dunx/infra`'s `closeWithin`, which bounds the same way. That
+ * one bounds a close during teardown and answers whether the bound expired; this
+ * bounds a read during a request and answers with a value a panel can render, so
+ * neither is the other with an argument added. Sharing the four lines under them
+ * would mean either `@dunx/dashboard` depending on `@dunx/infra`, which it does
+ * not and must not, or a timeout primitive on `@dunx/core`'s public surface.
  */
 export const bounded = async <T>(
   work: () => Promise<T>,

--- a/packages/infra/src/amqp/connection.ts
+++ b/packages/infra/src/amqp/connection.ts
@@ -8,6 +8,7 @@ import {
   type Publisher,
   type PublisherProps,
 } from 'rabbitmq-client';
+import { closeWithin } from '../close-within.js';
 import { AmqpOptions } from './options.js';
 
 /**
@@ -110,19 +111,12 @@ export class AmqpConnection implements OnShutdown {
     if (connection === undefined) return;
     this.#connection = undefined;
 
-    const timedOut = Symbol('timed out');
-    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const outcome = await Promise.race([
-        connection.close(),
-        new Promise<symbol>((resolve) => {
-          timer = setTimeout(
-            () => resolve(timedOut),
-            this.#options.closeTimeoutMs,
-          );
-        }),
-      ]);
-      if (outcome === timedOut) {
+      const timedOut = await closeWithin(
+        connection,
+        this.#options.closeTimeoutMs,
+      );
+      if (timedOut) {
         this.#logger.warn(
           'the AMQP connection did not close within ' +
             `${this.#options.closeTimeoutMs} ms`,
@@ -131,9 +125,8 @@ export class AmqpConnection implements OnShutdown {
     } catch (error) {
       this.#logger.warn('the AMQP connection failed to close', error);
     } finally {
-      // The loser of the race stays pending: a `Bun.sleep` here would hold the
-      // loop open for the whole window on every clean shutdown.
-      clearTimeout(timer);
+      // A socket still open is what keeps the process from exiting, so this runs
+      // whether the close finished, timed out or threw.
       connection.unsafeDestroy();
     }
   }

--- a/packages/infra/src/amqp/publisher.ts
+++ b/packages/infra/src/amqp/publisher.ts
@@ -7,6 +7,7 @@ import {
   type OnShutdown,
 } from '@dunx/core';
 import type { Envelope, Publisher } from 'rabbitmq-client';
+import { closeWithin } from '../close-within.js';
 import { AmqpConnection } from './connection.js';
 import { AmqpOptions } from './options.js';
 
@@ -130,19 +131,12 @@ export class AmqpPublisher implements OnShutdown {
     if (publisher === undefined) return;
     this.#publisher = undefined;
 
-    const timedOut = Symbol('timed out');
-    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const outcome = await Promise.race([
-        publisher.close(),
-        new Promise<symbol>((resolve) => {
-          timer = setTimeout(
-            () => resolve(timedOut),
-            this.#options.closeTimeoutMs,
-          );
-        }),
-      ]);
-      if (outcome === timedOut) {
+      const timedOut = await closeWithin(
+        publisher,
+        this.#options.closeTimeoutMs,
+      );
+      if (timedOut) {
         this.#logger.warn(
           'the AMQP publisher did not close within ' +
             `${this.#options.closeTimeoutMs} ms`,
@@ -150,10 +144,6 @@ export class AmqpPublisher implements OnShutdown {
       }
     } catch (error) {
       this.#logger.warn('the AMQP publisher failed to close', error);
-    } finally {
-      // The loser of the race stays pending; without this a channel that closed
-      // at once would hold the loop open for the rest of the window.
-      clearTimeout(timer);
     }
   }
 }

--- a/packages/infra/src/amqp/subscriber.ts
+++ b/packages/infra/src/amqp/subscriber.ts
@@ -1,5 +1,6 @@
 import { Logger, RequestContext, type App } from '@dunx/core';
 import type { Consumer, ConsumerProps } from 'rabbitmq-client';
+import { closeWithin } from '../close-within.js';
 import { ErrorThrottle } from '../error-throttle.js';
 import { AmqpConnection } from './connection.js';
 import { AmqpDispatcher, type DispatchSettings } from './dispatcher.js';
@@ -174,19 +175,12 @@ export class AmqpSubscriber {
   /** Bounded, and never rejecting: one consumer that will not close must not stop
    * the rest of teardown, which is what closes the socket under it. */
   async #drain(consumer: Consumer): Promise<void> {
-    const timedOut = Symbol('timed out');
-    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const outcome = await Promise.race([
-        consumer.close(),
-        new Promise<symbol>((resolve) => {
-          timer = setTimeout(
-            () => resolve(timedOut),
-            this.#options.drainTimeoutMs,
-          );
-        }),
-      ]);
-      if (outcome === timedOut) {
+      const timedOut = await closeWithin(
+        consumer,
+        this.#options.drainTimeoutMs,
+      );
+      if (timedOut) {
         this.#logger.warn(
           `an AMQP consumer on ${consumer.queue} did not drain within ` +
             `${this.#options.drainTimeoutMs} ms`,
@@ -194,10 +188,6 @@ export class AmqpSubscriber {
       }
     } catch (error) {
       this.#logger.warn('an AMQP consumer failed to close', error);
-    } finally {
-      // The loser of the race stays pending: a consumer that closed at once would
-      // otherwise hold the loop open for the whole window.
-      clearTimeout(timer);
     }
   }
 

--- a/packages/infra/src/close-within.test.ts
+++ b/packages/infra/src/close-within.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import { closeWithin } from './close-within.js';
+
+/**
+ * Shared by `@dunx/infra/queue`'s two closes and all three of
+ * `@dunx/infra/amqp`'s, which had written the same race five times.
+ */
+describe('closeWithin', () => {
+  /** bullmq's own shape: `close()` returns the promise it already started, so a
+   * second call with `force` is the same pending promise and escalates nothing. */
+  const bullmqLike = (settles: boolean) => {
+    const calls: (boolean | undefined)[] = [];
+    let closing: Promise<void> | undefined;
+    return {
+      calls,
+      close(force?: boolean): Promise<void> {
+        calls.push(force);
+        closing ??= settles
+          ? Promise.resolve()
+          : new Promise<void>(() => {
+              /* a close waiting on a broker that is gone */
+            });
+        return closing;
+      },
+    };
+  };
+
+  it('returns as soon as a close that finishes does', async () => {
+    const worker = bullmqLike(true);
+    const started = Bun.nanoseconds();
+    expect(await closeWithin(worker, 5_000)).toBe(false);
+    // Returned on the close, not on the bound.
+    expect((Bun.nanoseconds() - started) / 1e6).toBeLessThan(1_000);
+    expect(worker.calls).toEqual([undefined]);
+  });
+
+  it('stops waiting on a close that never finishes', async () => {
+    const worker = bullmqLike(false);
+    const started = Bun.nanoseconds();
+    expect(await closeWithin(worker, 40)).toBe(true);
+    const elapsedMs = (Bun.nanoseconds() - started) / 1e6;
+    // The point: it settles. Without the bound this test would never return.
+    expect(elapsedMs).toBeGreaterThanOrEqual(35);
+    expect(elapsedMs).toBeLessThan(2_000);
+    // And it did not try to escalate, which bullmq would have ignored anyway.
+    expect(worker.calls).toEqual([undefined]);
+  });
+
+  /** The four sites that warn also catch: a close that throws is the caller's to
+   * report, with the name of the thing that failed. */
+  it('lets the close reject on its own', async () => {
+    await expect(
+      closeWithin({ close: () => Promise.reject(new Error('boom')) }, 1_000),
+    ).rejects.toThrow('boom');
+  });
+
+  /** Without this a resource that closed at once held the loop open for the rest
+   * of the bound, and a clean shutdown took 2.37 s against 0.36 s. */
+  it('clears the timer for a close that finished in time', async () => {
+    const started = Bun.nanoseconds();
+    await closeWithin(bullmqLike(true), 30_000);
+    expect((Bun.nanoseconds() - started) / 1e6).toBeLessThan(500);
+  });
+});

--- a/packages/infra/src/close-within.test.ts
+++ b/packages/infra/src/close-within.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 import { closeWithin } from './close-within.js';
 
 /**
@@ -54,11 +54,27 @@ describe('closeWithin', () => {
     ).rejects.toThrow('boom');
   });
 
-  /** Without this a resource that closed at once held the loop open for the rest
-   * of the bound, and a clean shutdown took 2.37 s against 0.36 s. */
+  /**
+   * Without this a resource that closed at once held the loop open for the rest
+   * of the bound, and a clean shutdown took 2.37 s against 0.36 s.
+   *
+   * Asserted against the handle rather than the clock. The timer is unref'd, so a
+   * run that never cleared it would still return at the close and still finish
+   * inside any elapsed-time bound - which is what the first version of this test
+   * measured, and it passed with the `clearTimeout` deleted.
+   */
   it('clears the timer for a close that finished in time', async () => {
-    const started = Bun.nanoseconds();
-    await closeWithin(bullmqLike(true), 30_000);
-    expect((Bun.nanoseconds() - started) / 1e6).toBeLessThan(500);
+    const arm = spyOn(globalThis, 'setTimeout');
+    const disarm = spyOn(globalThis, 'clearTimeout');
+    try {
+      expect(await closeWithin(bullmqLike(true), 30_000)).toBe(false);
+      expect(arm).toHaveBeenCalledTimes(1);
+      expect(disarm).toHaveBeenCalledTimes(1);
+      // The one it cleared is the one it armed, not some other pending timer.
+      expect(arm.mock.results[0]?.value).toBe(disarm.mock.calls[0]?.[0]);
+    } finally {
+      arm.mockRestore();
+      disarm.mockRestore();
+    }
   });
 });

--- a/packages/infra/src/close-within.ts
+++ b/packages/infra/src/close-within.ts
@@ -1,0 +1,35 @@
+/** The half of a bullmq `Worker` or `QueueEvents`, or a rabbitmq-client
+ * `Consumer`, `Publisher` or `Connection`, that {@link closeWithin} needs. */
+export interface Closable {
+  close(): Promise<unknown>;
+}
+
+/**
+ * `closable.close()`, waited on for at most `timeoutMs`. Resolves `true` when the
+ * bound expired and `false` when the close finished first, so the caller decides
+ * whether that is worth a warning and what to do next. A close that rejects
+ * rejects here; the close is never escalated, since none of these can be.
+ *
+ * Shared by the five sites that had written this race by hand. The timer is
+ * cleared in a `finally`, because the loser of the race stays pending, and it is
+ * unref'd, because a bound on how long to wait is not a reason to stay alive. A
+ * race rather than the `AbortSignal.timeout` `ResiliencePolicy` prefers: none of
+ * the five closes takes a signal. The argument is in
+ * docs/architecture/message-brokers.md, "Bounding a close".
+ */
+export const closeWithin = async (
+  closable: Closable,
+  timeoutMs: number,
+): Promise<boolean> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<true>((resolve) => {
+    timer = setTimeout(() => resolve(true), timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([closable.close().then(() => false), expired]);
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/packages/infra/src/queue/events.ts
+++ b/packages/infra/src/queue/events.ts
@@ -1,5 +1,6 @@
 import { Logger, type OnShutdown } from '@dunx/core';
 import { QueueEvents } from 'bullmq';
+import { closeWithin } from '../close-within.js';
 import { QueueConnection } from './connection.js';
 import { QueueOptions } from './options.js';
 
@@ -105,28 +106,15 @@ export class JobEvents implements OnShutdown {
   /** Bounded, and never rejecting: one stream that will not close must not stop
    * the rest of shutdown, which is what closes the socket under it. */
   async #close(name: string, events: QueueEvents): Promise<void> {
-    const timedOut = Symbol('timed out');
-    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const outcome = await Promise.race([
-        events.close(),
-        new Promise<symbol>((resolve) => {
-          timer = setTimeout(() => resolve(timedOut), CLOSE_TIMEOUT_MS);
-        }),
-      ]);
-      if (outcome === timedOut) {
+      const timedOut = await closeWithin(events, CLOSE_TIMEOUT_MS);
+      if (timedOut) {
         this.#logger.warn(
           `the "${name}" queue events did not close within ${CLOSE_TIMEOUT_MS} ms`,
         );
       }
     } catch (error) {
       this.#logger.warn(`the "${name}" queue events failed to close`, error);
-    } finally {
-      // The loser of the race stays pending. A `Bun.sleep` here held the loop
-      // open for the whole window whenever `close()` won, so a clean shutdown
-      // took 2.37s against 0.36s - the delay this exists to prevent, caused by
-      // the code preventing it.
-      clearTimeout(timer);
     }
   }
 }

--- a/packages/infra/src/queue/worker.test.ts
+++ b/packages/infra/src/queue/worker.test.ts
@@ -17,12 +17,7 @@ import { QueueError, QueueErrorCode } from './errors.js';
 import { QueueMetrics } from './metrics.js';
 import { QueueModule, type QueueModuleSettings } from './module.js';
 import { JobPublisher } from './publisher.js';
-import {
-  closeWithin,
-  QueueConsumer,
-  WorkerFactory,
-  type WorkerApp,
-} from './worker.js';
+import { QueueConsumer, WorkerFactory, type WorkerApp } from './worker.js';
 
 const url = defaultRedisUrl();
 
@@ -526,53 +521,6 @@ describe('WorkerFactory.attach', () => {
     await consumer.stop();
 
     await app.shutdown();
-  });
-});
-
-/**
- * The close policy a failed start uses for a worker that **did** become ready.
- * bullmq starts consuming at readiness, so forcing it abandons whatever it holds;
- * waiting on it without a bound waits on the broker that just failed.
- */
-describe('closeWithin', () => {
-  /** bullmq's own shape: `close()` returns the promise it already started, so a
-   * second call with `force` is the same pending promise and escalates nothing. */
-  const bullmqLike = (settles: boolean) => {
-    const calls: (boolean | undefined)[] = [];
-    let closing: Promise<void> | undefined;
-    return {
-      calls,
-      close(force?: boolean): Promise<void> {
-        calls.push(force);
-        closing ??= settles
-          ? Promise.resolve()
-          : new Promise<void>(() => {
-              /* a close waiting on a broker that is gone */
-            });
-        return closing;
-      },
-    };
-  };
-
-  it('returns as soon as a close that finishes does', async () => {
-    const worker = bullmqLike(true);
-    const started = Bun.nanoseconds();
-    await closeWithin(worker, 5_000);
-    // Returned on the close, not on the bound.
-    expect((Bun.nanoseconds() - started) / 1e6).toBeLessThan(1_000);
-    expect(worker.calls).toEqual([undefined]);
-  });
-
-  it('stops waiting on a close that never finishes', async () => {
-    const worker = bullmqLike(false);
-    const started = Bun.nanoseconds();
-    await closeWithin(worker, 40);
-    const elapsedMs = (Bun.nanoseconds() - started) / 1e6;
-    // The point: it settles. Without the bound this test would never return.
-    expect(elapsedMs).toBeGreaterThanOrEqual(35);
-    expect(elapsedMs).toBeLessThan(2_000);
-    // And it did not try to escalate, which bullmq would have ignored anyway.
-    expect(worker.calls).toEqual([undefined]);
   });
 });
 

--- a/packages/infra/src/queue/worker.ts
+++ b/packages/infra/src/queue/worker.ts
@@ -11,6 +11,7 @@ import {
   type ResolvedModule,
 } from '@dunx/core';
 import { Worker, type Job } from 'bullmq';
+import { closeWithin } from '../close-within.js';
 import { ErrorThrottle } from '../error-throttle.js';
 import { QueueConnection } from './connection.js';
 import { declares, JobDispatcher, metricsIn } from './dispatcher.js';
@@ -44,49 +45,19 @@ export const childColourEnv = (
   return { ...env, FORCE_COLOR: '1' };
 };
 
-/** The half of a bullmq `Worker` {@link closeWithin} needs. */
-interface Closable {
-  close(force?: boolean): Promise<void>;
-}
-
 /**
  * How long a worker that reached readiness gets to finish what it is holding
  * before `start()` stops waiting for it. Workers drain concurrently, so this
  * bounds the whole teardown rather than each one.
+ *
+ * `closeWithin` stops waiting rather than forcing, which is the only decision
+ * available: bullmq's `close()` returns the promise a first call started, so a
+ * later `close(true)` is the same pending promise and escalates nothing. Which is
+ * why the choice is made per worker before either is called - a worker that never
+ * became ready is force-closed outright, and only one that may be holding a job is
+ * drained through here.
  */
 const DRAIN_ON_FAILED_START_MS = 5_000;
-
-/**
- * A graceful close, waited on for at most `ms`.
- *
- * **The close cannot be escalated**, so this stops waiting rather than forcing.
- * bullmq 6.0.5's `Worker.close` returns the `closing` promise it already started
- * (`worker.js:736`), so a later `close(true)` is the same pending promise and
- * forces nothing. A first call decides which kind of close a worker gets, and
- * that is the only decision available.
- *
- * Which is why the choice is made per worker before either is called: a worker
- * that never became ready is force-closed outright, and only one that may be
- * holding a job is drained through here.
- *
- * The timer is unref'd, so a worker that closes in time cannot leave it holding
- * the process open.
- */
-export const closeWithin = async (
-  worker: Closable,
-  ms: number,
-): Promise<void> => {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const gaveUp = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, ms);
-    timer.unref?.();
-  });
-  try {
-    await Promise.race([worker.close(), gaveUp]);
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-  }
-};
 
 /** How often one queue's worker may report a connection error. */
 const ERROR_LOG_INTERVAL_MS = 30_000;


### PR DESCRIPTION
Closes #127.

The five hand-rolled `Promise.race([close(), timer])` copies now call one
`closeWithin` in `packages/infra/src/`, which answers whether the bound expired
and leaves the warning to the caller. The `unref` and the `clearTimeout` that had
each reached one copy now apply to all five.

Two things the issue asked to be decided rather than assumed:

- **`@dunx/dashboard`'s `bounded` stays put.** It bounds a read and returns a
  value; these bound a close and return a verdict. Sharing them costs either a
  `@dunx/dashboard` -> `@dunx/infra` dependency or a timeout primitive on
  `@dunx/core`'s public surface.
- **The primitive stays a race, and `ResiliencePolicy`'s comment is amended to
  say why** rather than reading as a blanket preference: a signal where the
  operation takes one, a race where it does not. None of the five closes takes a
  signal. `docs/architecture/message-brokers.md`, "Bounding a close", carries the
  argument and names what cooperative cancellation would change - the handler
  timeout, not the bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Resource shutdowns now use consistent timeout handling across broker connections, publishers, subscribers, queues, and workers.
  - Shutdown operations stop waiting after their configured time limit while preserving warnings and error reporting.
  - Timers are cleaned up when shutdown completes promptly, preventing unnecessary lingering timers.

- **Documentation**
  - Added guidance on shutdown ordering, bounded close operations, timeout strategies, and signal-based timeouts.

- **Tests**
  - Added coverage for successful, delayed, timed-out, and failed resource closures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->