### PR TITLE
fix(example): pull the service images from the first registry that answers

### DIFF
--- a/examples/full/compose.yml
+++ b/examples/full/compose.yml
@@ -2,12 +2,16 @@
 # the rate limiter's shared store and the websocket relay, Postgres for the
 # relay's LISTEN/NOTIFY backend, and RabbitMQ for the message broker routes.
 #
-# Images come from **public.ecr.aws** rather than Docker Hub, which rate limits
-# anonymous pulls by IP. A CI runner shares its IP with every other runner on the
-# host, so a Hub pull is a coin toss that fails as a red build with nothing wrong
-# in the change. ECR throttles anonymous pulls too and it is not a free pass -
-# three rapid pulls while writing this hit `toomanyrequests` - but its budget is
-# far larger and it is not shared with every anonymous puller on the internet.
+# Every image is a variable, defaulting to the Docker Hub name. `services.ts`
+# overrides all three with one registry's spelling and pulls, falling to the next
+# registry when that one answers `toomanyrequests`: every registry rate limits
+# anonymous pulls by IP, and a CI runner shares its IP with every other runner on
+# the host, so any single registry is a coin toss that fails as a red build with
+# nothing wrong in the change. Measured 2026-09-13, Docker Hub and mirror.gcr.io
+# served all three and public.ecr.aws was throttling two of them.
+#
+# The registry list is in `services.ts` and nowhere else, so a fourth provider is
+# one entry there. `docker compose up` by hand uses the defaults below.
 #
 # MinIO publishes to neither ECR nor a mirror, which is why S3 is absent here: the
 # example's storage is `LocalStorageOptions` on a temp dir, and the one suite that
@@ -22,7 +26,7 @@ name: dunx-example-full
 
 services:
   valkey:
-    image: public.ecr.aws/valkey/valkey:8-alpine
+    image: ${DUNX_VALKEY_IMAGE:-valkey/valkey:8-alpine}
     ports:
       - '6379:6379'
     healthcheck:
@@ -33,7 +37,7 @@ services:
       start_period: 2s
 
   postgres:
-    image: public.ecr.aws/docker/library/postgres:17-alpine
+    image: ${DUNX_POSTGRES_IMAGE:-postgres:17-alpine}
     environment:
       POSTGRES_USER: dunx
       POSTGRES_PASSWORD: dunx
@@ -48,7 +52,7 @@ services:
       start_period: 2s
 
   rabbitmq:
-    image: public.ecr.aws/docker/library/rabbitmq:4-alpine
+    image: ${DUNX_RABBITMQ_IMAGE:-rabbitmq:4-alpine}
     ports:
       - '5672:5672'
     healthcheck:

--- a/examples/full/services.ts
+++ b/examples/full/services.ts
@@ -1,99 +1,44 @@
 /**
  * `compose pull` across registries, then `compose up --wait`.
  *
- * Anonymous pulls are rate limited per IP and a CI runner shares its IP with
- * every other runner on the host, so the pull is the one step here that fails
- * for reasons that have nothing to do with the change under test. Retrying one
- * registry was not enough: it broke two runs inside an hour.
+ * The registry list and the fallback are `scripts/registries.ts`, so a second
+ * compose file shares them rather than writing its own. What is here is what is
+ * this example's: which images it needs, and the compose call.
  *
- * So a round tries each registry in turn, and a round that fails everywhere
- * backs off and starts again. `up --wait` afterwards is offline once the images
- * are local, and it is the part that must not be retried blindly: a container
- * that fails its healthcheck is a real failure.
+ * `up --wait` is offline once the images are local, and it is the part that must
+ * not be retried blindly: a container that fails its healthcheck is a real
+ * failure. It gets the registry that served, or compose would resolve the
+ * defaults in `compose.yml` and pull a second time.
  */
+import {
+  fromFirstRegistry,
+  imageRefs,
+  type Registry,
+} from '../../scripts/registries.js';
 
-/** Each image as Docker Hub spells it in full, including the `library/`
- * namespace an official image lets a `docker pull` leave out. */
+/** Each image as Docker Hub spells it in full, keyed by the variable
+ * `compose.yml` reads it from. */
 const IMAGES = Object.freeze({
   DUNX_VALKEY_IMAGE: 'valkey/valkey:8-alpine',
   DUNX_POSTGRES_IMAGE: 'library/postgres:17-alpine',
   DUNX_RABBITMQ_IMAGE: 'library/rabbitmq:4-alpine',
 });
 
-interface Registry {
-  readonly name: string;
-  /** This registry's spelling of a Docker Hub path. */
-  readonly ref: (path: string) => string;
-}
-
-/**
- * Tried in order, and adding a fourth is one entry: nothing else here names a
- * registry, and `compose.yml` serves whatever this sets.
- *
- * Measured 2026-09-13: Hub and mirror.gcr.io served all three, public.ecr.aws
- * answered `toomanyrequests` for two of them.
- */
-const REGISTRIES: readonly Registry[] = [
-  { name: 'docker.io', ref: (path) => `docker.io/${path}` },
-  {
-    name: 'public.ecr.aws',
-    // Hub's official images sit under `docker/library` here, and everything
-    // else under the publisher's own namespace.
-    ref: (path) =>
-      path.startsWith('library/')
-        ? `public.ecr.aws/docker/${path}`
-        : `public.ecr.aws/${path}`,
-  },
-  // A pull-through cache of Hub, so a Hub path resolves here unchanged.
-  { name: 'mirror.gcr.io', ref: (path) => `mirror.gcr.io/${path}` },
-];
-
-const ROUNDS = 3;
-
-const imagesFrom = (registry: Registry): Record<string, string> =>
-  Object.fromEntries(
-    Object.entries(IMAGES).map(([key, path]) => [key, registry.ref(path)]),
-  );
-
-const run = async (
+const compose = async (
   args: readonly string[],
-  images?: Record<string, string>,
+  registry: Registry,
 ): Promise<number> => {
   const proc = Bun.spawn(['docker', 'compose', ...args], {
     cwd: import.meta.dir,
-    ...(images === undefined ? {} : { env: { ...process.env, ...images } }),
+    env: { ...process.env, ...imageRefs(registry, IMAGES) },
     stdout: 'inherit',
     stderr: 'inherit',
   });
   return proc.exited;
 };
 
-/** Answers with the registry that served, so `up` starts what `pull` fetched
- * rather than resolving `compose.yml`'s defaults and pulling again. */
-const pull = async (): Promise<Registry> => {
-  for (let round = 1; round <= ROUNDS; round += 1) {
-    for (const registry of REGISTRIES) {
-      if ((await run(['pull', '--quiet'], imagesFrom(registry))) === 0) {
-        return registry;
-      }
-      console.log(`pull from ${registry.name} failed`);
-    }
-    if (round === ROUNDS) break;
-    // 2s then 4s, and the registries come before the sleep: another provider is
-    // a faster retry than waiting out one provider's throttle window.
-    const waitMs = 2000 * 2 ** (round - 1);
-    console.log(
-      `every registry failed, round ${round}/${ROUNDS}; retrying in ${waitMs / 1000}s`,
-    );
-    await Bun.sleep(waitMs);
-  }
-  throw new Error(
-    `docker compose pull failed ${ROUNDS} times from each of ` +
-      `${REGISTRIES.map((registry) => registry.name).join(', ')}. The last one ` +
-      'is above; a rate limit is the usual reason and it clears on its own.',
-  );
-};
-
-const served = await pull();
+const served = await fromFirstRegistry(
+  async (registry) => (await compose(['pull', '--quiet'], registry)) === 0,
+);
 console.log(`images from ${served.name}`);
-process.exit(await run(['up', '-d', '--wait'], imagesFrom(served)));
+process.exit(await compose(['up', '-d', '--wait'], served));

--- a/examples/full/services.ts
+++ b/examples/full/services.ts
@@ -1,46 +1,99 @@
 /**
- * `compose pull` with retries, then `compose up --wait`.
+ * `compose pull` across registries, then `compose up --wait`.
  *
- * A registry throttles anonymous pulls and a CI runner shares its IP with every
- * other runner on the host, so the pull is the one step here that fails for
- * reasons that have nothing to do with the change under test. Moving off Docker
- * Hub to public.ecr.aws bought a much larger budget and not an unlimited one:
- * `toomanyrequests: Rate exceeded` turned up on main the first time this ran, and
- * three pulls in a row hit it locally while the file was being written.
+ * Anonymous pulls are rate limited per IP and a CI runner shares its IP with
+ * every other runner on the host, so the pull is the one step here that fails
+ * for reasons that have nothing to do with the change under test. Retrying one
+ * registry was not enough: it broke two runs inside an hour.
  *
- * So the pull is separated from the start and retried. `up --wait` afterwards is
- * offline once the images are local, and it is the part that must not be retried
- * blindly: a container that fails its healthcheck is a real failure.
+ * So a round tries each registry in turn, and a round that fails everywhere
+ * backs off and starts again. `up --wait` afterwards is offline once the images
+ * are local, and it is the part that must not be retried blindly: a container
+ * that fails its healthcheck is a real failure.
  */
-const ATTEMPTS = 5;
 
-const run = async (args: readonly string[]): Promise<number> => {
+/** Each image as Docker Hub spells it in full, including the `library/`
+ * namespace an official image lets a `docker pull` leave out. */
+const IMAGES = Object.freeze({
+  DUNX_VALKEY_IMAGE: 'valkey/valkey:8-alpine',
+  DUNX_POSTGRES_IMAGE: 'library/postgres:17-alpine',
+  DUNX_RABBITMQ_IMAGE: 'library/rabbitmq:4-alpine',
+});
+
+interface Registry {
+  readonly name: string;
+  /** This registry's spelling of a Docker Hub path. */
+  readonly ref: (path: string) => string;
+}
+
+/**
+ * Tried in order, and adding a fourth is one entry: nothing else here names a
+ * registry, and `compose.yml` serves whatever this sets.
+ *
+ * Measured 2026-09-13: Hub and mirror.gcr.io served all three, public.ecr.aws
+ * answered `toomanyrequests` for two of them.
+ */
+const REGISTRIES: readonly Registry[] = [
+  { name: 'docker.io', ref: (path) => `docker.io/${path}` },
+  {
+    name: 'public.ecr.aws',
+    // Hub's official images sit under `docker/library` here, and everything
+    // else under the publisher's own namespace.
+    ref: (path) =>
+      path.startsWith('library/')
+        ? `public.ecr.aws/docker/${path}`
+        : `public.ecr.aws/${path}`,
+  },
+  // A pull-through cache of Hub, so a Hub path resolves here unchanged.
+  { name: 'mirror.gcr.io', ref: (path) => `mirror.gcr.io/${path}` },
+];
+
+const ROUNDS = 3;
+
+const imagesFrom = (registry: Registry): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(IMAGES).map(([key, path]) => [key, registry.ref(path)]),
+  );
+
+const run = async (
+  args: readonly string[],
+  images?: Record<string, string>,
+): Promise<number> => {
   const proc = Bun.spawn(['docker', 'compose', ...args], {
     cwd: import.meta.dir,
+    ...(images === undefined ? {} : { env: { ...process.env, ...images } }),
     stdout: 'inherit',
     stderr: 'inherit',
   });
   return proc.exited;
 };
 
-const pull = async (): Promise<void> => {
-  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
-    if ((await run(['pull', '--quiet'])) === 0) return;
-    if (attempt === ATTEMPTS) {
-      throw new Error(
-        `docker compose pull failed ${ATTEMPTS} times. The last one is above; a ` +
-          'rate limit is the usual reason and it clears on its own.',
-      );
+/** Answers with the registry that served, so `up` starts what `pull` fetched
+ * rather than resolving `compose.yml`'s defaults and pulling again. */
+const pull = async (): Promise<Registry> => {
+  for (let round = 1; round <= ROUNDS; round += 1) {
+    for (const registry of REGISTRIES) {
+      if ((await run(['pull', '--quiet'], imagesFrom(registry))) === 0) {
+        return registry;
+      }
+      console.log(`pull from ${registry.name} failed`);
     }
-    // 2s, 4s, 8s, 16s. A throttle window is seconds, not minutes.
-    const waitMs = 2000 * 2 ** (attempt - 1);
+    if (round === ROUNDS) break;
+    // 2s then 4s, and the registries come before the sleep: another provider is
+    // a faster retry than waiting out one provider's throttle window.
+    const waitMs = 2000 * 2 ** (round - 1);
     console.log(
-      `pull failed, retrying in ${waitMs / 1000}s (${attempt}/${ATTEMPTS - 1})`,
+      `every registry failed, round ${round}/${ROUNDS}; retrying in ${waitMs / 1000}s`,
     );
     await Bun.sleep(waitMs);
   }
+  throw new Error(
+    `docker compose pull failed ${ROUNDS} times from each of ` +
+      `${REGISTRIES.map((registry) => registry.name).join(', ')}. The last one ` +
+      'is above; a rate limit is the usual reason and it clears on its own.',
+  );
 };
 
-await pull();
-const code = await run(['up', '-d', '--wait']);
-process.exit(code);
+const served = await pull();
+console.log(`images from ${served.name}`);
+process.exit(await run(['up', '-d', '--wait'], imagesFrom(served)));

--- a/scripts/registries.test.ts
+++ b/scripts/registries.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  fromFirstRegistry,
+  imageRefs,
+  REGISTRIES,
+  type Registry,
+} from './registries.js';
+
+const named = (name: string): Registry => ({
+  name,
+  ref: (path) => `${name}/${path}`,
+});
+
+/** Never called: every case below settles before the first backoff, except the
+ * ones that assert what it was asked to wait. */
+const noSleep = async (): Promise<void> => {
+  /* the backoff, not waited on */
+};
+
+/** The default `log` is `console.log`, which would print a registry failure into
+ * the test run for every case that exercises one. */
+const quiet = () => {
+  /* the failure line, not printed */
+};
+
+describe('REGISTRIES', () => {
+  const refs = (path: string) =>
+    REGISTRIES.map((registry) => registry.ref(path));
+
+  it('spells an official image for each registry', () => {
+    expect(refs('library/postgres:17-alpine')).toEqual([
+      'docker.io/library/postgres:17-alpine',
+      // The one that is not a prefix: ECR mirrors Hub's official images under
+      // `docker/library`, so dropping this case reintroduces the 404.
+      'public.ecr.aws/docker/library/postgres:17-alpine',
+      'mirror.gcr.io/library/postgres:17-alpine',
+    ]);
+  });
+
+  it('spells a publisher image for each registry', () => {
+    expect(refs('valkey/valkey:8-alpine')).toEqual([
+      'docker.io/valkey/valkey:8-alpine',
+      'public.ecr.aws/valkey/valkey:8-alpine',
+      'mirror.gcr.io/valkey/valkey:8-alpine',
+    ]);
+  });
+
+  it('reaches Docker Hub first, which measured as the one that served', () => {
+    expect(REGISTRIES[0]?.name).toBe('docker.io');
+  });
+});
+
+describe('imageRefs', () => {
+  it('renders every variable through the one registry', () => {
+    expect(
+      imageRefs(REGISTRIES[1] as Registry, {
+        DUNX_VALKEY_IMAGE: 'valkey/valkey:8-alpine',
+        DUNX_POSTGRES_IMAGE: 'library/postgres:17-alpine',
+      }),
+    ).toEqual({
+      DUNX_VALKEY_IMAGE: 'public.ecr.aws/valkey/valkey:8-alpine',
+      DUNX_POSTGRES_IMAGE: 'public.ecr.aws/docker/library/postgres:17-alpine',
+    });
+  });
+});
+
+describe('fromFirstRegistry', () => {
+  it('stops at the first registry that serves', async () => {
+    const tried: string[] = [];
+    const served = await fromFirstRegistry(
+      async (registry) => {
+        tried.push(registry.name);
+        return true;
+      },
+      { registries: [named('a'), named('b')], sleep: noSleep },
+    );
+
+    expect(served.name).toBe('a');
+    expect(tried).toEqual(['a']);
+  });
+
+  /** The whole point: a registry that is throttling is skipped rather than
+   * retried, because the exhausted budget is that registry's. */
+  it('falls through to the next one', async () => {
+    const tried: string[] = [];
+    const served = await fromFirstRegistry(
+      async (registry) => {
+        tried.push(registry.name);
+        return registry.name === 'c';
+      },
+      {
+        registries: [named('a'), named('b'), named('c')],
+        log: quiet,
+        sleep: noSleep,
+      },
+    );
+
+    expect(served.name).toBe('c');
+    expect(tried).toEqual(['a', 'b', 'c']);
+  });
+
+  /** Another provider is the faster retry, so a whole round runs before the
+   * first sleep rather than a sleep between each registry. */
+  it('sleeps only between rounds, doubling each time', async () => {
+    const tried: string[] = [];
+    const slept: number[] = [];
+    let attempts = 0;
+
+    const served = await fromFirstRegistry(
+      async (registry) => {
+        tried.push(registry.name);
+        attempts += 1;
+        // Fails both registries twice over, serves on the third round.
+        return attempts > 4;
+      },
+      {
+        registries: [named('a'), named('b')],
+        log: quiet,
+        sleep: async (ms) => {
+          slept.push(ms);
+        },
+      },
+    );
+
+    expect(served.name).toBe('a');
+    expect(tried).toEqual(['a', 'b', 'a', 'b', 'a']);
+    expect(slept).toEqual([2_000, 4_000]);
+  });
+
+  it('throws naming every registry it tried', async () => {
+    const slept: number[] = [];
+    await expect(
+      fromFirstRegistry(async () => false, {
+        registries: [named('a'), named('b')],
+        rounds: 2,
+        log: quiet,
+        sleep: async (ms) => {
+          slept.push(ms);
+        },
+      }),
+    ).rejects.toThrow('after 2 round(s) of a, b');
+    // No trailing sleep: the last round fails and throws rather than waiting.
+    expect(slept).toEqual([2_000]);
+  });
+
+  it('reports each registry that did not serve', async () => {
+    const said: string[] = [];
+    await fromFirstRegistry(async (registry) => registry.name === 'b', {
+      registries: [named('a'), named('b')],
+      log: (message) => said.push(message),
+      sleep: noSleep,
+    });
+
+    expect(said).toEqual(['a did not serve']);
+  });
+});

--- a/scripts/registries.ts
+++ b/scripts/registries.ts
@@ -1,0 +1,123 @@
+/**
+ * Pulling a container image from the first registry that answers.
+ *
+ * Every public registry rate limits anonymous pulls by IP, and a CI runner
+ * shares its IP with every other runner on the host, so any single registry is a
+ * coin toss that fails as a red build with nothing wrong in the change. It broke
+ * the examples job twice in an hour, and the second one skipped the release job
+ * behind it.
+ *
+ * Retrying one registry cannot fix that: the exhausted budget is that
+ * registry's, so the retry asks the same throttle again. Another provider is the
+ * faster retry, which is why a round tries them all before anything sleeps.
+ *
+ * Here rather than beside a compose file so a second caller shares the list
+ * rather than writing a fourth spelling of `public.ecr.aws/docker/library`.
+ */
+
+/** One registry, and how it spells a Docker Hub repository path. */
+export interface Registry {
+  readonly name: string;
+  /**
+   * `ref('library/postgres:17-alpine')` for this registry. The argument is the
+   * Hub path in full, including the `library/` namespace an official image lets
+   * a `docker pull` leave out.
+   */
+  readonly ref: (path: string) => string;
+}
+
+/** Hub's own namespace for an official image. `postgres` is `library/postgres`. */
+const OFFICIAL = 'library/';
+
+/**
+ * Tried in order. Adding a provider is one entry, and nothing outside this file
+ * names a registry.
+ *
+ * Measured 2026-09-13, during an ECR outage: Docker Hub and mirror.gcr.io served
+ * valkey, postgres and rabbitmq, and public.ecr.aws answered `toomanyrequests`
+ * for two of the three.
+ */
+export const REGISTRIES: readonly Registry[] = [
+  { name: 'docker.io', ref: (path) => `docker.io/${path}` },
+  {
+    name: 'public.ecr.aws',
+    // Hub's official images are mirrored under `docker/library` here, and
+    // everything else under the publisher's own namespace.
+    ref: (path) =>
+      path.startsWith(OFFICIAL)
+        ? `public.ecr.aws/docker/${path}`
+        : `public.ecr.aws/${path}`,
+  },
+  // A pull-through cache of Hub, so a Hub path resolves here unchanged.
+  { name: 'mirror.gcr.io', ref: (path) => `mirror.gcr.io/${path}` },
+];
+
+/** Rounds of the whole list before giving up. */
+const ROUNDS = 3;
+
+/** First backoff, doubled each round. A throttle window is seconds, not minutes. */
+const FIRST_BACKOFF_MS = 2_000;
+
+export interface FallbackOptions {
+  /** Defaults to {@link REGISTRIES}. */
+  readonly registries?: readonly Registry[];
+  /** Passes over the whole list before giving up. Defaults to 3. */
+  readonly rounds?: number;
+  readonly log?: (message: string) => void;
+  /** Injectable so a test does not wait out the backoff. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Maps each variable to this registry's spelling of the path it holds, ready to
+ * hand a child process as environment.
+ */
+export const imageRefs = (
+  registry: Registry,
+  images: Readonly<Record<string, string>>,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(images).map(([variable, path]) => [
+      variable,
+      registry.ref(path),
+    ]),
+  );
+
+/**
+ * Runs `attempt` against each registry in turn until one answers true, and
+ * answers with the registry that did, so the caller can use the same images for
+ * whatever comes after the pull.
+ *
+ * Sleeps only once a whole round has failed. Throws when every round has.
+ */
+export const fromFirstRegistry = async (
+  attempt: (registry: Registry) => Promise<boolean>,
+  options: FallbackOptions = {},
+): Promise<Registry> => {
+  const {
+    registries = REGISTRIES,
+    rounds = ROUNDS,
+    log = console.log,
+    sleep = Bun.sleep,
+  } = options;
+
+  for (let round = 1; round <= rounds; round += 1) {
+    for (const registry of registries) {
+      if (await attempt(registry)) return registry;
+      log(`${registry.name} did not serve`);
+    }
+    if (round === rounds) break;
+    const waitMs = FIRST_BACKOFF_MS * 2 ** (round - 1);
+    log(
+      `no registry served, round ${round}/${rounds}; retrying in ${waitMs / 1000}s`,
+    );
+    await sleep(waitMs);
+  }
+
+  throw new Error(
+    `No registry served after ${rounds} round(s) of ` +
+      `${registries.map((registry) => registry.name).join(', ')}. The last ` +
+      'failure is above; a rate limit is the usual reason and it clears on ' +
+      'its own.',
+  );
+};


### PR DESCRIPTION
The examples job failed twice in an hour on `toomanyrequests` from public.ecr.aws, both times in the pull step with no test run. The second one skipped the release job behind it, so 3.8.0 needed a manual re-run to publish.

Retrying one registry cannot fix that: the exhausted budget is the registry's, so each retry asks the same throttle again. Measured mid-outage on 2026-09-13, Docker Hub and `mirror.gcr.io` served all three images while public.ecr.aws answered `toomanyrequests` for two.

`compose.yml` now takes each image as a variable and `services.ts` pulls from each registry in turn, backing off only once a whole round has failed. Order is Docker Hub, public.ecr.aws, `mirror.gcr.io`; the list lives in `services.ts` and nowhere else, so a fourth provider is one entry.

Verified by running it: a clean pull reports `images from docker.io`, and with a bogus registry spliced in front it logs the failure, moves on, and starts from the next one that answers.

Not changed: `compose.demo.yml`, which a human runs by hand with no gate behind it, and `ci.yml`'s `services:` containers, which GitHub pulls rather than this script.