### PR TITLE
feat(example): a message broker panel on the demo, and the AMQP fixes it needed

### DIFF
--- a/examples/full/README.md
+++ b/examples/full/README.md
@@ -67,6 +67,7 @@ that check, because a service never exits.
 | `/api/upstream`   | `@dunx/http/client` - the outbound half, with retry and a 404           |
 | `/assets/*`       | `StaticFiles` - two cache policies and a traversal refusal              |
 | `/api/jobs`       | `@dunx/infra/queue` - bullmq; published and consumed by this process       |
+| `/api/messaging`  | `@dunx/infra/amqp` - a RabbitMQ topic exchange, two queues, one trace      |
 | `/api/auth/*`     | `@dunx/auth` - better-auth mounted, with `Bun.password` hashing          |
 | `/api/wiring`     | `@dunx/core` - `token()`, `inject()` and the three `provide()` shapes    |
 | `/api/demo/*`     | what the landing page renders - vitals, a source excerpt, a retry        |

--- a/examples/full/compose.demo.yml
+++ b/examples/full/compose.demo.yml
@@ -61,8 +61,14 @@ services:
       - demo
 
   dunx-demo-rabbitmq:
-    # public.ecr.aws for the reason the Redis above names it, and this tag
-    # publishes linux/arm64 for the Pi this runs on.
+    # The registry the Redis above uses, so this file names one registry rather
+    # than two, and a tag that publishes linux/arm64 for the Pi.
+    #
+    # `deploy-demo.sh` runs `docker compose` directly, so the fallback in
+    # `scripts/registries.ts` does not reach here: whichever registry these two
+    # lines name is the only one tried. That list now puts docker.io ahead of
+    # public.ecr.aws, measured during an ECR outage, so both lines are worth
+    # revisiting together rather than one of them here.
     image: public.ecr.aws/docker/library/rabbitmq:4-alpine
     container_name: dunx-demo-rabbitmq
     logging: *logging

--- a/examples/full/compose.demo.yml
+++ b/examples/full/compose.demo.yml
@@ -1,6 +1,6 @@
-# The deployed shape of demo.dunx.win: this example, its own broker, and nothing
-# else. `compose.yml` beside it is the local development pair; this one is the
-# public demo.
+# The deployed shape of demo.dunx.win: this example, its own two brokers, and
+# nothing else. `compose.yml` beside it is the local development set; this one is
+# the public demo.
 #
 #   docker compose -f examples/full/compose.demo.yml up -d --build
 #
@@ -14,12 +14,21 @@
 # question, and an isolated broker costs about 12 MB. Nothing here can reach the
 # other one: `REDIS_URL` names this service explicitly.
 #
+# ## Why a RabbitMQ beside it
+#
+# The landing page's message broker panel publishes to a topic exchange and reads
+# back what the consumers in this same container received. Without a broker that
+# panel answers 503, which demonstrates the degradation rather than the feature.
+# It holds nothing that outlives a restart: the exchange and both queues are
+# declared at boot and on every reconnect.
+#
 # ## Why no published port
 #
 # The only caller is cloudflared, which resolves `dunx-demo` by name over the
 # shared `app-network`. Publishing a host port would also expose the dashboard on
 # the LAN, and there is no reason for it to be reachable except through the
-# tunnel.
+# tunnel. Neither broker is on `app-network` at all, so only this app reaches
+# them - which is what makes RabbitMQ's default `guest` user acceptable here.
 name: dunx-demo
 
 x-logging:
@@ -51,6 +60,29 @@ services:
     networks:
       - demo
 
+  dunx-demo-rabbitmq:
+    # public.ecr.aws for the reason the Redis above names it, and this tag
+    # publishes linux/arm64 for the Pi this runs on.
+    image: public.ecr.aws/docker/library/rabbitmq:4-alpine
+    container_name: dunx-demo-rabbitmq
+    logging: *logging
+    restart: unless-stopped
+    # No `ports` and no volume, for the reasons the Redis above has none: only
+    # the app talks to it, and nothing published here is worth keeping.
+    # RabbitMQ 4 reads the cgroup limit rather than the host's memory, so its
+    # high watermark follows this number instead of the Pi's 8 GB.
+    mem_limit: 512m
+    healthcheck:
+      test: ['CMD', 'rabbitmq-diagnostics', '-q', 'ping']
+      interval: 10s
+      timeout: 5s
+      # The Erlang VM takes appreciably longer to boot on a Pi than on a laptop,
+      # and `depends_on` below holds the app until this passes.
+      retries: 12
+      start_period: 30s
+    networks:
+      - demo
+
   dunx-demo:
     container_name: dunx-demo
     logging: *logging
@@ -62,6 +94,10 @@ services:
     environment:
       # This service name, not the other app's broker.
       REDIS_URL: redis://dunx-demo-redis:6379
+      # Absent, the messaging routes answer 503 and the panel reports that.
+      # Spelled out rather than left to the guest default, so giving the broker a
+      # user of its own is one line here rather than a silent auth failure.
+      RABBITMQ_URL: amqp://guest:guest@dunx-demo-rabbitmq:5672
       # better-auth refuses to mint sessions without one. Supply it in a `.env`
       # beside this file, or in the environment that runs compose.
       AUTH_SECRET: ${DEMO_AUTH_SECRET:?set DEMO_AUTH_SECRET, at least 32 characters}
@@ -85,6 +121,8 @@ services:
     stop_grace_period: 20s
     depends_on:
       dunx-demo-redis:
+        condition: service_healthy
+      dunx-demo-rabbitmq:
         condition: service_healthy
     networks:
       - demo

--- a/examples/full/src/cache/catalog.demo.ts
+++ b/examples/full/src/cache/catalog.demo.ts
@@ -39,8 +39,13 @@ export class CatalogDemo {
         `(loads ${before} -> ${await this.loads(url)})`,
     );
 
+    // Unique per run, because "uncached" has to be true for the count below to
+    // mean anything: L2 is Redis, so a fixed symbol is still cached from the
+    // previous tour against the same server and ten reads then load zero times.
+    // `max(12)` on the route's param, so the suffix is short.
+    const fresh = `bun-${Bun.randomUUIDv7().slice(-6)}`;
     const at = await this.loads(url);
-    await Promise.all(Array.from({ length: 10 }, () => this.quote(url, 'bun')));
+    await Promise.all(Array.from({ length: 10 }, () => this.quote(url, fresh)));
     this.logger.info(
       `10 concurrent reads of an uncached key -> ${(await this.loads(url)) - at} ` +
         'load (single flight, per process)',

--- a/examples/full/src/landing/public/index.html
+++ b/examples/full/src/landing/public/index.html
@@ -246,6 +246,25 @@
         </section>
 
         <section>
+          <h2>Message broker</h2>
+          <p>
+            <code>@dunx/infra/amqp</code> over RabbitMQ.
+            <code>POST /api/messaging/orders</code> publishes to a topic
+            exchange and the broker routes the key to its own queue, both
+            consumed by this same container. The line that comes back is read
+            from <code>GET /api/messaging/orders</code>, and the
+            <code>traceId</code> on it is the one this request carried: a trace
+            that crossed the broker.
+          </p>
+          <div class="row">
+            <button id="mq-place">Place an order</button>
+            <button id="mq-ship">Ship one</button>
+            <button id="mq-bad">Publish a malformed body</button>
+          </div>
+          <pre id="mq-out"></pre>
+        </section>
+
+        <section>
           <h2>Session</h2>
           <p>
             better-auth mounted by <code>@dunx/auth</code>, with the anonymous

--- a/examples/full/src/landing/public/landing.js
+++ b/examples/full/src/landing/public/landing.js
@@ -138,6 +138,135 @@ $('job-go').addEventListener('click', async (event) => {
   }
 });
 
+/**
+ * Message broker: publish, then read back what the consumers in this same
+ * process received.
+ */
+
+/** Appends, where `append` prepends. Oldest first like the transactions panel,
+ * because a delivery line means nothing without the publish line above it. */
+const trail = (el, line) => {
+  el.textContent = `${el.textContent}${line}\n`.slice(-4000);
+};
+
+const DELIVERY_TRIES = 10;
+const DELIVERY_MS = 400;
+/**
+ * The app answers 503 once `publishTimeoutMs` is up, which the example sets to
+ * 2 s. This is the backstop for the request itself going nowhere, and `connected`
+ * below is read first so the usual case reports immediately rather than after
+ * that wait.
+ */
+const PUBLISH_MS = 8_000;
+
+/** Whether the consuming side is attached, which is also whether publishing is
+ * worth attempting. */
+const brokerReady = async (out) => {
+  const res = await fetch('/api/messaging/orders');
+  if (!res.ok) {
+    trail(out, `GET /api/messaging/orders -> ${res.status}`);
+    return false;
+  }
+  const { connected } = await res.json();
+  if (!connected) trail(out, 'no broker reachable - nothing is consuming');
+  return connected;
+};
+
+/**
+ * Waits for **this** publish rather than for a count. `handled` keeps the last
+ * hundred deliveries the process has seen, so a count crosses the moment anyone
+ * else on the page publishes anything.
+ */
+const awaitDelivery = async (id, out) => {
+  for (let i = 0; i < DELIVERY_TRIES; i++) {
+    await new Promise((done) => setTimeout(done, DELIVERY_MS));
+    const res = await fetch('/api/messaging/orders');
+    if (!res.ok) {
+      trail(out, `   GET /api/messaging/orders -> ${res.status}`);
+      return;
+    }
+    const { connected, handled } = await res.json();
+    const mine = handled.filter((entry) => entry.id === id);
+    for (const entry of mine) {
+      trail(out, `<- ${entry.queue} traceId=${entry.traceId ?? '(none)'}`);
+    }
+    if (mine.length > 0) return;
+    // A broker that went away mid-poll, rather than a delivery still in flight.
+    if (!connected) {
+      trail(out, '   no broker reachable - nothing consumed this');
+      return;
+    }
+  }
+  trail(out, `   nothing arrived in ${(DELIVERY_TRIES * DELIVERY_MS) / 1000}s`);
+};
+
+/**
+ * One publish for all three buttons: refuse early with no broker, bound the
+ * request, and hand the parsed body back for the caller to narrate. Returns
+ * nothing when there was no answer worth narrating.
+ */
+const publish = async (button, path, payload) => {
+  const out = $('mq-out');
+  button.disabled = true;
+  try {
+    if (!(await brokerReady(out))) return undefined;
+    const res = await fetch(path, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(PUBLISH_MS),
+    });
+    const body = await res.json();
+    if (res.ok) return body;
+    trail(out, `POST ${path} -> ${res.status} ${body.error}`);
+    return undefined;
+  } catch (error) {
+    // A timeout here is the broker going away between the readiness read and
+    // this publish, which is the case `connected` above cannot rule out.
+    trail(
+      out,
+      error.name === 'TimeoutError'
+        ? `POST ${path} did not answer in ${PUBLISH_MS / 1000}s`
+        : `POST ${path} failed: ${String(error)}`,
+    );
+    return undefined;
+  } finally {
+    button.disabled = false;
+  }
+};
+
+const publishOrder = async (event, shipped) => {
+  const out = $('mq-out');
+  // Short and per click, so two visitors publishing at once still each read
+  // back their own delivery.
+  const id = `web-${Math.random().toString(36).slice(2, 8)}`;
+  const body = await publish(event.currentTarget, '/api/messaging/orders', {
+    id,
+    total: 42,
+    shipped,
+  });
+  if (body === undefined) return;
+  trail(out, `-> ${body.routingKey} on ${body.exchange} as ${id}`);
+  await awaitDelivery(id, out);
+};
+$('mq-place').addEventListener('click', (event) => publishOrder(event, false));
+$('mq-ship').addEventListener('click', (event) => publishOrder(event, true));
+
+/**
+ * The same exchange with a body that is not an order. The handler returns DROP
+ * rather than throwing, so the broker discards it instead of redelivering it
+ * forever - which is what a throw on a `requeue: true` queue would cause.
+ */
+$('mq-bad').addEventListener('click', async (event) => {
+  const out = $('mq-out');
+  const sent = await publish(event.currentTarget, '/api/messaging/raw', {
+    not: 'an order',
+  });
+  if (sent === undefined) return;
+  trail(out, '-> order.placed carrying {"not":"an order"}');
+  trail(out, '   dropped by the handler, so it is never redelivered');
+});
+
 /** Validation, both directions. */
 const postUser = async (body, label) => {
   const out = $('bad-out');

--- a/examples/full/src/messaging.test.ts
+++ b/examples/full/src/messaging.test.ts
@@ -79,9 +79,16 @@ beforeAll(async () => {
   brokerUp = (await place('probe')).status === 201;
 });
 
+/**
+ * Past bun's 5 s default, because the teardown this file reaches with nothing
+ * running is the slow one: each consumer drain waits `drainTimeoutMs`, the
+ * connection close waits its own bound, and the queue and cache are shutting down
+ * against a Redis that is not answering either. All of that is bounded, and the
+ * sum is simply more than 5 s.
+ */
 afterAll(async () => {
   await app.shutdown();
-});
+}, 30_000);
 
 it('routes one publish to the queue its key binds', async () => {
   if (!brokerUp) return;
@@ -155,6 +162,43 @@ it('answers 503 with no broker rather than hanging', async () => {
   const { status } = await place('degraded');
   expect(status).toBe(503);
   expect((await inbox()).connected).toBe(false);
+});
+
+/**
+ * The landing page is where a visitor reaches these routes, and it is the half a
+ * rename can miss: `landing.js` holds the paths as strings, so nothing else fails
+ * when one moves. Asserted against the OpenAPI document rather than a literal, so
+ * the page and the controller cannot drift apart quietly.
+ *
+ * No broker needed - this is the wiring, not the delivery.
+ */
+it('wires the landing page panel to the routes that exist', async () => {
+  const page = await (await fetch(new URL('/', base))).text();
+  expect(page).toContain('<h2>Message broker</h2>');
+  for (const id of ['mq-place', 'mq-ship', 'mq-bad', 'mq-out']) {
+    expect(page).toContain(`id="${id}"`);
+  }
+
+  const byName = (left: string, right: string): number =>
+    left.localeCompare(right);
+
+  const script = await (await fetch(new URL('/landing.js', base))).text();
+  const used = [
+    ...new Set(
+      [...script.matchAll(/'(\/api\/messaging\/[^']*)'/g)].flatMap(
+        (match) => match[1] ?? [],
+      ),
+    ),
+  ].sort(byName);
+
+  const document = (await (await fetch(api('openapi.json'))).json()) as {
+    paths: Record<string, unknown>;
+  };
+  const mounted = Object.keys(document.paths)
+    .filter((path) => path.startsWith('/api/messaging/'))
+    .sort(byName);
+
+  expect(used).toEqual(mounted);
 });
 
 /**

--- a/examples/full/src/messaging/messaging.module.ts
+++ b/examples/full/src/messaging/messaging.module.ts
@@ -30,6 +30,10 @@ import { ORDERS_EXCHANGE, OrdersMessages } from './orders.messages.js';
           // Short, so `bun run tour` against an absent broker says so and moves
           // on instead of holding boot for five seconds.
           readyTimeoutMs: 1_500,
+          // Well under the package's 10 s default, because a request is waiting
+          // on this one: the landing page's broker panel wants the 503 while the
+          // visitor is still looking at it.
+          publishTimeoutMs: 2_000,
           drainTimeoutMs: 2_000,
           handlerTimeoutMs: 10_000,
         };

--- a/examples/full/src/tour.test.ts
+++ b/examples/full/src/tour.test.ts
@@ -367,11 +367,12 @@ it('times every redis command at the one seam, and keeps no key', () => {
  * matched without their sequence, since each has a consumer on its own channel.
  */
 it('routes through a topic exchange carrying its trace', () => {
-  const { RABBITMQ_URL, AMQP_URL } = process.env;
-  if (RABBITMQ_URL === undefined && AMQP_URL === undefined) {
-    expect(tour.text).toContain('skipping the message broker section');
-    return;
-  }
+  // Read off what the tour did rather than off the environment. Neither variable
+  // being set does not mean no broker: `defaultAmqpUrl` falls back to
+  // localhost:5672, so a machine running one there consumes the section, and
+  // asserting the skip line failed on exactly the setup the section works on.
+  if (tour.text.includes('skipping the message broker section')) return;
+
   expect(tour.text).toContain('2 of 2 delivered to');
   expect(tour.text).toContain('dunx-full.orders.placed');
   expect(tour.text).toContain('dunx-full.orders.shipped');

--- a/packages/infra/src/amqp/errors.ts
+++ b/packages/infra/src/amqp/errors.ts
@@ -8,6 +8,8 @@ export const AmqpErrorCode = Object.freeze({
   NO_HANDLERS: 'ERR_AMQP_NO_HANDLERS',
   /** A handler outran `handlerTimeoutMs`. */
   TIMED_OUT: 'ERR_AMQP_TIMED_OUT',
+  /** A publish outran `publishTimeoutMs`, so the broker never confirmed it. */
+  PUBLISH_TIMED_OUT: 'ERR_AMQP_PUBLISH_TIMED_OUT',
   INVALID_STATE: 'ERR_AMQP_INVALID_STATE',
   INVALID_URL: 'ERR_AMQP_INVALID_URL',
 } as const);

--- a/packages/infra/src/amqp/module.test.ts
+++ b/packages/infra/src/amqp/module.test.ts
@@ -56,7 +56,9 @@ describe('what the module binds', () => {
   it('binds the publish side and nothing that consumes', async () => {
     app = await AppFactory.create(AmqpModule.forRoot(options));
 
-    expect(app.get(AmqpOptions).url).toBe(unreachable);
+    // The host as given, with the credentials a url that names none is missing:
+    // `rabbitmq-client` would otherwise authenticate as the blank user.
+    expect(app.get(AmqpOptions).url).toBe('amqp://guest:guest@127.0.0.1:1');
     expect(app.get(AmqpConnection)).toBeInstanceOf(AmqpConnection);
     expect(app.get(AmqpPublisher)).toBeInstanceOf(AmqpPublisher);
     expect(app.get(AmqpRunner).subscriber).toBeUndefined();

--- a/packages/infra/src/amqp/options.test.ts
+++ b/packages/infra/src/amqp/options.test.ts
@@ -79,6 +79,42 @@ describe('the broker url', () => {
   });
 
   /**
+   * Only this one of the five timeouts is checked. It is the one this version
+   * adds, so nothing can already be passing a value the check would now reject.
+   */
+  describe('publishTimeoutMs', () => {
+    it('defaults to ten seconds', () => {
+      expect(new AmqpOptions().publishTimeoutMs).toBe(10_000);
+      expect(new AmqpOptions({ publishTimeoutMs: 250 }).publishTimeoutMs).toBe(
+        250,
+      );
+    });
+
+    /** Each of these reaches `withTimeout` as a timer that has already expired,
+     * so every publish would fail naming a bound nobody set. */
+    it('refuses zero, a negative, and anything not finite', () => {
+      for (const publishTimeoutMs of [
+        0,
+        -1,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+      ]) {
+        expect(() => new AmqpOptions({ publishTimeoutMs })).toThrow(AmqpError);
+      }
+    });
+
+    it('names the value it refused', () => {
+      try {
+        new AmqpOptions({ publishTimeoutMs: -5 });
+        expect.unreachable();
+      } catch (error) {
+        expect((error as AmqpError).code).toBe(AmqpErrorCode.INVALID_STATE);
+        expect((error as AmqpError).message).toContain('-5');
+      }
+    });
+  });
+
+  /**
    * Checked up front rather than at connect time. `rabbitmq-client` retries a
    * failed connection forever, so a typo would otherwise surface as a publish
    * that never settles.

--- a/packages/infra/src/amqp/options.test.ts
+++ b/packages/infra/src/amqp/options.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { AmqpError, AmqpErrorCode } from './errors.js';
 import { describeMessage } from './message.js';
-import { AmqpOptions, assertAmqpUrl, defaultAmqpUrl } from './options.js';
+import {
+  AmqpOptions,
+  assertAmqpUrl,
+  defaultAmqpUrl,
+  withDefaultCredentials,
+} from './options.js';
 
 describe('the broker url', () => {
   it('reads $RABBITMQ_URL before $AMQP_URL', () => {
@@ -29,6 +34,48 @@ describe('the broker url', () => {
       'amqp://localhost:5672',
     );
     expect(assertAmqpUrl('amqps://broker:5671')).toBe('amqps://broker:5671');
+  });
+
+  /**
+   * `rabbitmq-client` reads the credentials out of a url string unconditionally,
+   * with no fallback of its own: `amqp://host` authenticates as user '' with a
+   * blank password, which RabbitMQ refuses outright. Naming a host is not
+   * supposed to be a different case from naming none, so the AMQP URI spec's
+   * defaults are filled in here.
+   */
+  describe('credentials', () => {
+    it('fills in the spec default when the url names none', () => {
+      expect(withDefaultCredentials('amqp://localhost:5672')).toBe(
+        'amqp://guest:guest@localhost:5672',
+      );
+      expect(withDefaultCredentials('amqps://broker:5671/prod')).toBe(
+        'amqps://guest:guest@broker:5671/prod',
+      );
+    });
+
+    it('leaves a url that names them alone, byte for byte', () => {
+      for (const url of [
+        'amqp://app:hunter2@broker:5672',
+        // A username with no password is a deliberate choice, not an omission:
+        // filling in `guest` as the password of some other user would be worse
+        // than the blank one the caller asked for.
+        'amqp://app@broker:5672',
+        'amqp://app:p%40ss@broker:5672/vhost',
+      ]) {
+        expect(withDefaultCredentials(url)).toBe(url);
+      }
+    });
+
+    it('is what AmqpOptions stores, so the connection never sees a blank user', () => {
+      expect(new AmqpOptions({ url: 'amqp://localhost:5672' }).url).toBe(
+        'amqp://guest:guest@localhost:5672',
+      );
+    });
+
+    it('keeps the filled-in password out of the redacted url', () => {
+      const options = new AmqpOptions({ url: 'amqp://localhost:5672' });
+      expect(options.redactedUrl).not.toContain('guest:guest');
+    });
   });
 
   /**

--- a/packages/infra/src/amqp/options.ts
+++ b/packages/infra/src/amqp/options.ts
@@ -50,6 +50,28 @@ export const assertAmqpUrl = (url: string): string => {
   return url;
 };
 
+/**
+ * The AMQP URI spec's defaults for an absent user and password, filled in.
+ *
+ * `rabbitmq-client` reads both out of a url string unconditionally and has no
+ * fallback on that path, so `amqp://broker:5672` authenticates as user `''` with
+ * a blank password and RabbitMQ refuses it outright. Naming a host is not
+ * supposed to be a different case from naming none, which is what
+ * {@link defaultAmqpUrl} already spells out.
+ *
+ * Spliced rather than rebuilt through `URL`, so a url that names credentials
+ * comes back byte for byte and `toString()` does not move anything else about it.
+ */
+export const withDefaultCredentials = (url: string): string => {
+  const parsed = new URL(url);
+  // A username with no password is a choice rather than an omission: supplying
+  // `guest` as some other user's password would be worse than the blank one.
+  if (parsed.username !== '' || parsed.password !== '') return url;
+
+  const mark = url.indexOf('://') + 3;
+  return `${url.slice(0, mark)}guest:guest@${url.slice(mark)}`;
+};
+
 /** What `AmqpConnection` sets itself, so it is not yours to pass. */
 export type ConnectionPassthrough = Omit<
   ConnectionOptions,
@@ -115,6 +137,17 @@ export interface AmqpOptionsInit {
    */
   readonly handlerTimeoutMs?: number;
   /**
+   * Reject a publish whose confirm has not arrived within this. `Publisher.send`
+   * waits for a channel, and against an unreachable broker `rabbitmq-client`
+   * retries the reconnect rather than failing, so the promise settles in neither
+   * direction. A route publishing inside a request then holds that request open
+   * until the client gives up, where what it wants is an error it can answer 503
+   * with. Lower it where a caller is waiting on the publish.
+   *
+   * @default 10000
+   */
+  readonly publishTimeoutMs?: number;
+  /**
    * Open consumers in **this** process, rather than only binding the publish side.
    * Off by default: `AmqpModule` is imported by anything that publishes, and a
    * web process that started consuming to send a message would be a surprise.
@@ -140,10 +173,13 @@ export class AmqpOptions {
   readonly drainTimeoutMs: number;
   readonly closeTimeoutMs: number;
   readonly handlerTimeoutMs: number | undefined;
+  readonly publishTimeoutMs: number;
   readonly consume: boolean | 'if-any';
 
   constructor(init: AmqpOptionsInit = {}) {
-    this.url = assertAmqpUrl(init.url ?? defaultAmqpUrl());
+    this.url = withDefaultCredentials(
+      assertAmqpUrl(init.url ?? defaultAmqpUrl()),
+    );
     this.connectionName = init.connectionName ?? 'dunx';
     this.connection = init.connection ?? {};
     const given = init.consumer ?? {};
@@ -163,6 +199,7 @@ export class AmqpOptions {
     this.drainTimeoutMs = init.drainTimeoutMs ?? 10_000;
     this.closeTimeoutMs = init.closeTimeoutMs ?? 5_000;
     this.handlerTimeoutMs = init.handlerTimeoutMs;
+    this.publishTimeoutMs = init.publishTimeoutMs ?? 10_000;
     this.consume = init.consume ?? false;
   }
 

--- a/packages/infra/src/amqp/options.ts
+++ b/packages/infra/src/amqp/options.ts
@@ -199,7 +199,20 @@ export class AmqpOptions {
     this.drainTimeoutMs = init.drainTimeoutMs ?? 10_000;
     this.closeTimeoutMs = init.closeTimeoutMs ?? 5_000;
     this.handlerTimeoutMs = init.handlerTimeoutMs;
-    this.publishTimeoutMs = init.publishTimeoutMs ?? 10_000;
+    // Checked the way `CacheOptions` checks its ttl, and only here: zero or less
+    // reaches `withTimeout` as a timer that has already expired, so every publish
+    // would fail as a timeout and name a bound the caller never meant. The four
+    // above are published API with no guard, and adding one now would throw for a
+    // value they have always accepted - a separate decision from this one.
+    const publishTimeoutMs = init.publishTimeoutMs ?? 10_000;
+    if (!Number.isFinite(publishTimeoutMs) || publishTimeoutMs <= 0) {
+      throw new AmqpError(
+        AmqpErrorCode.INVALID_STATE,
+        'AMQP publishTimeoutMs must be a positive number of milliseconds, got ' +
+          `${String(publishTimeoutMs)}.`,
+      );
+    }
+    this.publishTimeoutMs = publishTimeoutMs;
     this.consume = init.consume ?? false;
   }
 

--- a/packages/infra/src/amqp/publisher.test.ts
+++ b/packages/infra/src/amqp/publisher.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, expect, it } from 'bun:test';
 import type { Envelope, MessageBody, Publisher } from 'rabbitmq-client';
 import { AmqpConnection } from './connection.js';
+import { AmqpError, AmqpErrorCode } from './errors.js';
 import { AmqpOptions } from './options.js';
 import { AmqpPublisher } from './publisher.js';
 
@@ -23,9 +24,13 @@ class FakePublisher {
   closed = 0;
   failClose = false;
   neverCloses = false;
+  /** What an unreachable broker looks like from here: `send` retries the
+   * reconnect underneath and the promise never settles either way. */
+  neverSends = false;
 
   send(envelope: Envelope, body: MessageBody): Promise<void> {
     this.sent.push({ envelope, body });
+    if (this.neverSends) return new Promise<void>(() => undefined);
     return Promise.resolve();
   }
 
@@ -57,7 +62,9 @@ const recorder = (): {
   return { logger, lines };
 };
 
-const build = (init: { context?: AsyncRequestContext } = {}) => {
+const build = (
+  init: { context?: AsyncRequestContext; publishTimeoutMs?: number } = {},
+) => {
   const fake = new FakePublisher();
   const { logger, lines } = recorder();
   const connection = {
@@ -69,7 +76,13 @@ const build = (init: { context?: AsyncRequestContext } = {}) => {
     lines,
     publisher: new AmqpPublisher(
       connection,
-      new AmqpOptions({ url: 'amqp://127.0.0.1:1', closeTimeoutMs: 50 }),
+      new AmqpOptions({
+        url: 'amqp://127.0.0.1:1',
+        closeTimeoutMs: 50,
+        ...(init.publishTimeoutMs === undefined
+          ? {}
+          : { publishTimeoutMs: init.publishTimeoutMs }),
+      }),
       logger,
       init.context,
     ),
@@ -271,5 +284,49 @@ describe('shutting down', () => {
 
     await publisher.onShutdown();
     expect(lines.some((line) => line.level === 'warn')).toBe(true);
+  });
+});
+
+/**
+ * `Publisher.send` waits for a channel, and against a broker that is unreachable
+ * `rabbitmq-client` retries the reconnect forever rather than failing: the
+ * promise never settles in either direction. An HTTP route publishing inside a
+ * request then holds that request open until the client gives up, which is a
+ * hang rather than the degradation the caller can answer with.
+ */
+describe('a publish that never settles', () => {
+  it('rejects once publishTimeoutMs is up rather than waiting forever', async () => {
+    const { publisher, fake } = build({ publishTimeoutMs: 60 });
+    fake.neverSends = true;
+
+    const started = Bun.nanoseconds();
+    await expect(publisher.publish('orders', { id: 1 })).rejects.toThrow(
+      /did not confirm within 60 ms/,
+    );
+    expect((Bun.nanoseconds() - started) / 1e6).toBeLessThan(2_000);
+  });
+
+  it('carries the code a caller maps onto a 503', async () => {
+    const { publisher, fake } = build({ publishTimeoutMs: 60 });
+    fake.neverSends = true;
+
+    try {
+      await publisher.publish('orders', { id: 1 });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(AmqpError);
+      expect((error as AmqpError).code).toBe(AmqpErrorCode.PUBLISH_TIMED_OUT);
+      // The url holds credentials, and this message reaches whatever logger is
+      // bound the way the boot errors do.
+      expect((error as AmqpError).message).not.toContain('guest:guest');
+    }
+  });
+
+  /** The bound is on the wait, not on the channel: a send that resolves in time
+   * leaves nothing pending behind it. */
+  it('leaves a publish that answers in time untouched', async () => {
+    const { publisher, fake } = build({ publishTimeoutMs: 60 });
+    await publisher.publish('orders', { id: 1 });
+    expect(fake.sent).toHaveLength(1);
   });
 });

--- a/packages/infra/src/amqp/publisher.ts
+++ b/packages/infra/src/amqp/publisher.ts
@@ -8,7 +8,9 @@ import {
 } from '@dunx/core';
 import type { Envelope, Publisher } from 'rabbitmq-client';
 import { closeWithin } from '../close-within.js';
+import { withTimeout } from '../with-timeout.js';
 import { AmqpConnection } from './connection.js';
+import { AmqpError, AmqpErrorCode } from './errors.js';
 import { AmqpOptions } from './options.js';
 
 /**
@@ -74,16 +76,36 @@ export class AmqpPublisher implements OnShutdown {
    *
    * `confirm` is on by default, so this resolves when the broker has accepted the
    * message rather than when the frame was written.
+   *
+   * **Bounded by `publishTimeoutMs`, and the bound is on the wait rather than on
+   * the send.** `rabbitmq-client` retries an unreachable broker instead of
+   * failing, so without it this settles in neither direction and a route
+   * publishing inside a request hangs that request. A send that outran the bound
+   * is still in flight, so a caller that retries can put the message on the
+   * broker twice - the same trade `handlerTimeoutMs` documents.
    */
   async publish<T>(envelope: string | Envelope, body: T): Promise<void> {
     const addressed: Envelope =
       typeof envelope === 'string' ? { routingKey: envelope } : envelope;
     const stamped = this.#traced(addressed);
+    const { publishTimeoutMs } = this.#options;
 
-    await this.publisher().send(stamped, body);
-    this.#logger.debug(
-      `Published AMQP message to ${stamped.exchange ?? ''}[${stamped.routingKey ?? ''}]`,
+    await withTimeout(
+      () => this.publisher().send(stamped, body),
+      publishTimeoutMs,
+      () =>
+        new AmqpError(
+          AmqpErrorCode.PUBLISH_TIMED_OUT,
+          `The publish to ${this.#addressOf(stamped)} did not confirm within ` +
+            `${publishTimeoutMs} ms. Broker ${this.#options.redactedUrl}.`,
+        ),
     );
+    this.#logger.debug(`Published AMQP message to ${this.#addressOf(stamped)}`);
+  }
+
+  /** `exchange[routingKey]`, the form the warnings above already use. */
+  #addressOf(envelope: Envelope): string {
+    return `${envelope.exchange ?? ''}[${envelope.routingKey ?? ''}]`;
   }
 
   /**

--- a/packages/infra/src/amqp/subscriber.test.ts
+++ b/packages/infra/src/amqp/subscriber.test.ts
@@ -215,7 +215,9 @@ describe('a subscriber whose broker is unreachable', () => {
  * without waiting on a socket.
  */
 class FakeConsumer extends EventEmitter {
-  readonly queue = 'orders';
+  /** What `rabbitmq-client` fills in at setup. A consumer that never reached the
+   * broker reports `''`, which is exactly the case the drain warning covers. */
+  queue = 'orders';
   closed = 0;
   neverCloses = false;
 
@@ -326,6 +328,26 @@ describe('a subscriber over a connection that misbehaves', () => {
 
     expect(lines.find((line) => line.level === 'warn')?.message).toContain(
       'did not drain within 50 ms',
+    );
+  });
+
+  /**
+   * The case that motivated naming the queue from the subscription rather than
+   * from the consumer: with no broker reachable the consumer never set up, so
+   * `Consumer.queue` is still `''` and the warning named nothing at all.
+   */
+  it('names the queue even when the consumer never reached the broker', async () => {
+    const { subscriber, consumer, lines } = await boot();
+    const started = subscriber.start();
+    consumer.emit('ready');
+    await started;
+
+    consumer.queue = '';
+    consumer.neverCloses = true;
+    await subscriber.stop();
+
+    expect(lines.find((line) => line.level === 'warn')?.message).toContain(
+      'an AMQP consumer on orders did not drain',
     );
   });
 });

--- a/packages/infra/src/amqp/subscriber.ts
+++ b/packages/infra/src/amqp/subscriber.ts
@@ -80,7 +80,12 @@ export class AmqpSubscriber {
   readonly #options: AmqpOptions;
   readonly #logger: Logger;
   readonly #dispatcher: AmqpDispatcher;
-  readonly #consumers: Consumer[] = [];
+  /**
+   * Paired with the queue each was opened for, rather than bare. `Consumer.queue`
+   * is filled in by the broker at setup, so one that never connected reports `''`
+   * and the drain warning named nothing - which is the case the warning is for.
+   */
+  readonly #consumers: { consumer: Consumer; queue: string }[] = [];
   #started = false;
   #stopping: Promise<void> | undefined;
 
@@ -167,14 +172,20 @@ export class AmqpSubscriber {
   async stop(): Promise<void> {
     this.#stopping ??= (async () => {
       const open = this.#consumers.splice(0);
-      await Promise.all(open.map((consumer) => this.#drain(consumer)));
+      await Promise.all(open.map((entry) => this.#drain(entry)));
     })();
     return this.#stopping;
   }
 
   /** Bounded, and never rejecting: one consumer that will not close must not stop
    * the rest of teardown, which is what closes the socket under it. */
-  async #drain(consumer: Consumer): Promise<void> {
+  async #drain({
+    consumer,
+    queue,
+  }: {
+    consumer: Consumer;
+    queue: string;
+  }): Promise<void> {
     try {
       const timedOut = await closeWithin(
         consumer,
@@ -182,7 +193,7 @@ export class AmqpSubscriber {
       );
       if (timedOut) {
         this.#logger.warn(
-          `an AMQP consumer on ${consumer.queue} did not drain within ` +
+          `an AMQP consumer on ${queue} did not drain within ` +
             `${this.#options.drainTimeoutMs} ms`,
         );
       }
@@ -204,7 +215,7 @@ export class AmqpSubscriber {
     const consumer = this.#connection.createConsumer(props, (message) =>
       this.#dispatcher.dispatch(found, settings, message),
     );
-    this.#consumers.push(consumer);
+    this.#consumers.push({ consumer, queue: found.queue });
 
     // Throttled, not deduplicated: a later outage still gets reported, and a
     // broker that is down emits on every retry.

--- a/tools/create-app/templates/features/cache/catalog.demo.ts
+++ b/tools/create-app/templates/features/cache/catalog.demo.ts
@@ -39,8 +39,13 @@ export class CatalogDemo {
         `(loads ${before} -> ${await this.loads(url)})`,
     );
 
+    // Unique per run, because "uncached" has to be true for the count below to
+    // mean anything: L2 is Redis, so a fixed symbol is still cached from the
+    // previous tour against the same server and ten reads then load zero times.
+    // `max(12)` on the route's param, so the suffix is short.
+    const fresh = `bun-${Bun.randomUUIDv7().slice(-6)}`;
     const at = await this.loads(url);
-    await Promise.all(Array.from({ length: 10 }, () => this.quote(url, 'bun')));
+    await Promise.all(Array.from({ length: 10 }, () => this.quote(url, fresh)));
     this.logger.info(
       `10 concurrent reads of an uncached key -> ${(await this.loads(url)) - at} ` +
         'load (single flight, per process)',

--- a/tools/create-app/templates/features/messaging/messaging.module.ts
+++ b/tools/create-app/templates/features/messaging/messaging.module.ts
@@ -30,6 +30,10 @@ import { ORDERS_EXCHANGE, OrdersMessages } from './orders.messages.js';
           // Short, so `bun run tour` against an absent broker says so and moves
           // on instead of holding boot for five seconds.
           readyTimeoutMs: 1_500,
+          // Well under the package's 10 s default, because a request is waiting
+          // on this one: the landing page's broker panel wants the 503 while the
+          // visitor is still looking at it.
+          publishTimeoutMs: 2_000,
           drainTimeoutMs: 2_000,
           handlerTimeoutMs: 10_000,
         };


### PR DESCRIPTION
demo.dunx.win exercised every part of the framework except the broker, and `compose.demo.yml` ran no RabbitMQ at all. Adds the panel and the service, and fixes what the panel hit on the way.

**`@dunx/infra/amqp`**, all three reachable without the example:

- A url with no userinfo authenticated as user `''` with a blank password, which RabbitMQ refuses. `rabbitmq-client` has no fallback on that path; omitting `RABBITMQ_URL` worked, naming a host without a user did not.
- A publish to an unreachable broker settled in neither direction, so a route publishing inside a request hung it. 20 s against a closed port, now a 503 in 2 s in the example. New `publishTimeoutMs`, default 10 s.
- The drain warning printed `an AMQP consumer on  did not drain`, having read the queue off a consumer that never connected.

**Two example assertions** that failed whenever the services were actually running: the broker tour step inferred "no broker" from an unset env var, and the single-flight step reused a key that L2 still held from the previous tour.

`bun run ci` 13/13 and `ci unit` 2/2, against a real broker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a RabbitMQ message-broker demo with order placement, shipping, malformed-message handling, delivery tracking, and results display.
  - Added RabbitMQ provisioning to the full demo environment.
  - Documented the new messaging route and broker workflow.

- **Bug Fixes**
  - Message publishing now fails within a bounded timeout instead of waiting indefinitely.
  - AMQP connections without credentials now receive safe defaults while preserving explicit credentials.
  - Cache concurrency demos now consistently use fresh keys for uncached reads.

- **Tests**
  - Expanded coverage for messaging routes, publish timeouts, credentials, and broker shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->