### PR TITLE
docs(example): correct what mem_limit does on the demo host

### DIFF
--- a/examples/full/compose.demo.yml
+++ b/examples/full/compose.demo.yml
@@ -75,8 +75,24 @@ services:
     restart: unless-stopped
     # No `ports` and no volume, for the reasons the Redis above has none: only
     # the app talks to it, and nothing published here is worth keeping.
-    # RabbitMQ 4 reads the cgroup limit rather than the host's memory, so its
-    # high watermark follows this number instead of the Pi's 8 GB.
+    #
+    # **`mem_limit` does nothing on the Pi this deploys to, and neither does the
+    # one on the two services beside it.** That kernel has no cgroup memory
+    # controller, so `docker compose up` prints "Your kernel does not support
+    # memory limit capabilities or the cgroup is not mounted. Limitation
+    # discarded" and `docker inspect` reports `memlimit=0` for all three.
+    # RabbitMQ then sizes itself off the host rather than off this number:
+    # measured on the deployed container, `Memory high watermark ... computed to:
+    # 5.0728 gb` of the Pi's 7.9 GB.
+    #
+    # Left in place because it is correct on a host that has the controller, and
+    # because the fix is that controller rather than a second setting here:
+    # `cgroup_enable=memory cgroup_memory=1` in the Pi's `cmdline.txt` makes this
+    # line work for all three at once. Setting RabbitMQ's own watermark instead
+    # is not the workaround it looks like - `RABBITMQ_VM_MEMORY_HIGH_WATERMARK`
+    # is deprecated in RabbitMQ 4 and the container exits on it.
+    #
+    # Idle, the broker holds about 104 MB, so this is a ceiling nobody is near.
     mem_limit: 512m
     healthcheck:
       test: ['CMD', 'rabbitmq-diagnostics', '-q', 'ping']


### PR DESCRIPTION
Comment-only. Found while deploying the demo: `docker compose up` prints `Your kernel does not support memory limit capabilities or the cgroup is not mounted. Limitation discarded`, and `docker inspect` reports `memlimit=0` on all three containers, not just the new broker.

So the claim I added in #130 - that RabbitMQ's watermark follows `mem_limit` - is false on this host. The deployed broker reports `Memory high watermark ... computed to: 5.0728 gb`, sized off the Pi's 7.9 GB.

Nothing is at risk today (the broker idles at ~104 MB), so this documents rather than papers over it. The real fix is `cgroup_enable=memory cgroup_memory=1` in the Pi's `cmdline.txt`, which needs a reboot and makes the existing `mem_limit` work for all three at once - your call, not a code change.

Worth recording: `RABBITMQ_VM_MEMORY_HIGH_WATERMARK` is the obvious workaround and is wrong. It is deprecated in RabbitMQ 4 and the container exits with `RABBITMQ_VM_MEMORY_HIGH_WATERMARK is set but deprecated`. I tested it before proposing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how the RabbitMQ memory limit behaves on systems without cgroup memory support.
  - Documented the host-memory sizing behavior, retained compatibility setting, recommended cgroup configuration, and deprecated high-watermark variable.
  - Added an estimate of the broker’s idle memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->