### PR TITLE
chore: move every action to its current major

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
         bun-version: 1.4.2
 
     - name: Cache Bun dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.bun/install/cache
         key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Lint, format, types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Build
@@ -42,7 +42,7 @@ jobs:
     # `coverage` runs the same files with every service attached. Declaring them
     # twice is what broke the release job: it ran the gate with none.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Build
@@ -67,7 +67,7 @@ jobs:
       DUNX_DB_TEST_URL: postgres://dunx:dunx@localhost:5432/dunx
       RABBITMQ_URL: amqp://guest:guest@localhost:5672
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Build
@@ -96,7 +96,7 @@ jobs:
     name: Site in a browser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Build
@@ -174,7 +174,7 @@ jobs:
           --health-retries 12
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       # MinIO cannot be a `services:` container: it needs `server /data` as its
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload lcov
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: coverage/lcov.info
@@ -228,7 +228,7 @@ jobs:
       # copy of the service containers the gate needs, which is exactly what broke
       # the first release run on main.
       - name: Upload the coverage model and badges
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-model
           path: |
@@ -241,7 +241,7 @@ jobs:
     name: Documentation site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Build
@@ -282,7 +282,7 @@ jobs:
       # means none arrives. With GITHUB_TOKEN here the release push was evaluated
       # as github-actions[bot], which cannot be a ruleset bypass actor, and was
       # rejected with GH013 after the packages were already on npm.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -344,7 +344,7 @@ jobs:
     steps:
       # `main` rather than the commit that triggered the run, which is what picks
       # up the release commit the job before this one may just have pushed.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
 
@@ -363,7 +363,7 @@ jobs:
       # none and leaves a real one alone, and before `docs:build`, which is what
       # copies `public/badges` into the deployed site.
       - name: Download the coverage model and badges
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-model
           path: internal/docs
@@ -388,7 +388,7 @@ jobs:
       # makes them rot quietly.
       - name: Deploy the documentation site to Cloudflare Pages
         id: deploy
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/dunxonu-deep-review.yml
+++ b/.github/workflows/dunxonu-deep-review.yml
@@ -129,17 +129,19 @@ jobs:
       # does not exist locally.
       #
       # `persist-credentials: false` because the reviewer reads files and the
-      # pull request it reads is attacker-controlled text. checkout@v4 leaves the
-      # workflow token in `.git/config` inside the workspace, so a prompt
-      # injection that got the agent to print that file would disclose a token
-      # holding `pull-requests: write`. Nothing here needs credentials after the
-      # fetch.
-      # Pinned to a commit: `v4` is mutable, and a retargeted tag would run
+      # pull request it reads is attacker-controlled text. Since v6 checkout
+      # writes the token to a config file in `RUNNER_TEMP` and reaches it from
+      # `.git/config` through an `includeIf`, so it is no longer inside the
+      # workspace, but the agent has a shell and `RUNNER_TEMP` is as readable as
+      # anything else. A prompt injection that got it to print that file would
+      # disclose a token holding `pull-requests: write`. Nothing here needs
+      # credentials after the fetch.
+      # Pinned to a commit: `v7` is mutable, and a retargeted tag would run
       # unreviewed code in a job that goes on to touch a token.
       #
       # Everything this brings into the workspace is attacker-controlled. It is
       # here for the agent to read and for nothing else to execute.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.gate.outputs.ok == 'true'
         with:
           fetch-depth: 0
@@ -150,7 +152,7 @@ jobs:
       # so retargeting `v1` would run unreviewed code with them.
       - id: review
         if: steps.gate.outputs.ok == 'true'
-        uses: anthropics/claude-code-action@b7912aeeb535234e3e9385ff49e8237f689b5f14 # v1
+        uses: anthropics/claude-code-action@a73a99cefc6aea0126f858804cd22a7a44e11924 # v1
         env:
           # A background task in a headless run never reports back, because the
           # run ends when the main agent stops. `-p` already runs this in the
@@ -210,7 +212,7 @@ jobs:
       # file in place. So the trusted copy does not exist while the agent runs.
       - name: Fetch the submission script from the default branch
         if: steps.gate.outputs.ok == 'true'
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           path: .trusted

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -144,7 +144,7 @@ jobs:
           echo "::error::No CI run for $SHA has uploaded coverage-model yet. Wait for the Coverage job to finish, push again if it failed, and ask a second time."
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: steps.gate.outputs.ok == 'true'
         with:
           ref: ${{ steps.head.outputs.sha }}
@@ -161,7 +161,7 @@ jobs:
       # is what copies `public/badges` into the deployed site.
       - name: Download the coverage model and badges
         if: steps.gate.outputs.ok == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-model
           path: internal/docs
@@ -182,7 +182,7 @@ jobs:
       - name: Deploy the preview to Cloudflare Pages
         id: deploy
         if: steps.gate.outputs.ok == 'true'
-        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Every GitHub Action in `.github/` moved to its current major.

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | `v4`, `11d5960` (v4.4.0) | `v7`, `3d3c42e` (v7.0.1) |
| `actions/cache` | `v4` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `cloudflare/wrangler-action` | `9acf94a` (v3.15.0) | `ebbaa15` (v4.0.0) |
| `anthropics/claude-code-action` | `b7912ae` (v1) | `a73a99c` (v1) |
| `actions/github-script` | `3a2844b` (v9.0.0) | unchanged, already latest |
| `oven-sh/setup-bun` | `v2` | unchanged, `v2` is v2.2.0 |
| `petarzarkov/fast-code-review` | `ac2587f` (v1.3.1) | unchanged, already latest |

`claude-code-action` pins a commit behind a moving `v1`, and `v1` had been
retargeted since, so the pin moves with it.

## The majors crossed, and why none of them lands here

- **checkout v5, upload-artifact v5/v6/v7, download-artifact v6/v7/v8** are the
  node24 runtime and an ESM rewrite. They need runner 2.327.1 or newer;
  `ubuntu-latest` is well past it and there are no self-hosted runners.
- **checkout v6** stops writing the persisted token into `.git/config` and puts
  it in a file under `RUNNER_TEMP`, reached through an `includeIf`. The release
  job's tag push relies on that credential and still gets it. The deep
  reviewer's comment named `.git/config` specifically, so it is corrected here
  rather than left to mislead; the `persist-credentials: false` it argues for is
  still right, because the agent has a shell and `RUNNER_TEMP` is as readable to
  it as the workspace.
- **checkout v7** blocks checking out a fork PR, but only under
  `pull_request_target` and `workflow_run`. Neither trigger exists in this repo.
- **download-artifact v5** changed the output path for downloads by
  `artifact-ids`. Both downloads here name the artifact, which is the path that
  did not change.
- **wrangler-action v4** changes only the default `wranglerVersion`. Both
  deploys pin `4.128.0` explicitly.

The pinning split ci.yml documents is unchanged: GitHub's own read-only actions
stay on a major, third-party actions near a credential stay on a commit.

## Verification

`bun run ci` green on `static`, `docs`, `coverage` and `browser`. The `examples`
phase failed once on `tour.test.ts:376`, the AMQP `2 of 2 delivered to`
assertion, and passed on a rerun: a local broker timing race, and this diff is
`.github/` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions used for dependency caching, source checkout, artifact handling, and preview/CI deployments.
  - Refreshed the pinned versions of the Cloudflare Wrangler and Claude Code actions.
  - Updated checkout credential handling documentation to reflect the newer action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->